### PR TITLE
fix in the native parser for floating-point's semantic triggers

### DIFF
--- a/sources/parsers/why_parser.mly
+++ b/sources/parsers/why_parser.mly
@@ -481,7 +481,7 @@ sq:
 | RIGHTSQ {false}
 
 bound:
-| QM                 { mk_var ($startpos, $endpos) "" }
+| QM                 { mk_var ($startpos, $endpos) "?" }
 | id = QM_ID         { mk_var ($startpos, $endpos) id }
 | id = ID            { mk_var ($startpos, $endpos) id }
 | i = INTEGER        { mk_int_const ($startpos, $endpos) i }


### PR DESCRIPTION
recent changes in why_lexer.mll, replaced the ID "?" with ""