### PR TITLE
Abstract over input method

### DIFF
--- a/sources/examples/lib_usage.ml
+++ b/sources/examples/lib_usage.ml
@@ -52,7 +52,7 @@ let goal_3 = PA.mk_goal Loc.dummy "toy_3" (PA.mk_not Loc.dummy eq1)
 
 let parsed = [goal_1; goal_2; goal_3]
 
-let typed, env = Typechecker.file parsed
+let typed, env = Typechecker.type_file parsed
 
 let pbs = Typechecker.split_goals_and_cnf typed
 

--- a/sources/lib/dune
+++ b/sources/lib/dune
@@ -13,7 +13,7 @@
   ; modules that make up the lib
   (modules
     ; frontend
-    Cnf Frontend Parsed_interface Typechecker
+    Cnf Input Frontend Parsed_interface Typechecker
     ; reasoners
     Ac Arith Arrays Arrays_rel Bitv Ccx Shostak Relation Enum Enum_rel
     Fun_sat Inequalities Bitv_rel Th_util

--- a/sources/lib/frontend/input.ml
+++ b/sources/lib/frontend/input.ml
@@ -1,0 +1,43 @@
+(******************************************************************************)
+(*                                                                            *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
+(*     Copyright (C) 2018-2018 --- OCamlPro SAS                               *)
+(*                                                                            *)
+(*     This file is distributed under the terms of the Apache Software        *)
+(*     License version 2.0                                                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+exception Method_not_registered of string
+
+module type S = sig
+
+  (* Parsing *)
+
+  type expr
+
+  type file
+
+  val parse_expr : Lexing.lexbuf -> expr
+
+  val parse_file : filename:string -> preludes:string list -> file
+
+  (* Typechecking *)
+
+  type env
+
+  val type_expr :
+    env -> (Symbols.t * Ty.t) list -> expr -> int Typed.atterm
+
+  val type_file : file -> (int Typed.atdecl * env) list * env
+end
+
+let input_methods = ref []
+
+let register name ((module M : S) as m) =
+  input_methods := (name, m) :: !input_methods
+
+let find name =
+  try List.assoc name !input_methods
+  with Not_found -> raise (Method_not_registered name)
+

--- a/sources/lib/frontend/input.ml
+++ b/sources/lib/frontend/input.ml
@@ -14,20 +14,13 @@ module type S = sig
 
   (* Parsing *)
 
-  type expr
-
   type file
-
-  val parse_expr : Lexing.lexbuf -> expr
 
   val parse_file : filename:string -> preludes:string list -> file
 
   (* Typechecking *)
 
   type env
-
-  val type_expr :
-    env -> (Symbols.t * Ty.t) list -> expr -> int Typed.atterm
 
   val type_file : file -> (int Typed.atdecl * env) list * env
 end

--- a/sources/lib/frontend/input.mli
+++ b/sources/lib/frontend/input.mli
@@ -1,0 +1,65 @@
+(******************************************************************************)
+(*                                                                            *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
+(*     Copyright (C) 2018-2018 --- OCamlPro SAS                               *)
+(*                                                                            *)
+(*     This file is distributed under the terms of the Apache Software        *)
+(*     License version 2.0                                                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Typed input
+
+    This module defines an abstraction layer over the
+    parsing and typechecking of input formulas. The goal is to
+    be able to use different parsing and/or typechecking
+    engines (e.g. the legacy typechecker, psmt2, or dolmen).
+    To do so, an input method actually generates the typed
+    representation of the input. *)
+
+exception Method_not_registered of string
+(** Exceptions raised when trying to lookup an input method
+    that has not been registered. *)
+
+(** This modules defines an input method. Input methods are responsible
+    for two things: parsing and typechceking either an input file (possibly
+    with some preludes files), or arbitrary terms. This last functionality
+    is currently only used in the GUI. *)
+module type S = sig
+
+  (** {5 Parsing} *)
+  type expr
+  (** The type of a parsed expression (i.e. a term, or formula, etc..) *)
+
+  type file
+  (** The type of a parsed file (including preludes). *)
+
+  val parse_expr : Lexing.lexbuf -> expr
+  (** Parse an expression from a lexbuf. *)
+
+  val parse_file : filename:string -> preludes:string list -> file
+  (** Parse a file (and some preludes). *)
+
+
+  (** {5 Typechecking} *)
+
+  type env
+  (** The type of local environments used for typechecking. *)
+
+  val type_expr :
+    env -> (Symbols.t * Ty.t) list -> expr -> int Typed.atterm
+  (** Parse and typecheck a term. *)
+
+  val type_file : file -> (int Typed.atdecl * env) list * env
+  (** Parse and typecheck some input file, together with some prelude files. *)
+
+end
+
+val register : string -> (module S) -> unit
+(** Register a new input method. *)
+
+val find : string -> (module S)
+(** Find an input method by name.
+    @raise Method_not_registered if the name is not registered. *)
+
+

--- a/sources/lib/frontend/input.mli
+++ b/sources/lib/frontend/input.mli
@@ -28,14 +28,9 @@ exception Method_not_registered of string
 module type S = sig
 
   (** {5 Parsing} *)
-  type expr
-  (** The type of a parsed expression (i.e. a term, or formula, etc..) *)
 
   type file
   (** The type of a parsed file (including preludes). *)
-
-  val parse_expr : Lexing.lexbuf -> expr
-  (** Parse an expression from a lexbuf. *)
 
   val parse_file : filename:string -> preludes:string list -> file
   (** Parse a file (and some preludes). *)
@@ -45,10 +40,6 @@ module type S = sig
 
   type env
   (** The type of local environments used for typechecking. *)
-
-  val type_expr :
-    env -> (Symbols.t * Ty.t) list -> expr -> int Typed.atterm
-  (** Parse and typecheck a term. *)
 
   val type_file : file -> (int Typed.atdecl * env) list * env
   (** Parse and typecheck some input file, together with some prelude files. *)

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -276,9 +276,6 @@ module Env = struct
 
 end
 
-let new_id = let r = ref 0 in fun () -> r := !r+1; !r
-
-
 let symbol_of = function
     PPadd -> Symbols.Op Symbols.Plus
   | PPsub -> Symbols.Op Symbols.Minus
@@ -1757,13 +1754,12 @@ let type_decl (acc, env) d =
     Loc.report std_formatter loc;
     acc, env
 
-let file ld =
+let type_file ld =
   let env = Env.empty in
   try
     let ltd, env =
       List.fold_left (fun acc d -> type_decl acc d) ([], env) ld
     in
-    if type_only () then exit 0;
     List.rev ltd, env
   with
   | Errors.Error(e,l) ->
@@ -1812,7 +1808,7 @@ let split_goals l =
 let split_goals_and_cnf l =
   split_goals_aux (fun td env acc -> Cnf.make acc td) l
 
-let term env vars t =
+let type_expr env vars t =
   let vmap =
     List.fold_left
       (fun m (s,ty)->
@@ -1823,3 +1819,4 @@ let term env vars t =
   type_term env t
 
 type env = Env.t
+

--- a/sources/lib/frontend/typechecker.mli
+++ b/sources/lib/frontend/typechecker.mli
@@ -26,27 +26,32 @@
 (*                                                                            *)
 (******************************************************************************)
 
-open Parsed
-open Typed
-
 type env
+(** The type of global environment of the typechecker. *)
 
-val file : file ->
-  ((int tdecl, int) annoted * env) list * env
+val type_expr :
+  env -> (Symbols.t * Ty.t) list -> Parsed.lexpr -> int Typed.atterm
+(** Typecheck an input expression (i.e. term (or formula ?)), given
+    a local environment and a list of local types used to extend the
+    initial environment. *)
+(* TODO: give the env a proper module with binding functions,
+         so that the list argument can be ommitted ? *)
 
+val type_file : Parsed.file -> (int Typed.atdecl * env) list * env
+(** Type an input file. Returns the successive global environments
+    obtained after typing each declaration. *)
+
+
+(* TODO: move these 2 functiosn out of the typechecker *)
 (* two functions split_goals to minimize useless changes in the GUI *)
 
 (* used by main_gui *)
 val split_goals :
-  ((int tdecl, int) annoted * env) list ->
-  (((int tdecl, int) annoted * env) list * string) list
+  (int Typed.atdecl * 'a) list ->
+  ((int Typed.atdecl * 'a) list * string) list
 
 (* used by main_text *)
 val split_goals_and_cnf :
-  ((int tdecl, int) annoted * env) list ->
+  (int Typed.atdecl * 'a) list ->
   (Commands.sat_tdecl list * string) list
 
-val term : env -> (Symbols.t * Ty.t) list -> Parsed.lexpr ->
-  (int tterm, int) annoted
-
-val new_id : unit -> int

--- a/sources/lib/structures/typed.ml
+++ b/sources/lib/structures/typed.ml
@@ -38,6 +38,11 @@ type ('a, 'b) annoted =
   { c : 'a;
     annot : 'b }
 
+let new_id = let r = ref 0 in fun () -> r := !r+1; !r
+
+let mk ?(annot=new_id ()) c = { c; annot; }
+
+
 (** Terms and Formulas *)
 
 type tconstant =

--- a/sources/lib/structures/typed.mli
+++ b/sources/lib/structures/typed.mli
@@ -40,6 +40,14 @@ type ('a, 'b) annoted = {
 }
 (** An annoted structure. Usually used to annotate terms. *)
 
+val new_id : unit -> int
+(** Generate a new, fresh integer (useful for annotations). *)
+
+val mk : ?annot:int -> 'a -> ('a, int) annoted
+(** Create an annoted value with the given annotation.
+    If no annotation is given, a fresh annotation is generated
+    using {!new_id}. *)
+
 
 (** {2 Terms and formulas} *)
 

--- a/sources/lib/util/options.ml
+++ b/sources/lib/util/options.ml
@@ -37,6 +37,7 @@ module M = struct
   let type_only = ref false
   let type_smt2 = ref false
   let parse_only = ref false
+  let frontend = ref "legacy"
   let steps_bound = ref (-1)
   let age_bound = ref 50
   let debug = ref false
@@ -250,6 +251,10 @@ module M = struct
     "-parse-only",
     Arg.Set parse_only,
     " stop after parsing";
+
+    "-frontend",
+    Arg.Set_string frontend,
+    " select the parsing and typing frontend";
 
     "-type-only",
     Arg.Set type_only,
@@ -733,6 +738,7 @@ let set_debug_explanations b = M.debug_explanations := b
 let set_type_only b = M.type_only := b
 let set_type_smt2 b = M.type_smt2 := b
 let set_parse_only b = M.parse_only := b
+let set_frontend s = M.frontend := s
 let set_steps_bound b = M.steps_bound := b
 let set_age_bound b = M.age_bound := b
 let set_no_user_triggers b = M.no_user_triggers := b
@@ -808,6 +814,7 @@ let js_mode () = !M.js_mode
 let type_only () = !M.type_only
 let type_smt2 () = !M.type_smt2
 let parse_only () = !M.parse_only
+let frontend () = !M.frontend
 let steps_bound () = !M.steps_bound
 let no_tcp () = !M.no_tcp
 let no_decisions () = !M.no_decisions

--- a/sources/lib/util/options.mli
+++ b/sources/lib/util/options.mli
@@ -61,6 +61,7 @@ val set_profiling : float -> bool -> unit
 val set_type_only : bool -> unit
 val set_type_smt2 : bool -> unit
 val set_parse_only : bool -> unit
+val set_frontend : string -> unit
 val set_verbose : bool -> unit
 val set_steps_bound : int -> unit
 val set_age_bound : int -> unit
@@ -133,6 +134,7 @@ val disable_ites : unit -> bool
 val type_only : unit -> bool
 val type_smt2 : unit -> bool
 val parse_only : unit -> bool
+val frontend : unit -> string
 val steps_bound : unit -> int
 val no_tcp : unit -> bool
 val no_decisions : unit -> bool

--- a/sources/parsers/parsers.ml
+++ b/sources/parsers/parsers.ml
@@ -134,7 +134,6 @@ let parse_input_file file =
     let ext = if String.equal ext "" then None else Some ext in
     let a = parse_file ?lang:ext lb in
     if opened_cin then close_in cin;
-    if parse_only () then exit 0;
     a
   with
   | Errors.Lexical_error (loc, s) ->

--- a/sources/tools/gui/connected_ast.ml
+++ b/sources/tools/gui/connected_ast.ml
@@ -348,7 +348,7 @@ let is_quantified_term vars at =
   | _ -> true
 
 let unquantify_aaterm (buffer:sbuffer) at =
-  new_annot buffer at.c (Typechecker.new_id ()) (tag buffer)
+  new_annot buffer at.c (Typed.new_id ()) (tag buffer)
 
 let unquantify_aatom (buffer:sbuffer) = function
   | AAtrue -> AAtrue
@@ -395,14 +395,14 @@ let rec unquantify_aform (buffer:sbuffer) tyenv vars_entries
               let lexpr = Parsers.parse_expr lb in
               let at, gu =
                 try
-                  let tt = Typechecker.term tyenv uplet lexpr in
+                  let tt = Typechecker.type_expr tyenv uplet lexpr in
                   annot_of_tterm buffer tt, []
                 with Errors.Error _ ->
                   let gv = List.fold_left (fun acc v ->
                       if List.mem v uplet then acc
                       else v::acc) [] goal_vars
                   in
-                  let tt = Typechecker.term tyenv (uplet@gv) lexpr in
+                  let tt = Typechecker.type_expr tyenv (uplet@gv) lexpr in
                   let at = annot_of_tterm buffer tt in
                   at, filter_used_vars_term gv at.c
               in
@@ -417,7 +417,7 @@ let rec unquantify_aform (buffer:sbuffer) tyenv vars_entries
         List.fold_left
           (fun af (u, s, at) ->
              new_annot buffer (AFlet (u, [s, ATletTerm at], af))
-               (Typechecker.new_id ()) (tag buffer))
+               (Typed.new_id ()) (tag buffer))
           afc lets in
       if nbv == [] then (add_lets aform lets).c, ve, goal_used
       else
@@ -441,10 +441,10 @@ let rec unquantify_aform (buffer:sbuffer) tyenv vars_entries
             } in
           (match f with
            | AFforall _ ->
-             AFforall (new_annot buffer c (Typechecker.new_id ()) (tag buffer)),
+             AFforall (new_annot buffer c (Typed.new_id ()) (tag buffer)),
              ve, goal_used
            | AFexists _ ->
-             AFexists (new_annot buffer c (Typechecker.new_id ()) (tag buffer)),
+             AFexists (new_annot buffer c (Typed.new_id ()) (tag buffer)),
              ve, goal_used
            | _ -> assert false)
 
@@ -455,10 +455,10 @@ let rec unquantify_aform (buffer:sbuffer) tyenv vars_entries
       let c = { aaqf.c with aqf_form = naqf_form } in
       (match f with
        | AFforall _ ->
-         AFforall (new_annot buffer c (Typechecker.new_id ()) (tag buffer)),
+         AFforall (new_annot buffer c (Typed.new_id ()) (tag buffer)),
          ve, goal_used
        | AFexists _ ->
-         AFexists (new_annot buffer c (Typechecker.new_id ()) (tag buffer)),
+         AFexists (new_annot buffer c (Typed.new_id ()) (tag buffer)),
          ve, goal_used
        | _ -> assert false)
 
@@ -477,7 +477,7 @@ let rec unquantify_aform (buffer:sbuffer) tyenv vars_entries
       in
       AFnamed (n, naaf), ve, goal_used
   in
-  new_annot buffer c (Typechecker.new_id ()) ptag, ve, goal_used
+  new_annot buffer c (Typed.new_id ()) ptag, ve, goal_used
 
 
 let make_instance (buffer:sbuffer) vars entries afc goal_form tyenv =
@@ -724,7 +724,7 @@ and add_trigger ?(register=true) t qid env str offset (sbuf:sbuffer) =
         let lexprs, _ = Parsers.parse_trigger lb in
         let atl = List.fold_right
             (fun lexpr l->
-               let tt = Typechecker.term tyenv
+               let tt = Typechecker.type_expr tyenv
                    (qf.c.aqf_upvars@qf.c.aqf_bvars) lexpr in
                let at = annot_of_tterm sbuf tt in
                at.tag#set_priority (t#priority - 1);

--- a/sources/tools/gui/main_gui.ml
+++ b/sources/tools/gui/main_gui.ml
@@ -995,7 +995,11 @@ let start_gui all_used_context =
   let filename = get_file () in
   let preludes = Options.preludes () in
   let pfile = Parsers.parse_problem ~filename ~preludes in
-  let typed_ast, _ = Typechecker.file pfile in
+  (* TODO: is the GUI ever invoked in parse_only mode ? *)
+  if parse_only () then exit 0;
+  let typed_ast, _ = Typechecker.type_file pfile in
+  (* TODO: is the GUI ever invoked in type_only mode ? *)
+  if type_only () then exit 0;
   let typed_ast = Typechecker.split_goals typed_ast in
 
   let main_vbox = GPack.vbox
@@ -1443,7 +1447,11 @@ let start_replay session_cin all_used_context =
   let filename = get_file () in
   let preludes = Options.preludes () in
   let pfile = Parsers.parse_problem ~filename ~preludes in
-  let typed_ast, _ = Typechecker.file pfile in
+  (* TODO: is the GUI ever invoked in parse_only mode ? *)
+  if parse_only () then exit 0;
+  let typed_ast, _ = Typechecker.type_file pfile in
+  (* TODO: is the GUI ever invoked in type_only mode ? *)
+  if type_only () then exit 0;
   let typed_ast = Typechecker.split_goals typed_ast in
   List.iter
     (fun (l, goal_name) ->

--- a/sources/tools/text/dune
+++ b/sources/tools/text/dune
@@ -4,8 +4,8 @@
   (public_name  alt-ergo)
   (package      alt-ergo)
   (libraries    alt-ergo-lib alt-ergo-parsers)
-  (modules      Main_text)
   (link_flags   (-linkall))
+  (modules      Main_input Main_text)
 )
 
 

--- a/sources/tools/text/main_input.ml
+++ b/sources/tools/text/main_input.ml
@@ -18,11 +18,7 @@ let () =
 
     (* Parsing *)
 
-    type expr = Parsed.lexpr
-
     type file = Parsed.file
-
-    let parse_expr l = Parsers.parse_expr l
 
     let parse_file = Parsers.parse_problem
 

--- a/sources/tools/text/main_input.ml
+++ b/sources/tools/text/main_input.ml
@@ -1,0 +1,79 @@
+(******************************************************************************)
+(*                                                                            *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
+(*     Copyright (C) 2018-2018 --- OCamlPro SAS                               *)
+(*                                                                            *)
+(*     This file is distributed under the terms of the Apache Software        *)
+(*     License version 2.0                                                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+open AltErgoLib
+open AltErgoParsers
+
+(* === LEGACY input method === *)
+
+let () =
+  let module M : Input.S = struct
+
+    (* Parsing *)
+
+    type expr = Parsed.lexpr
+
+    type file = Parsed.file
+
+    let parse_expr l = Parsers.parse_expr l
+
+    let parse_file = Parsers.parse_problem
+
+    (** Typechecking *)
+
+    include Typechecker
+
+  end in
+  Input.register "legacy" (module M)
+
+(*
+(* === DOLMEN inut method === *)
+
+let () =
+  let module M : Input.S = struct
+
+    (* Parsing *)
+
+    module L = Dolmen.Logic.Make
+        (Dolmen.ParseLocation)
+        (Dolmen.Id)(Dolmen.Term)
+        (Dolmen.Statement)
+
+    type expr (* TODO: fill this *)
+
+    type file = (L.language * Dolmen.Statement.t) list
+
+    let parse_expr _ = assert false
+
+    let parse_file ~filename ~preludes =
+      let aux f =
+        let lang, l = L.parse_file f in
+        List.map (fun x -> lang, x) l
+      in
+      (* TODO: expand includes ? *)
+      let l = List.concat (
+          List.rev_map aux (filename :: List.rev preludes)
+        ) in
+      l
+
+
+    (* Typechecking *)
+
+    type env = unit
+
+    let new_id () = 0
+
+    let type_expr _ _ _ = assert false
+
+    let type_file _ = [], ()
+
+  end in
+  Input.register "dolmen" (module M)
+*)


### PR DESCRIPTION
This PR creates the notion of input method.

An input method is a black box that outputs a list of typed statements, from a given filename. Currently, the only input method defined is the legacy one, using the AltErgoParsers lib and the builtin typechecker (as well as the psmt2 to native translation). Future input methods should include a direct psmt2 input method (to avoid typechecking twice), and a dolmen input method.

The choice of input method is currently done using a command line argument named "frontend".

Additionnally, this PR moves the generation of new ids for typed formulas from the typechecker to the `typed` module, as future input methods should not depend on the builtin typechecker, but only on the `typed` module.