### PR TITLE
Add exponentiation operation, `**` in native Alt-Ergo syntax.

### DIFF
--- a/sources/lib/frontend/cnf.ml
+++ b/sources/lib/frontend/cnf.ml
@@ -75,7 +75,8 @@ let make_adequate_app s l ty =
       | "min_real", [_;_] -> Sy.Op Sy.Min_real, l
       | "min_int", [_;_] -> Sy.Op Sy.Min_int, l
       | "integer_log2", [_] -> Sy.Op Sy.Integer_log2, l
-      | "pow", [_;_] -> Sy.Op Sy.Pow, l
+      | "**", [_;_] -> Sy.Op Sy.PowInt, l
+      | "**.", [_;_] -> Sy.Op Sy.PowReal, l
 
       (* should not happend thanks to well typedness *)
       | ("float"

--- a/sources/lib/frontend/cnf.ml
+++ b/sources/lib/frontend/cnf.ml
@@ -75,8 +75,6 @@ let make_adequate_app s l ty =
       | "min_real", [_;_] -> Sy.Op Sy.Min_real, l
       | "min_int", [_;_] -> Sy.Op Sy.Min_int, l
       | "integer_log2", [_] -> Sy.Op Sy.Integer_log2, l
-      | "**", [_;_] -> Sy.Op Sy.PowInt, l
-      | "**.", [_;_] -> Sy.Op Sy.PowReal, l
 
       (* should not happend thanks to well typedness *)
       | ("float"

--- a/sources/lib/frontend/cnf.ml
+++ b/sources/lib/frontend/cnf.ml
@@ -75,8 +75,7 @@ let make_adequate_app s l ty =
       | "min_real", [_;_] -> Sy.Op Sy.Min_real, l
       | "min_int", [_;_] -> Sy.Op Sy.Min_int, l
       | "integer_log2", [_] -> Sy.Op Sy.Integer_log2, l
-      | "pow_real_int", [_;_] -> Sy.Op Sy.Pow_real_int, l
-      | "pow_real_real", [_;_] -> Sy.Op Sy.Pow_real_real, l
+      | "pow", [_;_] -> Sy.Op Sy.Pow, l
 
       (* should not happend thanks to well typedness *)
       | ("float"

--- a/sources/lib/frontend/parsed_interface.ml
+++ b/sources/lib/frontend/parsed_interface.ml
@@ -141,8 +141,11 @@ let mk_div loc e1 e2 =
 let mk_mod loc e1 e2 =
   mk_localized loc (mk_infix e1 PPmod e2)
 
-let mk_pow loc e1 e2 =
-  mk_localized loc (mk_infix e1 PPpow e2)
+let mk_pow_int loc e1 e2 =
+  mk_localized loc (mk_infix e1 PPpow_int e2)
+
+let mk_pow_real loc e1 e2 =
+  mk_localized loc (mk_infix e1 PPpow_real e2)
 
 let mk_minus loc e =
   mk_localized loc (mk_prefix PPneg e)

--- a/sources/lib/frontend/parsed_interface.ml
+++ b/sources/lib/frontend/parsed_interface.ml
@@ -141,6 +141,9 @@ let mk_div loc e1 e2 =
 let mk_mod loc e1 e2 =
   mk_localized loc (mk_infix e1 PPmod e2)
 
+let mk_pow loc e1 e2 =
+  mk_localized loc (mk_infix e1 PPpow e2)
+
 let mk_minus loc e =
   mk_localized loc (mk_prefix PPneg e)
 

--- a/sources/lib/frontend/parsed_interface.mli
+++ b/sources/lib/frontend/parsed_interface.mli
@@ -101,6 +101,8 @@ val mk_div : Loc.t -> lexpr -> lexpr -> lexpr
 
 val mk_mod : Loc.t -> lexpr -> lexpr -> lexpr
 
+val mk_pow : Loc.t -> lexpr -> lexpr -> lexpr
+
 val mk_minus : Loc.t -> lexpr -> lexpr
 
 val mk_pred_lt : Loc.t -> lexpr -> lexpr -> lexpr

--- a/sources/lib/frontend/parsed_interface.mli
+++ b/sources/lib/frontend/parsed_interface.mli
@@ -101,7 +101,9 @@ val mk_div : Loc.t -> lexpr -> lexpr -> lexpr
 
 val mk_mod : Loc.t -> lexpr -> lexpr -> lexpr
 
-val mk_pow : Loc.t -> lexpr -> lexpr -> lexpr
+val mk_pow_int : Loc.t -> lexpr -> lexpr -> lexpr
+
+val mk_pow_real : Loc.t -> lexpr -> lexpr -> lexpr
 
 val mk_minus : Loc.t -> lexpr -> lexpr
 

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -501,18 +501,19 @@ let rec type_term ?(call_from_type_form=false) env f =
         match ty1, ty2, op with
         | Ty.Tint, Ty.Tint, PPpow_int ->
           Options.tool_req 1 (append_type "TR-Typing-Oppow_int type" ty1);
-          TTinfix(te1,s,te2) , ty1
-        | Ty.Treal, Ty.Treal, PPpow_real | Ty.Treal, Ty.Tint, PPpow_real
-        | Ty.Tint, Ty.Treal, PPpow_real ->
+          TTinfix(te1,s,te2) , Ty.Tint
+
+        | (Ty.Tint | Ty.Treal), (Ty.Tint | Ty.Treal), PPpow_real ->
           Options.tool_req 1 (append_type "TR-Typing-Oppow_real type" ty1);
-          TTinfix(te1,s,te2) , ty1
+          TTinfix(te1,s,te2) , Ty.Treal
+
         | Ty.Treal , _, PPpow_int -> error (ShouldHaveTypeInt Ty.Tint) t1.pp_loc
         | _, Ty.Treal, PPpow_int -> error (ShouldHaveTypeInt Ty.Tint) t2.pp_loc
-        | Ty.Tint, Ty.Tint, PPpow_real ->
-          error (ShouldHaveTypeInt Ty.Treal) t1.pp_loc
+
         | _, _, PPpow_real -> error (ShouldHaveTypeInt Ty.Treal) t1.pp_loc
         | _, _, PPpow_int -> error (ShouldHaveTypeInt Ty.Tint) t1.pp_loc
-        | _ -> assert false (* can't appen *)
+
+        | _ -> assert false (* can't happen *)
       end
     | PPprefix(PPneg, { pp_desc=PPconst (ConstInt n); _ }) ->
       Options.tool_req 1 (append_type "TR-Typing-OpUnarith type" Ty.Tint);
@@ -2329,4 +2330,3 @@ let type_expr env vars t =
 type env = Env.t
 
 let empty_env = Env.empty
-

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -328,7 +328,8 @@ let symbol_of = function
   | PPmul -> Symbols.Op Symbols.Mult
   | PPdiv -> Symbols.Op Symbols.Div
   | PPmod ->  Symbols.Op Symbols.Modulo
-  | PPpow ->  Symbols.Op Symbols.Pow
+  | PPpow_int ->  Symbols.Op Symbols.PowInt
+  | PPpow_real ->  Symbols.Op Symbols.PowReal
   | _ -> assert false
 
 let append_type msg ty =
@@ -490,17 +491,19 @@ let rec type_term ?(call_from_type_form=false) env f =
           TTinfix(te1,s,te2) , ty1
         | _ -> error (ShouldHaveTypeInt ty1) t1.pp_loc
       end
-    | PPinfix(t1, PPpow, t2) ->
+    | PPinfix(t1, (PPpow_int | PPpow_real as op), t2) ->
       begin
-        let s = symbol_of PPpow in
+        let s = symbol_of op in
         let te1 = type_term env t1 in
         let te2 = type_term env t2 in
         let ty1 = Ty.shorten te1.c.tt_ty in
         let ty2 = Ty.shorten te2.c.tt_ty in
-        match ty1, ty2 with
-        | Ty.Tint, Ty.Tint | Ty.Tint, Ty.Treal
-        | Ty.Treal, Ty.Tint | Ty.Treal, Ty.Treal  ->
-          Options.tool_req 1 (append_type "TR-Typing-OpMod type" ty1);
+        match ty1, ty2, op with
+        | Ty.Tint, Ty.Tint, PPpow_int ->
+          Options.tool_req 1 (append_type "TR-Typing-Oppow_int type" ty1);
+          TTinfix(te1,s,te2) , ty1
+        | Ty.Treal, Ty.Treal, PPpow_real ->
+          Options.tool_req 1 (append_type "TR-Typing-Oppow_real type" ty1);
           TTinfix(te1,s,te2) , ty1
         | _ -> error (ShouldHaveTypeInt ty1) t1.pp_loc
       end

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -502,10 +502,17 @@ let rec type_term ?(call_from_type_form=false) env f =
         | Ty.Tint, Ty.Tint, PPpow_int ->
           Options.tool_req 1 (append_type "TR-Typing-Oppow_int type" ty1);
           TTinfix(te1,s,te2) , ty1
-        | Ty.Treal, Ty.Treal, PPpow_real ->
+        | Ty.Treal, Ty.Treal, PPpow_real | Ty.Treal, Ty.Tint, PPpow_real
+        | Ty.Tint, Ty.Treal, PPpow_real ->
           Options.tool_req 1 (append_type "TR-Typing-Oppow_real type" ty1);
           TTinfix(te1,s,te2) , ty1
-        | _ -> error (ShouldHaveTypeInt ty1) t1.pp_loc
+        | Ty.Treal , _, PPpow_int -> error (ShouldHaveTypeInt Ty.Tint) t1.pp_loc
+        | _, Ty.Treal, PPpow_int -> error (ShouldHaveTypeInt Ty.Tint) t2.pp_loc
+        | Ty.Tint, Ty.Tint, PPpow_real ->
+          error (ShouldHaveTypeInt Ty.Treal) t1.pp_loc
+        | _, _, PPpow_real -> error (ShouldHaveTypeInt Ty.Treal) t1.pp_loc
+        | _, _, PPpow_int -> error (ShouldHaveTypeInt Ty.Tint) t1.pp_loc
+        | _ -> assert false (* can't appen *)
       end
     | PPprefix(PPneg, { pp_desc=PPconst (ConstInt n); _ }) ->
       Options.tool_req 1 (append_type "TR-Typing-OpUnarith type" Ty.Tint);

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -328,8 +328,8 @@ let symbol_of = function
   | PPmul -> Symbols.Op Symbols.Mult
   | PPdiv -> Symbols.Op Symbols.Div
   | PPmod ->  Symbols.Op Symbols.Modulo
-  | PPpow_int ->  Symbols.Op Symbols.PowInt
-  | PPpow_real ->  Symbols.Op Symbols.PowReal
+  | PPpow_int ->  Symbols.Op Symbols.Pow
+  | PPpow_real ->  Symbols.Op Symbols.Pow
   | _ -> assert false
 
 let append_type msg ty =

--- a/sources/lib/frontend/typechecker.ml
+++ b/sources/lib/frontend/typechecker.ml
@@ -328,6 +328,7 @@ let symbol_of = function
   | PPmul -> Symbols.Op Symbols.Mult
   | PPdiv -> Symbols.Op Symbols.Div
   | PPmod ->  Symbols.Op Symbols.Modulo
+  | PPpow ->  Symbols.Op Symbols.Pow
   | _ -> assert false
 
 let append_type msg ty =
@@ -485,6 +486,20 @@ let rec type_term ?(call_from_type_form=false) env f =
         let ty2 = Ty.shorten te2.c.tt_ty in
         match ty1, ty2 with
         | Ty.Tint, Ty.Tint ->
+          Options.tool_req 1 (append_type "TR-Typing-OpMod type" ty1);
+          TTinfix(te1,s,te2) , ty1
+        | _ -> error (ShouldHaveTypeInt ty1) t1.pp_loc
+      end
+    | PPinfix(t1, PPpow, t2) ->
+      begin
+        let s = symbol_of PPpow in
+        let te1 = type_term env t1 in
+        let te2 = type_term env t2 in
+        let ty1 = Ty.shorten te1.c.tt_ty in
+        let ty2 = Ty.shorten te2.c.tt_ty in
+        match ty1, ty2 with
+        | Ty.Tint, Ty.Tint | Ty.Tint, Ty.Treal
+        | Ty.Treal, Ty.Tint | Ty.Treal, Ty.Treal  ->
           Options.tool_req 1 (append_type "TR-Typing-OpMod type" ty1);
           TTinfix(te1,s,te2) , ty1
         | _ -> error (ShouldHaveTypeInt ty1) t1.pp_loc

--- a/sources/lib/reasoners/adt_rel.ml
+++ b/sources/lib/reasoners/adt_rel.ml
@@ -290,7 +290,7 @@ let add_guarded_destr env uf t hs e t_ty =
 
 
 [@@ocaml.ppwarning "working with X.term_extract r would be sufficient ?"]
-let add env (uf:uf) (r:r) t =
+let add_aux env (uf:uf) (r:r) t =
   if Options.disable_adts () then env
   else
     let { E.f = sy; xs; ty; _ } = match E.term_view t with
@@ -321,7 +321,7 @@ let add env (uf:uf) (r:r) t =
     | _ -> env
 
 let add env (uf:uf) (r:r) t =
-  add env (uf:uf) (r:r) t, []
+  add_aux env (uf:uf) (r:r) t, []
 
 
 let count_splits env la =

--- a/sources/lib/reasoners/adt_rel.ml
+++ b/sources/lib/reasoners/adt_rel.ml
@@ -320,6 +320,9 @@ let add env (uf:uf) (r:r) t =
     *)
     | _ -> env
 
+let add env (uf:uf) (r:r) t =
+  add env (uf:uf) (r:r) t, []
+
 
 let count_splits env la =
   let nb =

--- a/sources/lib/reasoners/arith.ml
+++ b/sources/lib/reasoners/arith.ml
@@ -41,15 +41,19 @@ let is_mult h = Sy.equal (Sy.Op Sy.Mult) h
 let mod_symb = Sy.name "@mod"
 
 let calc_power (c : Q.t) (d : Q.t) (ty : Ty.t) =
+  (* d must be integral and if we work on integer exponentation,
+     d must be positive*)
   if not (Q.is_int d) then raise Exit;
+  if Ty.Tint == ty && (Q.compare d Q.zero) < 0 then raise Exit;
   let n = match Z.to_machine_int (Q.to_z d) with
     | Some n -> n
     | None -> raise Exit
   in
+  (* This lines prevent overflow from computation *)
   let sz = Z.numbits (Q.num c) + Z.numbits (Q.den c) in
   if sz <> 0 && Pervasives.abs n > 100_000 / sz then raise Exit;
   let res = Q.power c n in
-  if Ty.Tint == ty && not (Q.is_int res) then raise Exit;
+  if ty == Ty.Tint then assert (Q.is_int c);
   res
 
 let calc_power_opt (c : Q.t) (d : Q.t) (ty : Ty.t) =

--- a/sources/lib/reasoners/arith.ml
+++ b/sources/lib/reasoners/arith.ml
@@ -44,7 +44,7 @@ let calc_power (c : Q.t) (d : Q.t) (ty : Ty.t) =
   (* d must be integral and if we work on integer exponentation,
      d must be positive*)
   if not (Q.is_int d) then raise Exit;
-  if Ty.Tint == ty && (Q.compare d Q.zero) < 0 then raise Exit;
+  if Ty.Tint == ty && Q.sign d < 0 then raise Exit;
   let n = match Z.to_machine_int (Q.to_z d) with
     | Some n -> n
     | None -> raise Exit
@@ -53,7 +53,7 @@ let calc_power (c : Q.t) (d : Q.t) (ty : Ty.t) =
   let sz = Z.numbits (Q.num c) + Z.numbits (Q.den c) in
   if sz <> 0 && Pervasives.abs n > 100_000 / sz then raise Exit;
   let res = Q.power c n in
-  if ty == Ty.Tint then assert (Q.is_int c);
+  assert (ty != Ty.Tint || Q.is_int c);
   res
 
 let calc_power_opt (c : Q.t) (d : Q.t) (ty : Ty.t) =

--- a/sources/lib/reasoners/arith.ml
+++ b/sources/lib/reasoners/arith.ml
@@ -119,7 +119,7 @@ module Shostak
          | Sqrt_real_default | Sqrt_real_excess
          | Real_of_int | Int_floor | Int_ceil
          | Max_int | Max_real | Min_int | Min_real
-         | PowInt | PowReal | Integer_log2
+         | Pow | Integer_log2
          | Integer_round) -> true
     | _ -> false
 
@@ -347,7 +347,7 @@ module Shostak
       in
       mk_partial_interpretation_1 aux_func coef p ty t x, ctx
 
-    | Sy.Op Sy.PowInt, [x; y] | Sy.Op Sy.PowReal, [x; y] ->
+    | Sy.Op Sy.Pow, [x; y] ->
       mk_partial_interpretation_2
         (fun x y -> calc_power x y ty) coef p ty t x y, ctx
 

--- a/sources/lib/reasoners/arith.ml
+++ b/sources/lib/reasoners/arith.ml
@@ -115,7 +115,7 @@ module Shostak
          | Sqrt_real_default | Sqrt_real_excess
          | Real_of_int | Int_floor | Int_ceil
          | Max_int | Max_real | Min_int | Min_real
-         | Pow | Integer_log2
+         | PowInt | PowReal | Integer_log2
          | Integer_round) -> true
     | _ -> false
 
@@ -343,7 +343,7 @@ module Shostak
       in
       mk_partial_interpretation_1 aux_func coef p ty t x, ctx
 
-    | Sy.Op Sy.Pow, [x; y] ->
+    | Sy.Op Sy.PowInt, [x; y] | Sy.Op Sy.PowReal, [x; y] ->
       mk_partial_interpretation_2
         (fun x y -> calc_power x y ty) coef p ty t x y, ctx
 

--- a/sources/lib/reasoners/arith.ml
+++ b/sources/lib/reasoners/arith.ml
@@ -40,6 +40,21 @@ module Q = Numbers.Q
 let is_mult h = Sy.equal (Sy.Op Sy.Mult) h
 let mod_symb = Sy.name "@mod"
 
+let calc_power (c : Q.t) (d : Q.t) (ty : Ty.t) =
+  if not (Q.is_int d) then raise Exit;
+  let n = match Z.to_machine_int (Q.to_z d) with
+    | Some n -> n
+    | None -> raise Exit
+  in
+  let sz = Z.numbits (Q.num c) + Z.numbits (Q.den c) in
+  if sz <> 0 && Pervasives.abs n > 100_000 / sz then raise Exit;
+  let res = Q.power c n in
+  if Ty.Tint == ty && not (Q.is_int res) then raise Exit;
+  res
+
+let calc_power_opt (c : Q.t) (d : Q.t) (ty : Ty.t) =
+  try Some (calc_power c d ty)
+  with Exit -> None
 
 module Type (X:Sig.X) : Polynome.T with type r = X.r = struct
   include
@@ -100,7 +115,7 @@ module Shostak
          | Sqrt_real_default | Sqrt_real_excess
          | Real_of_int | Int_floor | Int_ceil
          | Max_int | Max_real | Min_int | Min_real
-         | Pow_real_int | Pow_real_real | Integer_log2
+         | Pow | Integer_log2
          | Integer_round) -> true
     | _ -> false
 
@@ -328,31 +343,9 @@ module Shostak
       in
       mk_partial_interpretation_1 aux_func coef p ty t x, ctx
 
-    | Sy.Op Sy.Pow_real_int, [x; y] ->
-      let aux_func (c : Q.t) (d : Q.t) =
-        assert (Q.is_int d);
-        let n = match Z.to_machine_int (Q.to_z d) with
-          | Some n -> n
-          | None -> raise Exit
-        in
-        let sz = Z.numbits (Q.num c) + Z.numbits (Q.den c) in
-        if sz <> 0 && abs n > 100_000 / sz then raise Exit;
-        Q.power c n
-      in
-      mk_partial_interpretation_2 aux_func coef p ty t x y, ctx
-
-    | Sy.Op Sy.Pow_real_real, [x; y] ->
-      let aux_func (c : Q.t) (d : Q.t) =
-        if not (Q.is_int d) then raise Exit;
-        let n = match Z.to_machine_int (Q.to_z d) with
-          | Some n -> n
-          | None -> raise Exit
-        in
-        let sz = Z.numbits (Q.num c) + Z.numbits (Q.den c) in
-        if sz <> 0 && abs n > 100_000 / sz then raise Exit;
-        Q.power c n
-      in
-      mk_partial_interpretation_2 aux_func coef p ty t x y, ctx
+    | Sy.Op Sy.Pow, [x; y] ->
+      mk_partial_interpretation_2
+        (fun x y -> calc_power x y ty) coef p ty t x y, ctx
 
     | Sy.Op Sy.Fixed, _ ->
       (* Fixed-Point arithmetic currently not implemented *)

--- a/sources/lib/reasoners/arith.mli
+++ b/sources/lib/reasoners/arith.mli
@@ -26,12 +26,12 @@
 (*                                                                            *)
 (******************************************************************************)
 
-(** Compute x^y. Raise Exit if y is not an Int (castable in Int).
-    Raise Exit if the return type is Int but the result of x^y is not.*)
+(** [calc_power x y t] Compute x^y. Raise Exit if y is not an Int
+    (castable in Int). *)
 val calc_power : Numbers.Q.t -> Numbers.Q.t -> Ty.t -> Numbers.Q.t
 
 (** Same as calc_power but return an option.
-    Return None if the exception Exit is raised *)
+    Return None if the exception Exit is raised by calc_power *)
 val calc_power_opt : Numbers.Q.t -> Numbers.Q.t -> Ty.t -> Numbers.Q.t option
 
 module Type (X : Sig.X ): Polynome.T with type r = X.r

--- a/sources/lib/reasoners/arith.mli
+++ b/sources/lib/reasoners/arith.mli
@@ -26,6 +26,14 @@
 (*                                                                            *)
 (******************************************************************************)
 
+(** Compute x^y. Raise Exit if y is not an Int (castable in Int).
+    Raise Exit if the return type is Int but the result of x^y is not.*)
+val calc_power : Numbers.Q.t -> Numbers.Q.t -> Ty.t -> Numbers.Q.t
+
+(** Same as calc_power but return an option.
+    Return None if the exception Exit is raised *)
+val calc_power_opt : Numbers.Q.t -> Numbers.Q.t -> Ty.t -> Numbers.Q.t option
+
 module Type (X : Sig.X ): Polynome.T with type r = X.r
 
 module Shostak

--- a/sources/lib/reasoners/arrays_rel.ml
+++ b/sources/lib/reasoners/arrays_rel.ml
@@ -433,7 +433,7 @@ let assume env uf la =
   else assume env uf la
 
 let query _ _ _ = None
-let add env _ _ _ = env
+let add env _ _ _ = env, []
 let print_model _ _ _ = ()
 
 let new_terms env = env.new_terms

--- a/sources/lib/reasoners/bitv_rel.ml
+++ b/sources/lib/reasoners/bitv_rel.ml
@@ -33,7 +33,7 @@ let assume _ _ _ =
   (), { Sig_rel.assume = []; remove = []}
 let query _ _ _ = None
 let case_split _ _ ~for_model:_ = []
-let add env _ _ _ = env
+let add env _ _ _ = env, []
 let print_model _ _ _ = ()
 let new_terms _ = Expr.Set.empty
 let instantiate ~do_syntactic_matching:_ _ env _ _ = env, []

--- a/sources/lib/reasoners/ccx.ml
+++ b/sources/lib/reasoners/ccx.ml
@@ -160,16 +160,28 @@ module Main : S = struct
         fprintf fmt "[cc] congruence closure : %a = %a@."
           X.print r1 X.print r2
 
-    let make_cst orig  t ctx =
+    let make_cst t ctx =
       if debug_cc () then
         if ctx != [] then
           begin
-            fprintf fmt "[cc] constraints of %s(%a)@." orig Expr.print t;
+            fprintf fmt "[cc] constraints of make(%a)@." Expr.print t;
             let c = ref 0 in
             List.iter
               (fun a ->
                  incr c;
                  fprintf fmt " %d) %a@." !c E.print a) ctx
+          end
+
+    let rel_add_cst t ctx =
+      if debug_cc () then
+        if ctx != [] then
+          begin
+            fprintf fmt "[cc] constraints of Rel.add(%a)@." Expr.print t;
+            let c = ref 0 in
+            List.iter
+              (fun (a, _ex) ->
+                 incr c;
+                 fprintf fmt " %d) %a@." !c (A.print_view X.print) a) ctx
           end
 
     let add_to_use t =
@@ -458,7 +470,7 @@ module Main : S = struct
       let env = List.fold_left (fun env t -> add_term env facts t ex) env xs in
       (* we update uf and use *)
       let nuf, ctx  = Uf.add env.uf t in
-      Debug.make_cst "make" t ctx;
+      Debug.make_cst t ctx;
       List.iter (fun a -> add_fact facts (LTerm a, ex, Th_util.Other)) ctx;
       (*or Ex.empty ?*)
 
@@ -467,8 +479,8 @@ module Main : S = struct
       let nuse = Use.up_add env.use t rt lvs in
 
       (* If finitetest is used we add the term to the relation *)
-      let rel,eqs = Rel.add env.relation nuf rt t in
-      Debug.make_cst "relation" t ctx;
+      let rel, eqs = Rel.add env.relation nuf rt t in
+      Debug.rel_add_cst t eqs;
       (* We add terms made from relations as fact *)
       List.iter (fun (a,ex) -> add_fact facts (LSem a, ex, Th_util.Other)) eqs;
       Use.print nuse;

--- a/sources/lib/reasoners/ccx.ml
+++ b/sources/lib/reasoners/ccx.ml
@@ -160,11 +160,11 @@ module Main : S = struct
         fprintf fmt "[cc] congruence closure : %a = %a@."
           X.print r1 X.print r2
 
-    let make_cst t ctx =
+    let make_cst orig  t ctx =
       if debug_cc () then
         if ctx != [] then
           begin
-            fprintf fmt "[cc] constraints of make(%a)@." Expr.print t;
+            fprintf fmt "[cc] constraints of %s(%a)@." orig Expr.print t;
             let c = ref 0 in
             List.iter
               (fun a ->
@@ -458,7 +458,7 @@ module Main : S = struct
       let env = List.fold_left (fun env t -> add_term env facts t ex) env xs in
       (* we update uf and use *)
       let nuf, ctx  = Uf.add env.uf t in
-      Debug.make_cst t ctx;
+      Debug.make_cst "make" t ctx;
       List.iter (fun a -> add_fact facts (LTerm a, ex, Th_util.Other)) ctx;
       (*or Ex.empty ?*)
 
@@ -467,7 +467,10 @@ module Main : S = struct
       let nuse = Use.up_add env.use t rt lvs in
 
       (* If finitetest is used we add the term to the relation *)
-      let rel = Rel.add env.relation nuf rt t in
+      let rel,eqs = Rel.add env.relation nuf rt t in
+      Debug.make_cst "relation" t ctx;
+      (* We add terms made from relations as fact *)
+      List.iter (fun (a,ex) -> add_fact facts (LTerm a, ex, Th_util.Other)) eqs;
       Use.print nuse;
 
       (* we compute terms to consider for congruence *)

--- a/sources/lib/reasoners/ccx.ml
+++ b/sources/lib/reasoners/ccx.ml
@@ -470,7 +470,7 @@ module Main : S = struct
       let rel,eqs = Rel.add env.relation nuf rt t in
       Debug.make_cst "relation" t ctx;
       (* We add terms made from relations as fact *)
-      List.iter (fun (a,ex) -> add_fact facts (LTerm a, ex, Th_util.Other)) eqs;
+      List.iter (fun (a,ex) -> add_fact facts (LSem a, ex, Th_util.Other)) eqs;
       Use.print nuse;
 
       (* we compute terms to consider for congruence *)

--- a/sources/lib/reasoners/enum_rel.ml
+++ b/sources/lib/reasoners/enum_rel.ml
@@ -226,7 +226,7 @@ let assume env uf la =
   in
   env, { Sig_rel.assume = eqs; remove = [] }
 
-let add env _ r _ = add_aux env r
+let add env _ r _ = add_aux env r, []
 
 let case_split env _ ~for_model =
   let acc = MX.fold

--- a/sources/lib/reasoners/intervalCalculus.ml
+++ b/sources/lib/reasoners/intervalCalculus.ml
@@ -1447,7 +1447,8 @@ let update_used_by env r1 _r2 _p1 p2 orig _expl eqs =
     let s = MX0.find r1 env.used_by in
     SE.fold (fun t (env,eqs) ->
         match E.term_view t with
-        | E.Term { E.f = (Sy.Op Sy.Pow); xs = [a; b]; ty; _ } ->
+        | E.Term
+            { E.f = (Sy.Op (Sy.PowReal | Sy.PowInt)); xs = [a; b]; ty; _ } ->
           begin
             match calc_pow a b ty env.new_uf with
               None -> env, eqs
@@ -1699,10 +1700,10 @@ let default_case_split env uf ~for_model =
 let add_used_by x env =
   match X.term_extract x with
   | Some t, _ ->
+      { E.f = (Sy.Op (Sy.PowInt | Sy.PowReal)); xs = [a; b]; ty; _ } ->
     begin
       match E.term_view t with
       | E.Not_a_term _ -> assert false
-      | E.Term { E.f = (Sy.Op Sy.Pow); xs = [a; b]; ty; _ } ->
         begin
           match calc_pow a b ty env.new_uf with
           | Some (cst,ex) ->

--- a/sources/lib/reasoners/intervalCalculus.ml
+++ b/sources/lib/reasoners/intervalCalculus.ml
@@ -1462,21 +1462,21 @@ let update_used_by_pow env r1 p2 orig  eqs =
     if orig != Th_util.Subst then raise Exit;
     if P.is_const p2 == None then raise Exit;
     let s = (MX0.find r1 env.used_by).pow in
-    SE.fold (fun t (env,eqs) ->
+    SE.fold (fun t eqs ->
         match E.term_view t with
         | E.Term
             { E.f = (Sy.Op Sy.Pow); xs = [a; b]; ty; _ } ->
           begin
             match calc_pow a b ty env.new_uf with
-              None -> env, eqs
+              None -> eqs
             | Some (y,ex) ->
               let x = X.term_embed t in
               let eq = L.Eq (x,y) in
-              env, (eq, None, ex, Th_util.Other) :: eqs
+              (eq, None, ex, Th_util.Other) :: eqs
           end
         | _ -> assert false
-      ) s (env,eqs)
-  with Exit | Not_found -> env, eqs
+      ) s eqs
+  with Exit | Not_found -> eqs
 
 let assume ~query env uf la =
   Oracle.incr_age ();
@@ -1555,7 +1555,7 @@ let assume ~query env uf la =
              in
              let env, eqs = add_equality are_eq env eqs p expl in
              let env = tighten_eq_bounds env r1 r2 p1 p2 orig expl in
-             let env, eqs = update_used_by_pow env r1 p2 orig eqs in
+             let eqs = update_used_by_pow env r1 p2 orig eqs in
              env, eqs, new_ineqs, rm
 
            | _ -> acc

--- a/sources/lib/reasoners/intervalCalculus.ml
+++ b/sources/lib/reasoners/intervalCalculus.ml
@@ -1721,8 +1721,11 @@ let add_used_by t r env =
     begin
       match calc_pow a b ty env.new_uf with
       | Some (res,ex) ->
-        let eq = L.Eq(res, r) in
-        env, [eq,ex]
+        if X.equal res r then
+          (* in this case, Arith.make already reduced "t" to a constant "r" *)
+          env, []
+        else
+          env, [L.Eq(res, r), ex]
       | None ->
         let ra = Uf.make env.new_uf a in
         let rb = Uf.make env.new_uf b in

--- a/sources/lib/reasoners/ite_rel.ml
+++ b/sources/lib/reasoners/ite_rel.ml
@@ -65,7 +65,7 @@ let add_to_guarded p s t mp =
   let st = try ME.find p mp with Not_found -> SE2.empty in
   ME.add p (SE2.add (s, t) st) mp
 
-let add env _ _ t =
+let add_aux env t =
   if Options.disable_ites () then env
   else
     match is_ite t with
@@ -85,6 +85,9 @@ let add env _ _ t =
         let guarded_pos_deds = add_to_guarded p t t1 env.guarded_pos_deds in
         let guarded_neg_deds = add_to_guarded p t t2 env.guarded_neg_deds in
         {env with guarded_pos_deds; guarded_neg_deds}
+
+let add env _ _ t =
+  add_aux env t, []
 
 
 let extract_preds env la =

--- a/sources/lib/reasoners/records_rel.ml
+++ b/sources/lib/reasoners/records_rel.ml
@@ -33,7 +33,7 @@ let assume _ _ _ =
   (), { Sig_rel.assume = []; remove = []}
 let query _ _ _ = None
 let case_split _ _ ~for_model:_ = []
-let add env _ _ _ = env
+let add env _ _ _ = env, []
 let print_model _ _ _ = ()
 let new_terms _ = Expr.Set.empty
 let instantiate ~do_syntactic_matching:_ _ env _ _ = env, []

--- a/sources/lib/reasoners/relation.ml
+++ b/sources/lib/reasoners/relation.ml
@@ -145,14 +145,14 @@ let case_split env uf ~for_model =
 
 let add env uf r t =
   Options.exec_thread_yield ();
-  {r1=Rel1.add env.r1 uf r t;
-   r2=Rel2.add env.r2 uf r t;
-   r3=Rel3.add env.r3 uf r t;
-   r4=Rel4.add env.r4 uf r t;
-   r5=Rel5.add env.r5 uf r t;
-   r6=Rel6.add env.r6 uf r t;
-   r7=Rel7.add env.r7 uf r t;
-  }
+  let r1, eqs1 =Rel1.add env.r1 uf r t in
+  let r2, eqs2 =Rel2.add env.r2 uf r t in
+  let r3, eqs3 =Rel3.add env.r3 uf r t in
+  let r4, eqs4 =Rel4.add env.r4 uf r t in
+  let r5, eqs5 =Rel5.add env.r5 uf r t in
+  let r6, eqs6 =Rel6.add env.r6 uf r t in
+  let r7, eqs7 =Rel7.add env.r7 uf r t in
+  {r1;r2;r3;r4;r5;r6;r7;},eqs1|@|eqs2|@|eqs3|@|eqs4|@|eqs5|@|eqs6|@|eqs7
 
 
 let instantiate ~do_syntactic_matching t_match env uf selector =

--- a/sources/lib/reasoners/sig_rel.mli
+++ b/sources/lib/reasoners/sig_rel.mli
@@ -62,7 +62,8 @@ module type RELATION = sig
     (Shostak.Combine.r Xliteral.view * bool * Th_util.lit_origin) list
   (** case_split env returns a list of equalities *)
 
-  val add : t -> Uf.t -> Shostak.Combine.r -> Expr.t -> t
+  val add : t -> Uf.t -> Shostak.Combine.r -> Expr.t ->
+    t * (Expr.t * Explanation.t) list
   (** add a representant to take into account *)
 
   val instantiate :

--- a/sources/lib/reasoners/sig_rel.mli
+++ b/sources/lib/reasoners/sig_rel.mli
@@ -63,7 +63,7 @@ module type RELATION = sig
   (** case_split env returns a list of equalities *)
 
   val add : t -> Uf.t -> Shostak.Combine.r -> Expr.t ->
-    t * (Expr.t * Explanation.t) list
+    t * (Shostak.Combine.r Xliteral.view * Explanation.t) list
   (** add a representant to take into account *)
 
   val instantiate :

--- a/sources/lib/structures/expr.ml
+++ b/sources/lib/structures/expr.ml
@@ -493,10 +493,9 @@ let rec print_silent fmt t =
     end
 
   (* TODO: introduce PrefixOp in the future to simplify this ? *)
-  | Sy.Op op, [e1; e2] when op == Sy.PowInt || op == Sy.PowReal ||
+  | Sy.Op op, [e1; e2] when op == Sy.Pow || op == Sy.Integer_round ||
                             op == Sy.Max_real || op == Sy.Max_int ||
-                            op == Sy.Min_real || op == Sy.Min_int ||
-                            op == Sy.Integer_round ->
+                            op == Sy.Min_real || op == Sy.Min_int ->
     fprintf fmt "%a(%a,%a)" Sy.print f print e1 print e2
 
   (* TODO: introduce PrefixOp in the future to simplify this ? *)

--- a/sources/lib/structures/expr.ml
+++ b/sources/lib/structures/expr.ml
@@ -493,9 +493,9 @@ let rec print_silent fmt t =
     end
 
   (* TODO: introduce PrefixOp in the future to simplify this ? *)
-  | Sy.Op op, [e1; e2] when op == Sy.Pow || op == Sy.Max_real ||
-                            op == Sy.Max_int || op == Sy.Min_real ||
-                            op == Sy.Min_int ||
+  | Sy.Op op, [e1; e2] when op == Sy.PowInt || op == Sy.PowReal ||
+                            op == Sy.Max_real || op == Sy.Max_int ||
+                            op == Sy.Min_real || op == Sy.Min_int ||
                             op == Sy.Integer_round ->
     fprintf fmt "%a(%a,%a)" Sy.print f print e1 print e2
 

--- a/sources/lib/structures/expr.ml
+++ b/sources/lib/structures/expr.ml
@@ -493,10 +493,9 @@ let rec print_silent fmt t =
     end
 
   (* TODO: introduce PrefixOp in the future to simplify this ? *)
-  | Sy.Op op, [e1; e2] when op == Sy.Pow_real_int || op == Sy.Max_real ||
+  | Sy.Op op, [e1; e2] when op == Sy.Pow || op == Sy.Max_real ||
                             op == Sy.Max_int || op == Sy.Min_real ||
                             op == Sy.Min_int ||
-                            op == Sy.Pow_real_real ||
                             op == Sy.Integer_round ->
     fprintf fmt "%a(%a,%a)" Sy.print f print e1 print e2
 

--- a/sources/lib/structures/parsed.ml
+++ b/sources/lib/structures/parsed.ml
@@ -40,7 +40,8 @@ type constant =
 type pp_infix =
   | PPand | PPor | PPxor | PPimplies | PPiff
   | PPlt | PPle | PPgt | PPge | PPeq | PPneq
-  | PPadd | PPsub | PPmul | PPdiv | PPmod | PPpow
+  | PPadd | PPsub | PPmul | PPdiv | PPmod
+  | PPpow_int | PPpow_real
 
 type pp_prefix =
   | PPneg | PPnot

--- a/sources/lib/structures/parsed.ml
+++ b/sources/lib/structures/parsed.ml
@@ -40,7 +40,7 @@ type constant =
 type pp_infix =
   | PPand | PPor | PPxor | PPimplies | PPiff
   | PPlt | PPle | PPgt | PPge | PPeq | PPneq
-  | PPadd | PPsub | PPmul | PPdiv | PPmod
+  | PPadd | PPsub | PPmul | PPdiv | PPmod | PPpow
 
 type pp_prefix =
   | PPneg | PPnot

--- a/sources/lib/structures/parsed.mli
+++ b/sources/lib/structures/parsed.mli
@@ -37,7 +37,7 @@ type constant =
 type pp_infix =
   | PPand | PPor | PPxor | PPimplies | PPiff
   | PPlt | PPle | PPgt | PPge | PPeq | PPneq
-  | PPadd | PPsub | PPmul | PPdiv | PPmod
+  | PPadd | PPsub | PPmul | PPdiv | PPmod | PPpow
 
 type pp_prefix =
   | PPneg | PPnot

--- a/sources/lib/structures/parsed.mli
+++ b/sources/lib/structures/parsed.mli
@@ -37,7 +37,8 @@ type constant =
 type pp_infix =
   | PPand | PPor | PPxor | PPimplies | PPiff
   | PPlt | PPle | PPgt | PPge | PPeq | PPneq
-  | PPadd | PPsub | PPmul | PPdiv | PPmod | PPpow
+  | PPadd | PPsub | PPmul | PPdiv | PPmod
+  | PPpow_int | PPpow_real
 
 type pp_prefix =
   | PPneg | PPnot

--- a/sources/lib/structures/symbols.ml
+++ b/sources/lib/structures/symbols.ml
@@ -39,7 +39,8 @@ type operator =
   | Reach | Access of Hstring.t | Record
   | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
   | Sqrt_real_default | Sqrt_real_excess
-  | Min_real | Min_int | Max_real | Max_int | Integer_log2 | Pow
+  | Min_real | Min_int | Max_real | Max_int | Integer_log2
+  | PowInt | PowReal
   | Integer_round
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Hstring.t * bool
@@ -131,7 +132,7 @@ let compare_operators op1 op2 =
             | Access _ | Record | Sqrt_real | Abs_int | Abs_real
             | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
-            | Integer_log2 | Pow | Integer_round
+            | Integer_log2 | PowInt | PowReal | Integer_round
             | Constr _ | Destruct _ | Tite) -> assert false
     )
 
@@ -291,7 +292,8 @@ let to_string ?(show_vars=true) x = match x with
   | Op Min_real -> "min_real"
   | Op Min_int -> "min_int"
   | Op Integer_log2 -> "integer_log2"
-  | Op Pow -> "pow"
+  | Op PowInt -> "**"
+  | Op PowReal -> "**."
   | Op Integer_round -> "integer_round"
   | Op Concat -> "@"
   | Op Extract -> "^"

--- a/sources/lib/structures/symbols.ml
+++ b/sources/lib/structures/symbols.ml
@@ -39,8 +39,8 @@ type operator =
   | Reach | Access of Hstring.t | Record
   | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
   | Sqrt_real_default | Sqrt_real_excess
-  | Min_real | Min_int | Max_real | Max_int | Integer_log2 | Pow_real_int
-  | Pow_real_real | Integer_round
+  | Min_real | Min_int | Max_real | Max_int | Integer_log2 | Pow
+  | Integer_round
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Hstring.t * bool
   | Tite
@@ -131,7 +131,7 @@ let compare_operators op1 op2 =
             | Access _ | Record | Sqrt_real | Abs_int | Abs_real
             | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
-            | Integer_log2 | Pow_real_int | Pow_real_real | Integer_round
+            | Integer_log2 | Pow | Integer_round
             | Constr _ | Destruct _ | Tite) -> assert false
     )
 
@@ -291,8 +291,7 @@ let to_string ?(show_vars=true) x = match x with
   | Op Min_real -> "min_real"
   | Op Min_int -> "min_int"
   | Op Integer_log2 -> "integer_log2"
-  | Op Pow_real_int -> "pow_real_int"
-  | Op Pow_real_real -> "pow_real_real"
+  | Op Pow -> "pow"
   | Op Integer_round -> "integer_round"
   | Op Concat -> "@"
   | Op Extract -> "^"

--- a/sources/lib/structures/symbols.ml
+++ b/sources/lib/structures/symbols.ml
@@ -40,8 +40,7 @@ type operator =
   | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
   | Sqrt_real_default | Sqrt_real_excess
   | Min_real | Min_int | Max_real | Max_int | Integer_log2
-  | PowInt | PowReal
-  | Integer_round
+  | Pow | Integer_round
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Hstring.t * bool
   | Tite
@@ -132,7 +131,7 @@ let compare_operators op1 op2 =
             | Access _ | Record | Sqrt_real | Abs_int | Abs_real
             | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
-            | Integer_log2 | PowInt | PowReal | Integer_round
+            | Integer_log2 | Pow | Integer_round
             | Constr _ | Destruct _ | Tite) -> assert false
     )
 
@@ -292,8 +291,7 @@ let to_string ?(show_vars=true) x = match x with
   | Op Min_real -> "min_real"
   | Op Min_int -> "min_int"
   | Op Integer_log2 -> "integer_log2"
-  | Op PowInt -> "**"
-  | Op PowReal -> "**."
+  | Op Pow -> "**"
   | Op Integer_round -> "integer_round"
   | Op Concat -> "@"
   | Op Extract -> "^"

--- a/sources/lib/structures/symbols.mli
+++ b/sources/lib/structures/symbols.mli
@@ -36,7 +36,8 @@ type operator =
   | Reach | Access of Hstring.t | Record
   | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
   | Sqrt_real_default | Sqrt_real_excess
-  | Min_real | Min_int | Max_real | Max_int | Integer_log2 | Pow
+  | Min_real | Min_int | Max_real | Max_int | Integer_log2
+  | PowInt | PowReal
   | Integer_round
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Hstring.t * bool

--- a/sources/lib/structures/symbols.mli
+++ b/sources/lib/structures/symbols.mli
@@ -37,8 +37,7 @@ type operator =
   | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
   | Sqrt_real_default | Sqrt_real_excess
   | Min_real | Min_int | Max_real | Max_int | Integer_log2
-  | PowInt | PowReal
-  | Integer_round
+  | Pow | Integer_round
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Hstring.t * bool
   | Tite

--- a/sources/lib/structures/symbols.mli
+++ b/sources/lib/structures/symbols.mli
@@ -36,8 +36,8 @@ type operator =
   | Reach | Access of Hstring.t | Record
   | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
   | Sqrt_real_default | Sqrt_real_excess
-  | Min_real | Min_int | Max_real | Max_int | Integer_log2 | Pow_real_int
-  | Pow_real_real | Integer_round
+  | Min_real | Min_int | Max_real | Max_int | Integer_log2 | Pow
+  | Integer_round
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Hstring.t * bool
   | Tite

--- a/sources/lib/structures/xliteral.ml
+++ b/sources/lib/structures/xliteral.ml
@@ -93,6 +93,45 @@ module type S = sig
 
 end
 
+let print_view ?(lbl="") pr_elt fmt vw =
+  match vw with
+  | Eq (z1, z2) ->
+    Format.fprintf fmt "%s %a = %a" lbl pr_elt z1 pr_elt z2
+
+  | Distinct (b,(z::l)) ->
+    let b = if b then "~ " else "" in
+    Format.fprintf fmt "%s %s%a" lbl b pr_elt z;
+    List.iter (fun x -> Format.fprintf fmt " <> %a" pr_elt x) l
+
+  | Builtin (true, LE, [v1;v2]) ->
+    Format.fprintf fmt "%s %a <= %a" lbl pr_elt v1 pr_elt v2
+
+  | Builtin (true, LT, [v1;v2]) ->
+    Format.fprintf fmt "%s %a < %a" lbl pr_elt v1 pr_elt v2
+
+  | Builtin (false, LE, [v1;v2]) ->
+    Format.fprintf fmt "%s %a > %a" lbl pr_elt v1 pr_elt v2
+
+  | Builtin (false, LT, [v1;v2]) ->
+    Format.fprintf fmt "%s %a >= %a" lbl pr_elt v1 pr_elt v2
+
+  | Builtin (_, (LE | LT), _) ->
+    assert false (* not reachable *)
+
+  | Builtin (pos, IsConstr hs, [e]) ->
+    Format.fprintf fmt "%s(%a ? %a)"
+      (if pos then "" else "not ") pr_elt e Hstring.print hs
+
+  | Builtin (_, IsConstr _, _) ->
+    assert false (* not reachable *)
+
+  | Pred (p,b) ->
+    Format.fprintf fmt "%s %a = %s" lbl pr_elt p
+      (if b then "false" else "true")
+
+  | Distinct (_, _) -> assert false
+
+
 module Make (X : OrderedType) : S with type elt = X.t = struct
 
   type elt = X.t
@@ -141,42 +180,7 @@ module Make (X : OrderedType) : S with type elt = X.t = struct
   let print fmt a =
     let lbl = Hstring.view (label a) in
     let lbl = if String.length lbl = 0 then lbl else lbl^":" in
-    match view a with
-    | Eq (z1, z2) ->
-      Format.fprintf fmt "%s %a = %a" lbl X.print z1 X.print z2
-
-    | Distinct (b,(z::l)) ->
-      let b = if b then "~ " else "" in
-      Format.fprintf fmt "%s %s%a" lbl b X.print z;
-      List.iter (fun x -> Format.fprintf fmt " <> %a" X.print x) l
-
-    | Builtin (true, LE, [v1;v2]) ->
-      Format.fprintf fmt "%s %a <= %a" lbl X.print v1 X.print v2
-
-    | Builtin (true, LT, [v1;v2]) ->
-      Format.fprintf fmt "%s %a < %a" lbl X.print v1 X.print v2
-
-    | Builtin (false, LE, [v1;v2]) ->
-      Format.fprintf fmt "%s %a > %a" lbl X.print v1 X.print v2
-
-    | Builtin (false, LT, [v1;v2]) ->
-      Format.fprintf fmt "%s %a >= %a" lbl X.print v1 X.print v2
-
-    | Builtin (_, (LE | LT), _) ->
-      assert false (* not reachable *)
-
-    | Builtin (pos, IsConstr hs, [e]) ->
-      Format.fprintf fmt "%s(%a ? %a)"
-        (if pos then "" else "not ") X.print e Hstring.print hs
-
-    | Builtin (_, IsConstr _, _) ->
-      assert false (* not reachable *)
-
-    | Pred (p,b) ->
-      Format.fprintf fmt "%s %a = %s" lbl X.print p
-        (if b then "false" else "true")
-
-    | Distinct (_, _) -> assert false
+    print_view ~lbl X.print fmt (view a)
 
   let equal_builtins n1 n2 =
     match n1, n2 with

--- a/sources/lib/structures/xliteral.mli
+++ b/sources/lib/structures/xliteral.mli
@@ -90,4 +90,11 @@ module type S = sig
   module Set : Set.S with type elt = t
 end
 
+val print_view :
+  ?lbl:string ->
+  (Format.formatter -> 'a -> unit) ->
+  Format.formatter ->
+  'a view ->
+  unit
+
 module Make ( X : OrderedType ) : S with type elt = X.t

--- a/sources/parsers/why_lexer.mll
+++ b/sources/parsers/why_lexer.mll
@@ -197,6 +197,7 @@ rule parse_token = parse
   | "+"   { PLUS }
   | "-"   { MINUS }
   | "*"   { TIMES }
+  | "**." { POWDOT }
   | "**"  { POW }
   | "/"   { SLASH }
   | "%"   { PERCENT }

--- a/sources/parsers/why_lexer.mll
+++ b/sources/parsers/why_lexer.mll
@@ -197,6 +197,7 @@ rule parse_token = parse
   | "+"   { PLUS }
   | "-"   { MINUS }
   | "*"   { TIMES }
+  | "**"  { POW }
   | "/"   { SLASH }
   | "%"   { PERCENT }
   | "@"   { AT }

--- a/sources/parsers/why_parser.mly
+++ b/sources/parsers/why_parser.mly
@@ -50,7 +50,7 @@
 %token NOT NOTEQ OR PERCENT PLUS PRED PROP
 %token QUOTE REAL UNIT
 %token RIGHTPAR RIGHTSQ RIGHTBR
-%token SLASH
+%token SLASH POW
 %token THEN TIMES TRUE TYPE
 
 /* Precedences */
@@ -63,7 +63,7 @@
 %nonassoc prec_ite
 %left prec_relation EQUAL NOTEQ LT LE GT GE
 %left PLUS MINUS
-%left TIMES SLASH PERCENT AT
+%left TIMES SLASH PERCENT POW AT
 %nonassoc HAT
 %nonassoc uminus
 %nonassoc NOT
@@ -252,6 +252,9 @@ lexpr:
 
 | se1 = lexpr PERCENT se2 = lexpr
    { mk_mod ($startpos, $endpos) se1 se2 }
+
+| se1 = lexpr POW se2 = lexpr
+   { mk_pow ($startpos, $endpos) se1 se2 }
 
 | se1 = lexpr AND se2 = lexpr
    { mk_and ($startpos, $endpos) se1 se2 }

--- a/sources/parsers/why_parser.mly
+++ b/sources/parsers/why_parser.mly
@@ -50,7 +50,7 @@
 %token NOT NOTEQ OR PERCENT PLUS PRED PROP
 %token QUOTE REAL UNIT
 %token RIGHTPAR RIGHTSQ RIGHTBR
-%token SLASH POW
+%token SLASH POW POWDOT
 %token THEN TIMES TRUE TYPE
 
 /* Precedences */
@@ -63,7 +63,7 @@
 %nonassoc prec_ite
 %left prec_relation EQUAL NOTEQ LT LE GT GE
 %left PLUS MINUS
-%left TIMES SLASH PERCENT POW AT
+%left TIMES SLASH PERCENT POW POWDOT AT
 %nonassoc HAT
 %nonassoc uminus
 %nonassoc NOT
@@ -254,7 +254,10 @@ lexpr:
    { mk_mod ($startpos, $endpos) se1 se2 }
 
 | se1 = lexpr POW se2 = lexpr
-   { mk_pow ($startpos, $endpos) se1 se2 }
+   { mk_pow_int ($startpos, $endpos) se1 se2 }
+
+| se1 = lexpr POWDOT se2 = lexpr
+   { mk_pow_real ($startpos, $endpos) se1 se2 }
 
 | se1 = lexpr AND se2 = lexpr
    { mk_and ($startpos, $endpos) se1 se2 }

--- a/sources/preludes/fpa-theory-2019-10-08-19h00.why
+++ b/sources/preludes/fpa-theory-2019-10-08-19h00.why
@@ -1,0 +1,1137 @@
+(******************************************************************************)
+(*                                                                            *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
+(*     Copyright (C) 2013-2017 --- OCamlPro SAS                               *)
+(*                                                                            *)
+(*     This file is distributed under the terms of the license indicated      *)
+(*     in the file 'License.OCamlPro'. If 'License.OCamlPro' is not           *)
+(*     present, please contact us to clarify licensing.                       *)
+(*                                                                            *)
+(******************************************************************************)
+
+type fpa_rounding_mode =
+  (* five standard/why3 fpa rounding modes *)
+    NearestTiesToEven (*ne in Gappa: to nearest, tie breaking to even mantissas*)
+  | ToZero (* zr in Gappa: toward zero *)
+  | Up (* up in Gappa: toward plus infinity *)
+  | Down (* dn in Gappa: toward minus infinity *)
+  | NearestTiesToAway (* na : to nearest, tie breaking away from zero *)
+
+  (* additional Gappa rounding modes *)
+  | Aw (* aw in Gappa: away from zero **)
+  | Od (* od in Gappa: to odd mantissas *)
+  | No (* no in Gappa: to nearest, tie breaking to odd mantissas *)
+  | Nz (* nz in Gappa: to nearest, tie breaking toward zero *)
+  | Nd (* nd in Gappa: to nearest, tie breaking toward minus infinity *)
+  | Nu (* nu in Gappa: to nearest, tie breaking toward plus infinity *)
+
+
+(* the first argument is mantissas' size (including the implicit bit),
+   the second one is the exp of the min representable normalized number,
+   the third one is the rounding mode, and the last one is the real to
+   be rounded *)
+logic float: int, int, fpa_rounding_mode, real -> real
+
+(* syntactic sugar for simple precision floats:
+   mantissas size = 24, min exp = 149 *)
+logic float32: fpa_rounding_mode, real -> real
+
+(* syntactic sugar for simple precision floats with default rounding mode
+(i.e. NearestTiesToEven)*)
+logic float32d: real -> real
+
+(* syntactic sugar for double precision floats:
+   mantissas size = 53, min exp = 1074 *)
+logic float64: fpa_rounding_mode, real -> real
+
+(* syntactic sugar for double precision floats with default rounding mode
+(i.e. NearestTiesToEven) *)
+logic float64d: real -> real
+
+(* rounds to nearest integer depending on rounding mode *)
+logic integer_round: fpa_rounding_mode, real -> int
+
+(* type cast: from int to real *)
+logic real_of_int : int -> real
+
+(* abs value of a real *)
+logic abs_real : real -> real
+
+(* sqrt value of a real *)
+logic sqrt_real : real -> real
+
+(* sqrt value of a real by default *)
+logic sqrt_real_default : real -> real
+
+(* sqrt value of a real by excess *)
+logic sqrt_real_excess : real -> real
+
+(* abs value of an int *)
+logic abs_int : int -> int
+
+(* (integer) floor of a rational *)
+logic int_floor : real -> int
+
+(* (integer) ceiling of a rational *)
+logic int_ceil : real -> int
+
+(* The functions below are only interpreted when applied on constants.
+  Aximatization for the general case are not currently imlemented *)
+
+(* maximum of two reals *)
+logic max_real : real, real -> real
+
+(* maximum of two ints *)
+logic max_int  : int, int -> int
+
+(* minimum of two reals *)
+logic min_real : real, real -> real
+
+(* minimum of two ints *)
+logic min_int  : int, int -> int
+
+(* computes an integer log2 of a real. The function is only
+interpreted on (non-zero) positive real constants. When applied on a
+real 'm', the result 'res' of the function is such that: 2^res <= m <
+2^(res+1) *)
+
+logic integer_log2 : real -> int
+
+(* only used for arithmetic. It should not be used for x in float(x)
+   to enable computations modulo equality *)
+
+logic not_theory_constant : real -> bool
+
+logic is_theory_constant : 'a -> bool
+
+logic linear_dependency : real, real -> bool
+
+theory Simple_FPA extends FPA =
+
+
+   (* what happends if we add versions for partially bounded float(x) ?
+      whould this be better ? *)
+
+   axiom rounding_operator_1 :
+     forall x : real.
+     forall i, j : real.
+     forall i2, j2 : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        x in [i, j],
+        i2 |-> float(m, p, mode, i),
+        j2 |-> float(m, p, mode, j)
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     i2 <= float(m, p, mode, x) <= j2
+
+
+   axiom integer_rounding_operator_1 :
+     forall x : real.
+     forall i, j : real.
+     forall i2, j2 : int.
+     forall mode : fpa_rounding_mode
+     [
+        integer_round(mode, x),
+        is_theory_constant(mode),
+        x in [i, j],
+        i2 |-> integer_round(mode, i),
+        j2 |-> integer_round(mode, j)
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     i2 <= integer_round(mode, x) <= j2
+
+
+  (* add the version with x in ? -> o(x) - x in ? *)
+  axiom rounding_operator_absolute_error_1_NearestTiesToEven :
+     forall x : real.
+     forall i, j, k : real.
+     forall exp_min, prec : int
+     [
+        float(prec, exp_min, NearestTiesToEven, x),
+        is_theory_constant(prec),
+        is_theory_constant(exp_min),
+        x in [i, j],
+        k |->
+           (
+            2. **
+            (integer_log2(
+              max_real(
+                abs_real(i),
+                max_real(
+                  abs_real(j),
+                  (2. ** - exp_min + prec-1)
+                )
+               )
+             ) - prec (* we can improve by -1 for some rounding modes *)
+           ))
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     - k <=  float(prec, exp_min, NearestTiesToEven, x) - x <= k
+
+
+  axiom rounding_operator_absolute_error_1_ALL :
+     forall x : real.
+     forall i, j, k : real.
+     forall mode : fpa_rounding_mode.
+     forall exp_min, prec : int
+     [
+        float(prec, exp_min, mode, x),
+        is_theory_constant(prec),
+        is_theory_constant(exp_min),
+        is_theory_constant(mode),
+        x in [i, j],
+        k |->
+           (
+            2. **
+            (integer_log2(
+              max_real(
+                abs_real(i),
+                max_real(
+                  abs_real(j),
+                  (2. ** - exp_min + prec-1)
+                )
+               )
+             ) - prec + 1(* we can improve by -1 for some rounding modes *)
+           ))
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     - k <=  float(prec, exp_min, mode, x) - x <= k
+
+   axiom monotonicity_contrapositive_1 :
+      forall x, i, k : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in [?, i[,
+         k |-> float(prec, exp_min, Up, i)
+      ]
+      {
+         float(prec, exp_min, mode, x) < i
+      }.
+      (*float(prec, exp_min, mode, x) < i ->*)
+      x < k
+
+
+   axiom monotonicity_contrapositive_2 :
+      forall x, i, k : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in ]i, ?],
+         k |-> float(prec, exp_min, Down, i)
+      ]
+      {
+         float(prec, exp_min, mode, x) > i
+      }.
+      (*float(prec, exp_min, mode, x) > i ->*)
+      x > k
+
+   (* Remark: should add semantic trigger 'x <= y'
+      or maybe also 'float(m,p,md,x) > float(m,p,md,y)' in future
+      version *)
+   (* same as old monotonicity_contrapositive_3 *)
+   axiom float_is_monotonic:
+     forall m, p : int.
+     forall md : fpa_rounding_mode.
+     forall x, y : real
+     [
+         float(m,p,md,x), float(m,p,md,y),
+         is_theory_constant(m),
+         is_theory_constant(p),
+         is_theory_constant(md)
+     ].
+     x <= y -> float(m,p,md,x) <= float(m,p,md,y)
+
+
+   (* these two axioms are too expensive if put inside a theory *)
+   axiom monotonicity_contrapositive_4 :
+      forall x, y : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),float(prec, exp_min, mode, y),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < float(prec, exp_min, mode, y) ->
+      x < float(prec, exp_min, mode, y)
+
+   axiom monotonicity_contrapositive_5 :
+      forall x, y : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x), float(prec, exp_min, mode, y),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, x) < y
+
+
+   axiom contrapositive_enabeler_1 :
+      forall x, i : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in [?, i]
+      ]
+      { float(prec, exp_min, mode, x) <= i }.
+      float(prec, exp_min, mode, x) = i or float(prec, exp_min, mode, x) < i
+
+   axiom contrapositive_enabeler_2 :
+      forall x, i : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in [i, ?]
+      ]
+      { float(prec, exp_min, mode, x) >= i }.
+      float(prec, exp_min, mode, x) = i or float(prec, exp_min, mode, x) > i
+
+
+   axiom gradual_underflow_1:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) > float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)) > 0.
+
+   axiom gradual_underflow_2:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) > - float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)) > 0.
+
+
+   axiom gradual_underflow_3:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)) < 0.
+
+   axiom gradual_underflow_4:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < - float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)) < 0.
+
+
+   axiom float_of_float_same_formats:
+      forall x : real.
+      forall mode1, mode2 : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode1, float(prec, exp_min, mode2, x)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode1),
+         is_theory_constant(mode2)
+      ].
+      float(prec, exp_min, mode1, float(prec, exp_min, mode2, x)) =
+      float(prec, exp_min, mode2, x)
+
+   axiom float_of_float_different_formats:
+      forall x : real.
+      forall mode1, mode2 : fpa_rounding_mode.
+      forall exp_min1, prec1, exp_min2, prec2 : int
+      [
+         float(prec1, exp_min1, mode1, float(prec2, exp_min2, mode2, x)),
+         is_theory_constant(prec1),
+         is_theory_constant(exp_min1),
+         is_theory_constant(prec2),
+         is_theory_constant(exp_min2),
+         is_theory_constant(mode1),
+         is_theory_constant(mode2)
+      ].
+      prec2 <= prec1 ->
+      exp_min2 <= exp_min1 ->
+      float(prec1, exp_min1, mode1, float(prec2, exp_min2, mode2, x)) =
+      float(prec2, exp_min2, mode2, x)
+
+
+   axiom tighten_float_intervals_1__min_large : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in [i, ?],
+        k |-> float(m, p, Up, i)
+     ]
+     {
+        i <= float(m, p, mode, x)
+     }.
+     (*i < k -> not needed => subsumed *)
+     k <= float(m, p, mode, x)
+
+   axiom tighten_float_intervals__2__min_strict : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in ]i, ?],
+        k |-> float(m, p, Up, i)
+     ]
+     {
+        i < float(m, p, mode, x)
+     }. (* we can improve even if this condition is not true, with epsilon *)
+     (*i < k -> not needed => subsumed*)
+     k <= float(m, p, mode, x)
+
+   axiom tighten_float_intervals_3__max_large : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in [?, i],
+        k |-> float(m, p, Down, i)
+     ]
+     {
+        i >= float(m, p, mode, x)
+     }.
+     (*k < i -> not needed => subsumed*)
+     k >= float(m, p, mode, x)
+
+   axiom tighten_float_intervals__4__max_strict : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in [?, i[,
+        k |-> float(m, p, Down, i)
+     ]
+     {
+        float(m, p, mode, x) < i
+     }. (* we can improve even if this condition is not true, with epsilon *)
+     (*k < i -> not needed => subsumed*)
+     float(m, p, mode, x) <= k
+
+
+   axiom float_of_minus_float:
+     forall x : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, - float(m, p, mode, x)),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode)
+     ].
+     float(m, p, mode, - float(m, p, mode, x)) = - float(m, p, mode, float(m, p, mode, x))
+     (* which can be directly simplified to - float(m, p, mode, x). Another axiom will do this *)
+     (* this axiom probably applies more generally to float(m, p, mode, - x) = - float(m, p, mode, x) *)
+
+
+   axiom float_of_int:
+     forall x : int.
+     forall k : real.
+     forall mode : fpa_rounding_mode.
+     forall exp_min, prec : int
+     [
+        float(prec, exp_min, mode, real_of_int(x)),
+        is_theory_constant(prec),
+        is_theory_constant(exp_min),
+        is_theory_constant(mode),
+        real_of_int(x) + (2. ** prec)  in [0., ?],
+        real_of_int(x) - (2. ** prec) in [?, 0.],
+        k |-> (2. ** prec)
+     ]
+     {
+        -k <= real_of_int(x),
+        real_of_int(x) <= k
+     }.
+     float(prec, exp_min, mode, real_of_int(x)) = real_of_int(x)
+
+
+   axiom float_of_pos_pow_of_two:
+     forall x, y, i, k1, k2 : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x * float(m, p, mode, y)),
+        is_theory_constant(p),
+        is_theory_constant(m),
+        is_theory_constant(mode),
+        is_theory_constant(x),
+        x in [i , i],
+        k1 |-> abs_real(i),
+        k2 |-> (2. ** integer_log2(abs_real(i)))
+     ].
+     k1 >= 1. ->
+     k1 = k2 -> (* is pow of 2 ?*)
+     float(m, p, mode, x * float(m, p, mode, y)) = x * float(m, p, mode, y)
+
+
+   axiom tighten_open_float_bounds :
+     forall x : real.
+     forall i, j, i2, j2 : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in ]i, j[,
+        i2 |-> float(m, p, Up, i + (2. ** (2 * (- p)))),
+        j2 |-> float(m, p, Down, j - (2. **(2 * (- p))))
+        (* (2. ** (2 * (- p))) is smaller than any gap between two successive floats *)
+     ]
+     {
+        float(m, p, mode, x) > i,
+        float(m, p, mode, x) < j
+     }.
+     i = float(m, p, mode, i) ->
+     j = float(m, p, mode, j) ->
+     i2 <= float(m, p, mode, x) <= j2
+
+end
+
+(*** Handling of real_of_int: ***)
+theory Real_of_Int extends FPA =
+
+   axiom roi_add :
+     forall x, y : int [real_of_int(x+y)].
+       real_of_int(x + y) = real_of_int(x) + real_of_int(y)
+
+   axiom roi_sub :
+     forall x, y : int [real_of_int(x-y)].
+       real_of_int(x - y) = real_of_int(x) - real_of_int(y)
+
+   axiom roi_mult :
+     forall x, y : int [real_of_int(x*y)].
+       real_of_int(x * y) = real_of_int(x) * real_of_int(y)
+
+   axiom roi_monotonicity_1 :
+     forall x : int.
+     forall k : real.
+     forall i : int
+     [real_of_int(x), x in ]?, i], k |-> real_of_int(i)]
+     {x <= i}.
+     real_of_int(x) <= k
+
+   axiom roi_monotonicity_2 :
+     forall x : int.
+     forall k : real.
+     forall i : int
+     [real_of_int(x), x in [i, ?[, k |-> real_of_int(i)]
+     {i <= x}.
+     k <= real_of_int(x)
+
+   axiom real_of_int_to_int_1 :
+     forall x, k : int.
+     forall i : real
+     [real_of_int(x), real_of_int(x) in ]?, i], k |-> int_floor(i)]
+     {real_of_int(x) <= i}.
+     x <= k
+
+   axiom real_of_int_to_int_2 :
+     forall x, k : int.
+     forall i : real
+     [real_of_int(x), real_of_int(x) in [i, ?[, k |-> int_ceil(i)]
+     {i <= real_of_int(x)}.
+     k <= x
+
+   (* can add other axioms on strict ineqs on rationals ? *)
+
+end
+
+theory ABS extends FPA =
+
+   axiom abs_real_pos :
+     forall x : real
+     [
+        abs_real(x),
+        x in [0., ?[
+     ]
+     {x >= 0.}.
+     abs_real(x) = x
+
+  axiom abs_real_neg :
+     forall x : real
+     [
+        abs_real(x),
+        x in ]?, 0.]
+     ]
+     {x <= 0.}.
+     abs_real(x) = -x
+
+   case_split abs_real_cs:
+     forall x : real
+     [
+        abs_real(x),
+        x in [?i,?j],
+        0. in ]?i,?j[
+     ].
+     (* not of the form (a or not a) to avoid simplification of F.mk_or *)
+     x <= 0. or x >= 0.
+
+   axiom abs_real_interval_1 :
+     forall x : real
+     [
+        abs_real(x),
+        abs_real(x) in [?i, ?j],
+        0. in ]?i, ?j[
+     ].
+     0. <= abs_real(x)
+
+   axiom abs_real_interval_2 : (* should block this axiom once the deduction is made,
+         but this needs to have i and j on the left-hand-side of semantic triggers *)
+     forall i, j, k : real.
+     forall x : real
+     [
+        abs_real(x),
+        x in [i, j],
+        k |-> max_real (abs_real(i), abs_real(j))
+     ]
+     {i <= x, x <= j}.
+     abs_real(x) <= k
+
+   axiom abs_real_interval_3 : (* should block this axiom once the deduction is made,
+         but this needs to have i and j on the left-hand-side of semantic triggers *)
+     forall i : real.
+     forall x : real
+     [
+        abs_real(x),
+        abs_real(x) in [?, i]
+     ]
+     { abs_real(x) <= i }.
+     - i <= x <= i
+
+   axiom abs_real_from_square_large:
+     forall x, y : real[x*x,y*y]. (* semantic triggers mising *)
+       x*x <= y*y ->
+       abs_real(x) <= abs_real(y)
+
+   axiom abs_real_from_square_strict:
+     forall x, y : real[x*x,y*y]. (* semantic triggers mising *)
+       x*x < y*y ->
+       abs_real(x) < abs_real(y)
+
+
+   axiom abs_real_greater_than_real :
+     forall x : real
+     [
+        abs_real(x)
+     ].
+     x <= abs_real(x)
+
+
+  (* TODO: add semantic triggers not_theory_constant(x) on axioms of abs_int *)
+
+   axiom abs_int_pos :
+     forall x : int[abs_int(x) , x in [0, ?[ ]
+     {x >= 0}.
+     abs_int(x) = x
+
+  axiom abs_int_neg :
+     forall x : int[abs_int(x), x in ]?, 0]]
+     {x <= 0}.
+     abs_int(x) = -x
+
+   case_split abs_int_cs:
+     forall x : int [abs_int(x) , x in [?i,?j], 0 in ]?i,?j[].
+     (* not of the form (a or not a) to avoid simplification of F.mk_or *)
+     x <= 0 or x >= 0
+
+  axiom abs_int_interval_1 :
+     forall x : int [abs_int(x), abs_int(x) in [?i, ?j], 0 in ]?i, ?j[].
+     0 <= abs_int(x)
+
+  axiom abs_int_interval_2 :
+     forall i, j, k : int.
+     forall x : int [abs_int(x), x in [i, j], k |-> max_int (abs_int(i), abs_int(j))]
+     {i <= x , x <= j}.
+     abs_int(x) <= k
+
+  axiom abs_int_interval_3 :
+     forall i : int.
+     forall x : int [abs_int(x), abs_int(x) in [?, i]]
+     { abs_int(x) <= i }.
+     - i <= x <= i
+
+end
+
+
+theory NRA extends FPA =
+
+   (* TODO: linearizations with strict inequalities are missing *)
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_1:
+         forall x, y: real.
+         forall a: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x >= 0. ->
+         x*a <= x*y
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_2:
+         forall x, y: real.
+         forall a: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x <= 0. ->
+         x*a >= x*y
+
+  (* needs more semantic triggers, case-split, and discarding of linear terms*)
+  axiom linearize_mult_3:
+         forall x, y: real.
+         forall b: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x >= 0. ->
+         x*y <= x*b
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_4:
+         forall x, y: real.
+         forall b: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x <= 0. ->
+         x*y >= x*b
+
+
+   (* commutativity of four axiomes above *)
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_5:
+         forall x, y: real.
+         forall a: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x >= 0. ->
+         a*x <= y*x
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_6:
+         forall x, y: real.
+         forall a: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x <= 0. ->
+         a*x >= y*x
+
+  (* needs more semantic triggers, case-split, and discarding of linear terms*)
+  axiom linearize_mult_7:
+         forall x, y: real.
+         forall b: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x >= 0. ->
+         y*x <= b*x
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_8:
+         forall x, y: real.
+         forall b: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x <= 0. ->
+         y*x >= b*x
+
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_1:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [c, ?]
+    ]
+    {a/b >= c}.
+    b > 0. ->
+    a >= b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_2:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [c, ?]
+    ]
+    {a/b >= c}.
+    b < 0. ->
+    a <= b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_3:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c]
+    ]
+    {a/b <= c}.
+    b > 0. ->
+    a <= b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_4:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c]
+    ]
+    {a/b <= c}.
+    b < 0. ->
+    a >= b * c
+
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_1:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in ]c, ?]
+    ]
+    {a/b > c}.
+    b > 0. ->
+    a > b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_2:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in ]c, ?]
+    ]
+    {a/b > c}.
+    b < 0. ->
+    a < b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_3:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c[
+    ]
+    {a/b < c}.
+    b > 0. ->
+    a < b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_4: (* add the same thing for equality ?? *)
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c[
+    ]
+    {a/b < c}.
+    b < 0. ->
+    a > b * c
+
+
+   axiom linearize_mult_zero_one_1:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]
+     {0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     x*y <= y
+
+   axiom linearize_mult_zero_one_2:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]{0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     y*x <= y
+
+   axiom linearize_mult_zero_one_3:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]{0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= x*y
+
+   axiom linearize_mult_zero_one_4:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]{0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= y*x
+
+   axiom linearize_mult_zero_one_5:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     x*y <= y
+
+   axiom linearize_mult_zero_one_6:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     y*x <= y
+
+   axiom linearize_mult_zero_one_7:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= x*y
+
+   axiom linearize_mult_zero_one_8:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= y*x
+
+end
+
+theory Principal_Sqrt_real extends FPA = (* some axioms about sqrt: shoud add more *)
+
+axiom sqrt_bounds:
+      forall x, i, j : real
+      [sqrt_real(x), x in [i,j]]
+      (* x may be a constant. i.e. x = i = j and sqrt_real(x) is not exact *)
+      {i <= x, x <= j}.
+      sqrt_real_default(i) <= sqrt_real(x) <= sqrt_real_excess(j)
+
+axiom sqrt_real_is_positive:
+  forall x:real[sqrt_real(x)]. (* semantic triggers ? case-split ? *)
+     x >= 0. ->
+     sqrt_real(x) >= 0.
+
+axiom sqrt_real_is_positive_strict:
+  forall x:real[sqrt_real(x)]. (* semantic triggers ? case-split ? *)
+     x > 0. ->
+     sqrt_real(x) > 0.
+
+axiom square_of_sqrt_real:
+  forall x:real[sqrt_real(x)]. (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    sqrt_real(x) * sqrt_real(x) = x
+
+axiom sqrt_real_of_square:
+  forall x:real[sqrt_real(x * x)]. (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    sqrt_real(x * x) = x
+
+
+axiom sqrt_real_monotonicity:
+  forall x, y:real[sqrt_real(x), sqrt_real(y)].
+    (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    y >= 0. ->
+    x <= y ->
+    sqrt_real(x) <= sqrt_real(y)
+
+(* what about contrapositive of sqrt_real_monotonicity *)
+
+axiom sqrt_real_monotonicity_strict:
+  forall x, y:real[sqrt_real(x), sqrt_real(y)].
+    (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    y >= 0. ->
+    x < y ->
+    sqrt_real(x) < sqrt_real(y)
+
+(* what about contrapositive of sqrt_real_monotonicity_strict *)
+
+end

--- a/sources/preludes/fpa-theory-2019-10-08-19h00.why
+++ b/sources/preludes/fpa-theory-2019-10-08-19h00.why
@@ -166,16 +166,19 @@ theory Simple_FPA extends FPA =
         k |->
            (
             2. **
-            (integer_log2(
-              max_real(
-                abs_real(i),
+            real_of_int(
+              (integer_log2(
                 max_real(
-                  abs_real(j),
-                  (2. ** - exp_min + prec-1)
-                )
+                  abs_real(i),
+                  max_real(
+                    abs_real(j),
+                    (2. ** real_of_int(- exp_min + prec-1))
+                    )
+                   )
+                 ) - prec (* we can improve by -1 for some rounding modes *)
                )
-             ) - prec (* we can improve by -1 for some rounding modes *)
-           ))
+             )
+           )
      ]
      {
         i <= x,
@@ -198,16 +201,19 @@ theory Simple_FPA extends FPA =
         k |->
            (
             2. **
-            (integer_log2(
-              max_real(
-                abs_real(i),
+            real_of_int(
+              (integer_log2(
                 max_real(
-                  abs_real(j),
-                  (2. ** - exp_min + prec-1)
+                  abs_real(i),
+                  max_real(
+                    abs_real(j),
+                    (2. ** real_of_int(- exp_min + prec-1))
+                   )
+                  )
+                 ) - prec + 1(* we can improve by -1 for some rounding modes *)
                 )
                )
-             ) - prec + 1(* we can improve by -1 for some rounding modes *)
-           ))
+              )
      ]
      {
         i <= x,
@@ -515,9 +521,9 @@ theory Simple_FPA extends FPA =
         is_theory_constant(prec),
         is_theory_constant(exp_min),
         is_theory_constant(mode),
-        real_of_int(x) + (2. ** prec)  in [0., ?],
-        real_of_int(x) - (2. ** prec) in [?, 0.],
-        k |-> (2. ** prec)
+        real_of_int(x) + (2. ** real_of_int(prec))  in [0., ?],
+        real_of_int(x) - (2. ** real_of_int(prec)) in [?, 0.],
+        k |-> (2. ** real_of_int(prec))
      ]
      {
         -k <= real_of_int(x),
@@ -538,7 +544,7 @@ theory Simple_FPA extends FPA =
         is_theory_constant(x),
         x in [i , i],
         k1 |-> abs_real(i),
-        k2 |-> (2. ** integer_log2(abs_real(i)))
+        k2 |-> (2. ** real_of_int(integer_log2(abs_real(i))))
      ].
      k1 >= 1. ->
      k1 = k2 -> (* is pow of 2 ?*)
@@ -556,9 +562,9 @@ theory Simple_FPA extends FPA =
         is_theory_constant(p),
         is_theory_constant(mode),
         float(m, p, mode, x) in ]i, j[,
-        i2 |-> float(m, p, Up, i + (2. ** (2 * (- p)))),
-        j2 |-> float(m, p, Down, j - (2. **(2 * (- p))))
-        (* (2. ** (2 * (- p))) is smaller than any gap between two successive floats *)
+        i2 |-> float(m, p, Up, i + (2. ** real_of_int((2 * (- p))))),
+        j2 |-> float(m, p, Down, j - (2. ** real_of_int((2 * (- p)))))
+        (* (2. ** real_of_int((2 * (- p)))) is smaller than any gap between two successive floats *)
      ]
      {
         float(m, p, mode, x) > i,

--- a/sources/preludes/fpa-theory-2019-10-08-19h00.why
+++ b/sources/preludes/fpa-theory-2019-10-08-19h00.why
@@ -164,20 +164,16 @@ theory Simple_FPA extends FPA =
         is_theory_constant(exp_min),
         x in [i, j],
         k |->
-           (
-            2. **
-            real_of_int(
-              (integer_log2(
+           2 **. (
+            integer_log2(
+              max_real(
+                abs_real(i),
                 max_real(
-                  abs_real(i),
-                  max_real(
-                    abs_real(j),
-                    (2. ** real_of_int(- exp_min + prec-1))
-                    )
-                   )
-                 ) - prec (* we can improve by -1 for some rounding modes *)
+                  abs_real(j),
+                  2 **. (- exp_min + prec-1)
+                )
                )
-             )
+             ) - prec (* we can improve by -1 for some rounding modes *)
            )
      ]
      {
@@ -199,21 +195,17 @@ theory Simple_FPA extends FPA =
         is_theory_constant(mode),
         x in [i, j],
         k |->
-           (
-            2. **
-            real_of_int(
-              (integer_log2(
+           2 **. (
+            integer_log2(
+              max_real(
+                abs_real(i),
                 max_real(
-                  abs_real(i),
-                  max_real(
-                    abs_real(j),
-                    (2. ** real_of_int(- exp_min + prec-1))
-                   )
-                  )
-                 ) - prec + 1(* we can improve by -1 for some rounding modes *)
+                  abs_real(j),
+                  2 **. (- exp_min + prec-1)
                 )
                )
-              )
+             ) - prec + 1(* we can improve by -1 for some rounding modes *)
+           )
      ]
      {
         i <= x,
@@ -521,9 +513,9 @@ theory Simple_FPA extends FPA =
         is_theory_constant(prec),
         is_theory_constant(exp_min),
         is_theory_constant(mode),
-        real_of_int(x) + (2. ** real_of_int(prec))  in [0., ?],
-        real_of_int(x) - (2. ** real_of_int(prec)) in [?, 0.],
-        k |-> (2. ** real_of_int(prec))
+        real_of_int(x) + (2 **. prec)  in [0., ?],
+        real_of_int(x) - (2 **. prec) in [?, 0.],
+        k |-> 2 **. prec
      ]
      {
         -k <= real_of_int(x),
@@ -544,7 +536,7 @@ theory Simple_FPA extends FPA =
         is_theory_constant(x),
         x in [i , i],
         k1 |-> abs_real(i),
-        k2 |-> (2. ** real_of_int(integer_log2(abs_real(i))))
+        k2 |-> 2 **. (integer_log2(abs_real(i)))
      ].
      k1 >= 1. ->
      k1 = k2 -> (* is pow of 2 ?*)
@@ -562,9 +554,9 @@ theory Simple_FPA extends FPA =
         is_theory_constant(p),
         is_theory_constant(mode),
         float(m, p, mode, x) in ]i, j[,
-        i2 |-> float(m, p, Up, i + (2. ** real_of_int((2 * (- p))))),
-        j2 |-> float(m, p, Down, j - (2. ** real_of_int((2 * (- p)))))
-        (* (2. ** real_of_int((2 * (- p)))) is smaller than any gap between two successive floats *)
+        i2 |-> float(m, p, Up, i + (2 **. (2 * (- p)))),
+        j2 |-> float(m, p, Down, j - (2 **. (2 * (- p))))
+        (* pow_real_int(2.,2 * (- p)) is smaller than any gap between two successive floats *)
      ]
      {
         float(m, p, mode, x) > i,


### PR DESCRIPTION
- new non-linear arithmetic infix operator for exponentiation denoted '**', such that:

Typing:
 `(u : Int) ** (v : Int)` is of type Int

 `(u : Real) **. (v : Real)` is of type Real
 `(u : Real) **. (v : Int)` is of type Real
 `(u : Int) **. (v : Real)` is of type Real
 `(u : Int **. (v : Int)` is of type Real

Interpretation:
 u ** v is not interpreted, except when:
   - u and v are constants (modulo theories) and v is integral, in which case, the result of u ** v is computed
   - v is equal to 1 (modulo theories), in which case u ** v is equal to u
   - v is equal to 0 (modulo theories), in which case u ** v is equal to 1