### PR TITLE
Remove dependency of Typed on Parsed

### DIFF
--- a/sources/lib/structures/ty.ml
+++ b/sources/lib/structures/ty.ml
@@ -77,7 +77,18 @@ let print full =
     | Text(l, s) -> fprintf fmt "%a %s" print_list l (Hstring.view s)
     | Tfarray (t1, t2) -> fprintf fmt "(%a,%a) farray" print t1 print t2
     | Tnext t -> fprintf fmt "%a next" print t
-    | Tsum(s, _) -> fprintf fmt "%s" (Hstring.view s)
+    | Tsum(s, lc) ->
+      fprintf fmt "%s" (Hstring.view s);
+      if full then begin
+        fprintf fmt " = ";
+        let first = ref true in
+        List.iter
+          (fun s ->
+             fprintf fmt "%s%s" (if !first then "" else " | ")
+               (Hstring.view s);
+             first := false
+          ) lc
+      end
     | Trecord {args=lv; name=n; lbs=lbls} ->
       fprintf fmt "%a %s" print_list lv (Hstring.view n);
       if full then begin

--- a/sources/lib/structures/ty.mli
+++ b/sources/lib/structures/ty.mli
@@ -72,9 +72,7 @@ and tvar = {
 
 and trecord = {
   mutable args : t list;
-  (** parameters of the record
-      TODO: or are they the arguments applied
-            to the record constructor type ? *)
+  (** Arguments passed to the record constructor *)
   name : Hstring.t;
   (** Name of the record type *)
   mutable lbs :  (Hstring.t * t) list;

--- a/sources/lib/structures/typed.ml
+++ b/sources/lib/structures/typed.ml
@@ -27,7 +27,6 @@
 (******************************************************************************)
 
 open Format
-open Parsed
 
 [@@@ocaml.warning "-33"]
 open Options
@@ -141,6 +140,12 @@ type theories_extensions =
   | NIA
   | FPA
 
+type axiom_kind = Parsed.axiom_kind = Default | Propagator
+
+type tlogic_type =
+  | TPredicate of Ty.t list
+  | TFunction of Ty.t list * Ty.t
+
 type 'a atdecl = ('a tdecl, 'a) annoted
 
 and 'a tdecl =
@@ -152,14 +157,14 @@ and 'a tdecl =
   | TAxiom of Loc.t * string * axiom_kind * ('a tform, 'a) annoted
   | TRewriting of Loc.t * string * (('a tterm, 'a) annoted rwt_rule) list
   | TGoal of Loc.t * goal_sort * string * ('a tform, 'a) annoted
-  | TLogic of Loc.t * string list * plogic_type
+  | TLogic of Loc.t * string list * tlogic_type
   | TPredicate_def of
       Loc.t * string *
-      (string * ppure_type) list * ('a tform, 'a) annoted
+      (string * Ty.t) list * ('a tform, 'a) annoted
   | TFunction_def of
       Loc.t * string *
-      (string * ppure_type) list * ppure_type * ('a tform, 'a) annoted
-  | TTypeDecl of Loc.t * string list * string * body_type_decl
+      (string * Ty.t) list * Ty.t * ('a tform, 'a) annoted
+  | TTypeDecl of Loc.t * Ty.t
 
 (*****)
 

--- a/sources/lib/structures/typed.mli
+++ b/sources/lib/structures/typed.mli
@@ -31,7 +31,6 @@
     This module defines a typed AST, used to represent typed terms
     before they are hashconsed. *)
 
-open Parsed
 
 (** {2 Annotations} *)
 
@@ -241,6 +240,19 @@ type theories_extensions =
 (** Theories known in alt-ergo. These theories correspond
     to sets of axioms to extend expressive power of some theory. *)
 
+type axiom_kind = Parsed.axiom_kind =
+  | Default     (** *)
+  | Propagator  (** *)
+(** Axiom kinds. *)
+
+type tlogic_type =
+  | TPredicate of Ty.t list       (** Predicate type declarations *)
+  | TFunction of Ty.t list * Ty.t (** Function type declarations *)
+(** Type declarations. Specifies the list of argument types,
+    as well as the return type for functions (predicate implicitly
+    returns a proposition, so there is no need for an explicit return
+    type). *)
+
 type 'a atdecl = ('a tdecl, 'a) annoted
 (** Type alias for annoted typed declarations. *)
 
@@ -254,20 +266,20 @@ and 'a tdecl =
   (** New rewrite rule that can be used. *)
   | TGoal of Loc.t * goal_sort * string * 'a atform
   (** New goal to prove. *)
-  | TLogic of Loc.t * string list * plogic_type
+  | TLogic of Loc.t * string list * tlogic_type
   (** Function (or predicate) type declaration. *)
   | TPredicate_def of
-      Loc.t * string * (string * ppure_type) list * 'a atform
+      Loc.t * string * (string * Ty.t) list * 'a atform
   (** Predicate definition.
-      [TPredicate_def (loc, name, vars, body)] declares a predicate
+      [TPredicate_def (loc, name, vars, body)] defines a predicate
       [fun vars => body]. *)
   | TFunction_def of
       Loc.t * string *
-      (string * ppure_type) list * ppure_type * 'a atform
+      (string * Ty.t) list * Ty.t * 'a atform
   (** Predicate definition.
-      [TPredicate_def (loc, name, vars, ret, body)] declares a function
+      [TPredicate_def (loc, name, vars, ret, body)] defines a function
       [fun vars => body], where body has type [ret]. *)
-  | TTypeDecl of Loc.t * string list * string * body_type_decl
+  | TTypeDecl of Loc.t * Ty.t
   (** New type declaration. [TTypeDecl (loc, vars, t, body)]
       declares a type [t], with parameters [vars], and with
       contents [body]. This new type may either be abstract,

--- a/sources/tools/gui/annoted_ast.mli
+++ b/sources/tools/gui/annoted_ast.mli
@@ -158,12 +158,13 @@ type atyped_decl =
   | AAxiom of Loc.t * string * Parsed.axiom_kind * aform
   | ARewriting of Loc.t * string * ((aterm rwt_rule) annoted) list
   | AGoal of Loc.t * goal_sort * string * aform annoted
-  | ALogic of Loc.t * string list * plogic_type
-  | APredicate_def of Loc.t * string * (string * ppure_type) list * aform
+  | ALogic of Loc.t * string list * plogic_type * tlogic_type
+  | APredicate_def
+    of Loc.t * string * (string * ppure_type * Ty.t) list * aform
   | AFunction_def
-    of Loc.t * string * (string * ppure_type) list * ppure_type * aform
-  | ATypeDecl of Loc.t * string list * string * body_type_decl
-
+    of Loc.t * string * (string * ppure_type * Ty.t) list
+       * ppure_type * Ty.t * aform
+  | ATypeDecl of Loc.t * string list * string * body_type_decl * Ty.t
 
 type annoted_node =
   | AD of (atyped_decl annoted * Typechecker.env)

--- a/sources/tools/gui/connected_ast.ml
+++ b/sources/tools/gui/connected_ast.ml
@@ -961,7 +961,7 @@ let rec connect_atyped_decl env td =
   | AGoal (_, _, _, aaf) ->
     connect_tag env env.buffer td.tag;
     connect_aform env env.buffer aaf.c
-  | AFunction_def (_, _, _, _, af) ->
+  | AFunction_def (_, _, _, _, _, af) ->
     connect_tag env env.buffer td.tag;
     connect_aform env env.buffer af
   | ALogic _


### PR DESCRIPTION
This PR changes the type of typed declarations so that everything in these declarations are typed. Before, a lot of strings and parts of the parsed/untyped AST were left as is even though the type declaration had been typechecked. Here we replace these using the typed AST.

There are two main motivations for that: make the code cleaner, and more importantly, make `Typed` a standalone entrypoint for the backend, so that typecheckers can directly produce typed declarations (without having to produce untyped declarations). This should make the addition of new typecheckers (dolmen's, as well as psmt2's) easier.