### PR TITLE
Separate Typing from Trigger inference

### DIFF
--- a/sources/lib/frontend/triggers.ml
+++ b/sources/lib/frontend/triggers.ml
@@ -1035,3 +1035,30 @@ let make keep_triggers gopt f = match f.c with
             {qf_bvars=[]; qf_upvars=[]; qf_triggers=trs; qf_form=f; qf_hyp=[]}
       }
 
+let make_decl keep_triggers ({ c; _ } as d) =
+  match c with
+  | TAxiom (loc, name, kind, f) ->
+    let f' = make keep_triggers false f in
+    { d with c = TAxiom (loc, name, kind, f') }
+  | TGoal (loc, sort, name, f) ->
+    let f' = make keep_triggers true f in
+    { d with c = TGoal (loc, sort, name, f') }
+  | TTheory (loc, name, exts, l) ->
+    let l' =
+      List.map (fun d' ->
+          match d'.c with
+          | TAxiom (loc', name', kind', f') ->
+            let f'' = make true false f' in
+            { d' with c = TAxiom (loc', name', kind', f'') }
+          | _ -> d'
+        ) l
+    in
+    { d with c = TTheory (loc, name, exts, l') }
+  | TPredicate_def (loc, name, l, f) ->
+    let f' = make keep_triggers false f in
+    { d with c = TPredicate_def (loc, name, l, f') }
+  | TFunction_def (loc, name, l, ty, f) ->
+    let f' = make keep_triggers false f in
+    { d with c = TFunction_def (loc, name, l, ty, f') }
+  | _ -> d
+

--- a/sources/lib/frontend/triggers.mli
+++ b/sources/lib/frontend/triggers.mli
@@ -32,3 +32,7 @@ open Typed
    if k is true existing triggers are checked
    if b is true then variables are authorized in multi-triggers *)
 val make : bool -> bool -> (int tform, int) annoted -> (int tform, int) annoted
+
+(* [make_decl k d] computes the triggers for a declaration d
+   if k is true existing triggers are checked *)
+val make_decl : bool -> (int tdecl, int) annoted -> (int tdecl, int) annoted

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -1678,7 +1678,6 @@ let axioms_of_rules keep_triggers loc name lf acc env =
   let acc =
     List.fold_left
       (fun acc (f, _) ->
-         let f = Triggers.make keep_triggers false f in
          let name = (Hstring.fresh_string ()) ^ "_" ^ name in
          let td = {c = TAxiom(loc,name,Default, f); annot = new_id () } in
          (td, env)::acc
@@ -1691,7 +1690,6 @@ let axioms_of_rules keep_triggers loc name lf acc env =
 let type_hypothesis keep_triggers acc env_f loc sort f =
   let f,_ = type_form env_f f in
   let f = monomorphize_form f in
-  let f = Triggers.make keep_triggers false f in
   let td =
     {c = TAxiom(loc, fresh_hypothesis_name sort,Default, f);
      annot = new_id () } in
@@ -1701,7 +1699,6 @@ let type_hypothesis keep_triggers acc env_f loc sort f =
 let type_goal keep_triggers acc env_g loc sort n goal =
   let goal, _ = type_form env_g goal in
   let goal = monomorphize_form goal in
-  let goal = Triggers.make keep_triggers true goal in
   let td = {c = TGoal(loc, sort, n, goal); annot = new_id () } in
   (td, env_g)::acc
 
@@ -1736,7 +1733,6 @@ let type_one_th_decl keep_triggers env e =
   match e with
   | Axiom(loc,name,ax_kd,f)  ->
     let f,_ = type_form ~in_theory:true env f in
-    let f = Triggers.make (*keep_triggers=*) true false f in
     {c = TAxiom (loc,name,ax_kd,f); annot = new_id ()}
 
   | Theory (loc, _, _, _)
@@ -1771,7 +1767,6 @@ let type_decl keep_triggers (acc, env) d =
     | Axiom(loc,name,ax_kd,f) ->
       Options.tool_req 1 "TR-Typing-AxiomDecl$_F$";
       let f, _ = type_form env f in
-      let f = Triggers.make keep_triggers false f in
       let td = {c = TAxiom(loc,name,ax_kd,f); annot = new_id () } in
       (td, env)::acc, env
 
@@ -1815,7 +1810,6 @@ let type_decl keep_triggers (acc, env) d =
       let trs = max_terms e in
       let f = make_pred loc [[p], false ; trs, false] f l in
       let f,_ = type_form env f in
-      let f = Triggers.make keep_triggers false f in
       let td =
         match d with
         | Function_def(_,_,_,t,_) ->
@@ -1858,7 +1852,9 @@ let file ld =
         ([], env) ld
     in
     if type_only () then exit 0;
-    List.rev ltd, env
+    let l = List.rev_map (fun (d, env) ->
+        Triggers.make_decl keep_triggers d, env) ltd in
+    l, env
   with
   | Errors.Error(e,l) ->
     Loc.report err_formatter l;

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -239,7 +239,7 @@ module Env = struct
         { args = List.map (Types.ty_of_pp loc env.types None) args;
           result = Ty.Tbool }
       (*| PFunction ([], PPTvarid (_, loc)) ->
-        	  error CannotGeneralize loc*)
+          error CannotGeneralize loc*)
       | PFunction(args, res) ->
         let args = List.map (Types.ty_of_pp loc env.types None) args in
         let res = Types.ty_of_pp loc env.types None res in
@@ -1498,7 +1498,7 @@ let rec intro_hypothesis env valid_mode f =
         let var = {pp_desc = PPvar var; pp_loc = f.pp_loc} in
         let feq = {pp_desc = PPinfix(var,PPeq,t1); pp_loc = f.pp_loc} in
         let axioms, goal = intro_hypothesis env valid_mode
-        	(alpha_renaming_env env f2) in
+          (alpha_renaming_env env f2) in
         (feq,env)::axioms, goal
   *)
   | PPforall (lv, _, _, f) when valid_mode ->
@@ -1810,8 +1810,8 @@ let type_decl keep_triggers (acc, env) d =
       let infix = match d with Function_def _ -> PPeq | _ -> PPiff in
       let f = { pp_desc = PPinfix(p,infix,e) ; pp_loc = loc } in
       (* le trigger [[p]] ne permet pas de replier la definition,
-         	   donc on calcule les termes maximaux de la definition pour
-         	   laisser une possibilite de replier *)
+         donc on calcule les termes maximaux de la definition pour
+         laisser une possibilite de replier *)
       let trs = max_terms e in
       let f = make_pred loc [[p], false ; trs, false] f l in
       let f,_ = type_form env f in


### PR DESCRIPTION
This PR tries and factorize trigger inference so that it can more easily be moved outside the typechecker. The trigger inference is still done in the typechecker, but only at one place, when typechecking a whole input file.