### PR TITLE
Four versions of SAT-solvers: Tableaux, CDCL, Tableaux-with-CDCL, CDCL-with-Tableaux

### DIFF
--- a/non-regression/run_invalid.sh
+++ b/non-regression/run_invalid.sh
@@ -6,6 +6,23 @@ files="$files `find invalid/ -name '*'.mlw`"
 files="$files `find invalid/ -name '*'.why`"
 files="$files `find invalid/ -name '*'.zip`"
 
+## run Alt-Ergo with imperative SAT solver assisted with tableaux on invalid tests
+for options in "" "-no-minimal-bj" "-no-tableaux-cdcl-in-theories" "-no-tableaux-cdcl-in-instantiation" "-no-tableaux-cdcl-in-theories -no-tableaux-cdcl-in-instantiation" "-no-minimal-bj -no-tableaux-cdcl-in-theories -no-tableaux-cdcl-in-instantiation"
+do
+    cpt=0
+    for f in $files
+    do
+        cpt=`expr $cpt + 1`
+        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL_Tableaux $f`
+        if [ "`echo $res | grep -c ":I don't know"`" -eq "0" ]
+        then
+            echo "[run_invalid > default cdcl solver with tableaux] issue with file $f"
+            echo "Result is $res"
+            exit 1
+        fi
+    done
+    echo "[run_invalid > default cdcl solver with tableaux and options '$options'] $cpt files considered"
+done
 
 ## run Alt-Ergo with functional SAT solver on invalid tests
 cpt=0
@@ -15,12 +32,12 @@ do
     res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux $f`
     if [ "`echo $res | grep -c ":I don't know"`" -eq "0" ]
     then
-        echo "[run_invalid > default test] issue with file $f"
+        echo "[run_invalid > tableaux solver] issue with file $f"
         echo "Result is $res"
         exit 1
     fi
 done
-echo "[run_invalid > default test] $cpt files considered"
+echo "[run_invalid > tableaux solver test] $cpt files considered"
 
 ## run Alt-Ergo with functional SAT solver assisted with cdcl on invalid tests
 cpt=0
@@ -30,15 +47,15 @@ do
     res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux_CDCL $f`
     if [ "`echo $res | grep -c ":I don't know"`" -eq "0" ]
     then
-        echo "[run_invalid > default test] issue with file $f"
+        echo "[run_invalid > tableaux solver with cdcl] issue with file $f"
         echo "Result is $res"
         exit 1
     fi
 done
-echo "[run_invalid > default test] $cpt files considered"
+echo "[run_invalid > tableaux solver with cdcl test] $cpt files considered"
 
 ## run Alt-Ergo with imperative SAT solver on invalid tests
-for options in "" "-no-minimal-bj" "-no-tableaux-cdcl" "-no-minimal-bj -no-tableaux-cdcl"
+for options in "" "-no-minimal-bj"
 do
     cpt=0
     for f in $files
@@ -47,32 +64,13 @@ do
         res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL $f`
         if [ "`echo $res | grep -c ":I don't know"`" -eq "0" ]
         then
-            echo "[run_invalid > satML-plugin test] issue with file $f"
+            echo "[run_invalid > cdcl solver] issue with file $f"
             echo "Result is $res"
             exit 1
         fi
     done
-    echo "[run_invalid > satML-plugin test with options '$options'] $cpt files considered"
+    echo "[run_invalid > cdcl solver with options '$options'] $cpt files considered"
 done
-
-## run Alt-Ergo with imperative SAT solver assisted with tableaux on invalid tests
-for options in "" "-no-minimal-bj" "-no-tableaux-cdcl" "-no-minimal-bj -no-tableaux-cdcl"
-do
-    cpt=0
-    for f in $files
-    do
-        cpt=`expr $cpt + 1`
-        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL_Tableaux $f`
-        if [ "`echo $res | grep -c ":I don't know"`" -eq "0" ]
-        then
-            echo "[run_invalid > satML-plugin test] issue with file $f"
-            echo "Result is $res"
-            exit 1
-        fi
-    done
-    echo "[run_invalid > satML-plugin test with options '$options'] $cpt files considered"
-done
-
 
 ## run Alt-Ergo with FM-Simplex on invalid tests
 cpt=0

--- a/non-regression/run_invalid.sh
+++ b/non-regression/run_invalid.sh
@@ -13,7 +13,7 @@ do
     for f in $files
     do
         cpt=`expr $cpt + 1`
-        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL_Tableaux $f`
+        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL-Tableaux $f`
         if [ "`echo $res | grep -c ":I don't know"`" -eq "0" ]
         then
             echo "[run_invalid > default cdcl solver with tableaux] issue with file $f"
@@ -44,7 +44,7 @@ cpt=0
 for f in $files
 do
     cpt=`expr $cpt + 1`
-    res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux_CDCL $f`
+    res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux-CDCL $f`
     if [ "`echo $res | grep -c ":I don't know"`" -eq "0" ]
     then
         echo "[run_invalid > tableaux solver with cdcl] issue with file $f"

--- a/non-regression/run_valid.sh
+++ b/non-regression/run_valid.sh
@@ -13,7 +13,7 @@ do
     for f in $files
     do
         cpt=`expr $cpt + 1`
-        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL_Tableaux $f`
+        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL-Tableaux $f`
         if [ "`echo $res | grep -c ":Valid"`" -eq "0" ]
         then
             echo "[run_valid > default cdcl solver with tableaux] issue with file $f"
@@ -44,7 +44,7 @@ cpt=0
 for f in $files
 do
     cpt=`expr $cpt + 1`
-    res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux_CDCL $f`
+    res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux-CDCL $f`
     if [ "`echo $res | grep -c ":Valid"`" -eq "0" ]
     then
         echo "[run_valid > tableaux solver with cdcl] issue with file $f"

--- a/non-regression/run_valid.sh
+++ b/non-regression/run_valid.sh
@@ -6,6 +6,24 @@ files="$files `find valid/ -name '*'.mlw`"
 files="$files `find valid/ -name '*'.why`"
 files="$files `find valid/ -name '*'.zip`"
 
+## run Alt-Ergo with imperative SAT solver assisted with tableaux on valid tests
+for options in "" "-no-minimal-bj" "-no-tableaux-cdcl-in-theories" "-no-tableaux-cdcl-in-instantiation"  "-no-tableaux-cdcl-in-theories -no-tableaux-cdcl-in-instantiation" "-no-minimal-bj -no-tableaux-cdcl-in-theories -no-tableaux-cdcl-in-instantiation"
+do
+    cpt=0
+    for f in $files
+    do
+        cpt=`expr $cpt + 1`
+        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL_Tableaux $f`
+        if [ "`echo $res | grep -c ":Valid"`" -eq "0" ]
+        then
+            echo "[run_valid > default cdcl solver with tableaux] issue with file $f"
+            echo "Result is $res"
+            exit 1
+        fi
+    done
+    echo "[run_valid > default cdcl solver with tableaux and options '$options'] $cpt files considered"
+done
+
 ## run Alt-Ergo with functional SAT solver on valid tests
 cpt=0
 for f in $files
@@ -14,12 +32,12 @@ do
     res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux $f`
     if [ "`echo $res | grep -c ":Valid"`" -eq "0" ]
     then
-        echo "[run_valid > default test] issue with file $f"
+        echo "[run_valid > tableaux solver] issue with file $f"
         echo "Result is $res"
         exit 1
     fi
 done
-echo "[run_valid > default test] $cpt files considered"
+echo "[run_valid > tableaux solver test] $cpt files considered"
 
 ## run Alt-Ergo with functional SAT solver assisted with cdcl on valid tests
 cpt=0
@@ -29,15 +47,15 @@ do
     res=`$alt_ergo_bin -timelimit $timelimit -sat-solver Tableaux_CDCL $f`
     if [ "`echo $res | grep -c ":Valid"`" -eq "0" ]
     then
-        echo "[run_valid > default test] issue with file $f"
+        echo "[run_valid > tableaux solver with cdcl] issue with file $f"
         echo "Result is $res"
         exit 1
     fi
 done
-echo "[run_valid > default test] $cpt files considered"
+echo "[run_valid > tableaux solver with cdcl test] $cpt files considered"
 
 ## run Alt-Ergo with imperative SAT solver on valid tests
-for options in "" "-no-minimal-bj" "-no-tableaux-cdcl" "-no-minimal-bj -no-tableaux-cdcl"
+for options in "" "-no-minimal-bj"
 do
     cpt=0
     for f in $files
@@ -46,30 +64,12 @@ do
         res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL $f`
         if [ "`echo $res | grep -c ":Valid"`" -eq "0" ]
         then
-            echo "[run_valid > satML-plugin test] issue with file $f"
+            echo "[run_valid > cdcl solver] issue with file $f"
             echo "Result is $res"
             exit 1
         fi
     done
-    echo "[run_valid > satML-plugin test with options '$options'] $cpt files considered"
-done
-
-## run Alt-Ergo with imperative SAT solver assisted with tableaux on valid tests
-for options in "" "-no-minimal-bj" "-no-tableaux-cdcl" "-no-minimal-bj -no-tableaux-cdcl"
-do
-    cpt=0
-    for f in $files
-    do
-        cpt=`expr $cpt + 1`
-        res=`$alt_ergo_bin -timelimit $timelimit $options -sat-solver CDCL_Tableaux $f`
-        if [ "`echo $res | grep -c ":Valid"`" -eq "0" ]
-        then
-            echo "[run_valid > satML-plugin test] issue with file $f"
-            echo "Result is $res"
-            exit 1
-        fi
-    done
-    echo "[run_valid > satML-plugin test with options '$options'] $cpt files considered"
+    echo "[run_valid > cdcl solver with options '$options'] $cpt files considered"
 done
 
 ## run Alt-Ergo with FM-Simplex on valid tests

--- a/sources/lib/reasoners/satml.ml
+++ b/sources/lib/reasoners/satml.ml
@@ -54,6 +54,7 @@ module type SAT_ML = sig
 
   val boolean_model : t -> Atom.atom list
   val theory_assumed : t -> Literal.LT.Set.t
+  val assumed : t -> Satml_types.Atom.Set.t
   val current_tbox : t -> th
   val set_current_tbox : t -> th -> unit
   val empty : unit -> t
@@ -406,7 +407,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     if Options.profiling() then
       Profiling.decision (decision_level env) "<none>";
     Vec.push env.tenv_queue env.tenv; (* save the current tenv *)
-    if Options.tableaux_cdcl () then begin
+    if Options.cdcl_tableaux_inst () || Options.cdcl_tableaux_th () then begin
       Vec.push env.lazy_cnf_queue env.lazy_cnf;
       Vec.push env.relevants_queue env.relevants
     end
@@ -485,14 +486,14 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       Queue.clear env.tatoms_queue;
       Queue.clear env.th_tableaux;
       env.tenv <- Vec.get env.tenv_queue lvl; (* recover the right tenv *)
-      if Options.tableaux_cdcl () then begin
+      if Options.cdcl_tableaux_inst () || Options.cdcl_tableaux_th () then begin
         env.lazy_cnf <- Vec.get env.lazy_cnf_queue lvl;
         env.relevants <- Vec.get env.relevants_queue lvl;
       end;
       Vec.shrink env.trail ((Vec.size env.trail) - env.qhead) true;
       Vec.shrink env.trail_lim ((Vec.size env.trail_lim) - lvl) true;
       Vec.shrink env.tenv_queue ((Vec.size env.tenv_queue) - lvl) true;
-      if Options.tableaux_cdcl () then begin
+      if Options.cdcl_tableaux_inst () || Options.cdcl_tableaux_th () then begin
         Vec.shrink
           env.lazy_cnf_queue ((Vec.size env.lazy_cnf_queue) - lvl) true;
         Vec.shrink env.relevants_queue
@@ -787,9 +788,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
   let theory_propagate env =
     let facts = ref [] in
     let dlvl = decision_level env in
+    if Options.cdcl_tableaux_th () || Options.cdcl_tableaux_inst () then
+      compute_facts_for_theory_propagate env;
     let tatoms_queue =
-      if Options.tableaux_cdcl () then begin
-        compute_facts_for_theory_propagate env;
+      if Options.cdcl_tableaux_th () then begin
         env.th_tableaux
       end
       else env.tatoms_queue
@@ -825,7 +827,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
           (*let full_model = nb_assigns() = env.nb_init_vars in*)
           (* XXX what to do with the other results of Th.assume ? *)
           let t,_,cpt =
-            Th.assume ~ordered:(not (Options.tableaux_cdcl ()))
+            Th.assume ~ordered:(not (Options.cdcl_tableaux_th ()))
               (List.rev !facts) env.tenv
           in
           steps := Int64.add (Int64.of_int cpt) !steps;
@@ -1077,7 +1079,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     | C_bool c -> C_bool c
     | C_theory _ -> assert false
     | C_none ->
-      if Options.hybrid_sat () then
+      if Options.tableaux_cdcl () then
         C_none
       else
         match theory_propagate env with
@@ -1338,13 +1340,13 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         if decision_level env = 0 then report_conflict env confl;
         conflict_analyze_and_fix env confl;
         propagate_and_stabilize env propagator conflictC strat;
-        if Options.hybrid_sat () then
+        if Options.tableaux_cdcl () then
           match x with
           | None -> ()
           | Some r -> raise (Last_UIP_reason r)
       with
         Unsat _ as e ->
-        if Options.hybrid_sat () then begin
+        if Options.tableaux_cdcl () then begin
           if not (Options.minimal_bj ()) then assert (decision_level env = 0);
           raise (Last_UIP_reason Atom.Set.empty)
         end
@@ -1386,7 +1388,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       propagate_and_stabilize env all_propagations conflictC !strat;
 
       if nb_assigns env = env.nb_init_vars ||
-         (Options.tableaux_cdcl () && Matoms.is_empty env.lazy_cnf) then
+         (Options.cdcl_tableaux_inst () && Matoms.is_empty env.lazy_cnf) then
         raise Sat;
       if Options.enable_restarts ()
       && n_of_conflicts >= 0 && !conflictC >= n_of_conflicts then begin
@@ -1552,7 +1554,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
 
   let update_lazy_cnf env ~do_bcp mff ~dec_lvl =
-    if Options.tableaux_cdcl () && dec_lvl <= decision_level env then begin
+    if (Options.cdcl_tableaux_inst () || Options.cdcl_tableaux_th ()) &&
+       dec_lvl <= decision_level env then begin
       let s =
         try Util.MI.find dec_lvl env.lvl_ff
         with Not_found -> SFF.empty
@@ -1630,7 +1633,9 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
           env.tenv     <- old_tenv
         end
     in
-    fun env mff -> if Options.tableaux_cdcl () then better_bj env mff
+    fun env mff ->
+      if Options.cdcl_tableaux_inst () || Options.cdcl_tableaux_th () then
+        better_bj env mff
 
 
   let assume env unit_cnf nunit_cnf f ~cnumber mff ~dec_lvl =
@@ -1661,7 +1666,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       try_to_backjump_further env mff
 
   let exists_in_lazy_cnf env f' =
-    not (Options.tableaux_cdcl ()) || MFF.mem f' env.ff_lvl
+    not (Options.cdcl_tableaux_inst () || Options.cdcl_tableaux_th ()) ||
+    MFF.mem f' env.ff_lvl
 
   let boolean_model env =
     let l = ref [] in
@@ -1671,6 +1677,13 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     !l
 
   let theory_assumed env = Th.get_assumed env.tenv
+
+  let assumed env =
+    SFF.fold (fun f acc ->
+        match FF.view f with
+        | FF.UNIT a -> SA.add a acc
+        | _ -> acc
+      )env.relevants SA.empty
 
   let current_tbox env = env.tenv
   let set_current_tbox env tb = env.tenv <- tb

--- a/sources/lib/reasoners/satml.mli
+++ b/sources/lib/reasoners/satml.mli
@@ -45,8 +45,8 @@ module type SAT_ML = sig
     unit
 
   val boolean_model : t -> Satml_types.Atom.atom list
-  val theory_assumed : t -> Literal.LT.Set.t
-  val assumed : t -> Satml_types.Atom.Set.t
+  val instantiation_context :
+    t -> Satml_types.Flat_Formula.hcons_env -> Satml_types.Atom.Set.t
   val current_tbox : t -> th
   val set_current_tbox : t -> th -> unit
   val empty : unit -> t

--- a/sources/lib/reasoners/satml.mli
+++ b/sources/lib/reasoners/satml.mli
@@ -46,6 +46,7 @@ module type SAT_ML = sig
 
   val boolean_model : t -> Satml_types.Atom.atom list
   val theory_assumed : t -> Literal.LT.Set.t
+  val assumed : t -> Satml_types.Atom.Set.t
   val current_tbox : t -> th
   val set_current_tbox : t -> th -> unit
   val empty : unit -> t

--- a/sources/lib/reasoners/satml_frontend.ml
+++ b/sources/lib/reasoners/satml_frontend.ml
@@ -277,8 +277,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     )Ex.empty lc*)
 
   let selector env f orig =
-    (Options.cdcl_tableaux_inst () || Options.cdcl_tableaux_th () ||
-     not (MF.mem f env.gamma))
+    (Options.cdcl_tableaux () || not (MF.mem f env.gamma))
     && begin match F.view orig with
       | F.Lemma _ -> env.add_inst orig
       | _ -> true
@@ -470,8 +469,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
            fprintf fmt "expand skolem of %a@.@." Literal.LT.print a;
          try
            let {F.f} as gf = A.Map.find a env.skolems in
-           if not (Options.cdcl_tableaux_inst () ||
-                   Options.cdcl_tableaux_th ()) &&
+           if not (Options.cdcl_tableaux ()) &&
               MF.mem f env.gamma then acc
            else gf :: acc
          with Not_found -> acc
@@ -593,15 +591,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
           add_reasons_graph _todo (SA.add a _done)
     in
     fun ~frugal env ->
-      let sa =
-        if Options.cdcl_tableaux_th () then
-          Literal.LT.Set.fold
-            (fun a accu ->
-               SA.add (FF.get_atom env.ff_hcons_env a) accu
-            )(SAT.theory_assumed env.satml) SA.empty
-        else
-          SAT.assumed env.satml
-      in
+      let sa = SAT.instantiation_context env.satml env.ff_hcons_env in
       let sa =
         if frugal then sa
         else add_reasons_graph (SA.elements sa) SA.empty

--- a/sources/lib/reasoners/satml_frontend.ml
+++ b/sources/lib/reasoners/satml_frontend.ml
@@ -573,10 +573,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
            | Some (_,l) -> List.fold_left (fun sa a -> A.Set.add a sa) sa l
         ) env.conj A.Set.empty
 
-  module SA = Set.Make (struct
-      type t = Atom.atom
-      let compare = Atom.cmp_atom
-    end)
+  module SA = Satml_types.Atom.Set
 
   let atoms_from_lazy_sat =
     let rec add_reasons_graph _todo _done =

--- a/sources/lib/reasoners/satml_frontend_hybrid.ml
+++ b/sources/lib/reasoners/satml_frontend_hybrid.ml
@@ -141,7 +141,7 @@ module Make (Th : Theory.S) = struct
        * env *)
 
       | Satml.Unsat confl ->
-        if Options.hybrid_sat () || SAT.decision_level env.sat = 0 then begin
+        if Options.tableaux_cdcl () || SAT.decision_level env.sat = 0 then begin
           (* fprintf fmt "nb decisions : %d @."
              (List.length env.decisions); *)
           raise (Exception.Inconsistent (Ex.empty, []));

--- a/sources/lib/structures/satml_types.ml
+++ b/sources/lib/structures/satml_types.ml
@@ -435,11 +435,8 @@ module Atom : ATOM = struct
       end;
       !l
 
-
-  let compare a b = a.aid - b.aid
-
-  module Set = Set.Make(struct type t=atom let compare=compare end)
-  module Map = Map.Make(struct type t=atom let compare=compare end)
+  module Set = Set.Make(struct type t=atom let compare=cmp_atom end)
+  module Map = Map.Make(struct type t=atom let compare=cmp_atom end)
 
 end
 

--- a/sources/lib/util/options.ml
+++ b/sources/lib/util/options.ml
@@ -100,8 +100,9 @@ module M = struct
   let normalize_instances = ref false
 
   let sat_solver = ref Util.CDCL_Tableaux
-  let tableaux_cdcl = ref true
-  let hybrid_sat = ref false
+  let cdcl_tableaux_inst = ref true
+  let cdcl_tableaux_th = ref true
+  let tableaux_cdcl = ref false
   let minimal_bj = ref true
   let enable_restarts = ref false
   let disable_flat_formulas_simplification = ref false
@@ -236,16 +237,19 @@ module M = struct
   let set_sat_solver s =
     match s with
     | "CDCL" | "satML" ->
-      sat_solver := Util.CDCL
+      sat_solver := Util.CDCL;
+      cdcl_tableaux_inst := false;
+      cdcl_tableaux_th := false
     | "CDCL_Tableaux" | "satML_Tableaux" | "CDCL_tableaux" | "satML_tableaux" ->
-      sat_solver := Util.CDCL_Tableaux
+      sat_solver := Util.CDCL_Tableaux;
+      cdcl_tableaux_inst := true;
+      cdcl_tableaux_th := true
     | "tableaux" | "Tableaux" | "tableaux-like" | "Tableaux-like" ->
-      sat_solver := Util.Tableaux
+      sat_solver := Util.Tableaux;
+      tableaux_cdcl := false
     | "tableaux_cdcl" | "Tableaux_CDCL" | "tableaux_CDCL" | "Tableaux_cdcl" ->
-      (* disable tableaux in cdcl solver *)
-      tableaux_cdcl := false;
-      hybrid_sat := true;
-      sat_solver := Util.Tableaux_CDCL
+      sat_solver := Util.Tableaux_CDCL;
+      tableaux_cdcl := true;
     | _ ->
       Format.eprintf "Args parsing error: unkown SAT solver %S@." s;
       exit 1
@@ -573,10 +577,15 @@ module M = struct
     Arg.Clear minimal_bj,
     " disable minimal backjumping in satML CDCL solver";
 
-    "-no-tableaux-cdcl",
-    Arg.Clear tableaux_cdcl,
+    "-no-tableaux-cdcl-in-instantiation",
+    Arg.Clear cdcl_tableaux_inst,
     " when satML is used, this disables the use of a tableaux-like method \
-     together with the CDCL solver";
+     for instantiations with the CDCL solver";
+
+    "-no-tableaux-cdcl-in-theories",
+    Arg.Clear cdcl_tableaux_th,
+    " when satML is used, this disables the use of a tableaux-like method \
+     for the theories with the CDCL solver";
 
     "-disable-flat-formulas-simplification",
     Arg.Set disable_flat_formulas_simplification,
@@ -848,8 +857,9 @@ let case_split_policy () = !M.case_split_policy
 let instantiate_after_backjump () = !M.instantiate_after_backjump
 let disable_weaks () = !M.disable_weaks
 let minimal_bj () = !M.minimal_bj
+let cdcl_tableaux_inst () = !M.cdcl_tableaux_inst
+let cdcl_tableaux_th () = !M.cdcl_tableaux_th
 let tableaux_cdcl () = !M.tableaux_cdcl
-let hybrid_sat () = !M.hybrid_sat
 let disable_flat_formulas_simplification () =
   !M.disable_flat_formulas_simplification
 

--- a/sources/lib/util/options.ml
+++ b/sources/lib/util/options.ml
@@ -240,14 +240,14 @@ module M = struct
       sat_solver := Util.CDCL;
       cdcl_tableaux_inst := false;
       cdcl_tableaux_th := false
-    | "CDCL_Tableaux" | "satML_Tableaux" | "CDCL_tableaux" | "satML_tableaux" ->
+    | "CDCL-Tableaux" | "satML-Tableaux" | "CDCL-tableaux" | "satML-tableaux" ->
       sat_solver := Util.CDCL_Tableaux;
       cdcl_tableaux_inst := true;
       cdcl_tableaux_th := true
     | "tableaux" | "Tableaux" | "tableaux-like" | "Tableaux-like" ->
       sat_solver := Util.Tableaux;
       tableaux_cdcl := false
-    | "tableaux_cdcl" | "Tableaux_CDCL" | "tableaux_CDCL" | "Tableaux_cdcl" ->
+    | "tableaux-cdcl" | "Tableaux-CDCL" | "tableaux-CDCL" | "Tableaux-cdcl" ->
       sat_solver := Util.Tableaux_CDCL;
       tableaux_cdcl := true;
     | _ ->
@@ -859,6 +859,7 @@ let disable_weaks () = !M.disable_weaks
 let minimal_bj () = !M.minimal_bj
 let cdcl_tableaux_inst () = !M.cdcl_tableaux_inst
 let cdcl_tableaux_th () = !M.cdcl_tableaux_th
+let cdcl_tableaux () = !M.cdcl_tableaux_th || !M.cdcl_tableaux_inst
 let tableaux_cdcl () = !M.tableaux_cdcl
 let disable_flat_formulas_simplification () =
   !M.disable_flat_formulas_simplification

--- a/sources/lib/util/options.mli
+++ b/sources/lib/util/options.mli
@@ -199,8 +199,9 @@ val profiling_plugin : unit -> string
 val normalize_instances : unit -> bool
 
 val sat_solver : unit -> Util.sat_solver
+val cdcl_tableaux_inst : unit -> bool
+val cdcl_tableaux_th : unit -> bool
 val tableaux_cdcl : unit -> bool
-val hybrid_sat : unit -> bool
 val minimal_bj : unit -> bool
 val enable_restarts : unit -> bool
 val disable_flat_formulas_simplification : unit -> bool

--- a/sources/lib/util/options.mli
+++ b/sources/lib/util/options.mli
@@ -201,6 +201,7 @@ val normalize_instances : unit -> bool
 val sat_solver : unit -> Util.sat_solver
 val cdcl_tableaux_inst : unit -> bool
 val cdcl_tableaux_th : unit -> bool
+val cdcl_tableaux : unit -> bool
 val tableaux_cdcl : unit -> bool
 val minimal_bj : unit -> bool
 val enable_restarts : unit -> bool


### PR DESCRIPTION
Add a new option "-no-tableaux-cdcl-in-theories" for disabling Tableaux reduction model for the theories.