### PR TITLE
ignore multi-triggers with a size greater than a given constant (default const = 2)

### DIFF
--- a/sources/lib/reasoners/matching.ml
+++ b/sources/lib/reasoners/matching.ml
@@ -424,12 +424,16 @@ module Make (X : Arg) : S with type theory = X.t = struct
     Debug.match_pats_modulo pat lsubsts;
     List.fold_left (match_one_pat env tbox pat) [] lsubsts
 
+  let trig_weight s t =
+    match T.view s, T.view t with
+    | {T.f=Symbols.Name _}, {T.f=Symbols.Op _}   -> -1
+    | {T.f=Symbols.Op _}  , {T.f=Symbols.Name _} -> 1
+    | _ -> (T.view t).T.depth - (T.view s).T.depth
+
+
   let matching env tbox pat_info =
     let pats = pat_info.trigger in
-    let pats_list =
-      List.stable_sort
-        (fun s t -> (T.view t).T.depth - (T.view s).T.depth) pats.F.content
-    in
+    let pats_list = List.stable_sort trig_weight pats.F.content in
     Debug.matching pats;
     let egs =
       { sbs = SubstT.empty;


### PR DESCRIPTION
@bobot @correnson

I noticed a very bad user-given multi-trigger in axioms `separated_1` of file `Memory.why`. This makes Alt-Ergo stuck in the instantiation module, and I decided to ignore "big" multi-triggers.

Maybe you should rewrite the axiom, as follows:

```
axiom separated_1 : forall p:addr, q:addr. forall a:int, b:int
  [separated p a q b].
  separated p a q b ->
  forall i:int, j:int  [Mk_addr (base p) i, Mk_addr (base q) j].
 (Int.(<=) (offset p) (i)) /\ (Int.(<) (i) ((Int.(+) (offset
  p) (a)))) -> (Int.(<=) (offset q) (j)) /\ (Int.(<) (j) ((Int.(+) (offset
  q) (b)))) -> not ((Mk_addr (base p) i) = (Mk_addr (base q) j))

```