### PR TITLE
Add support for opam < 2

### DIFF
--- a/sources/configure.ml
+++ b/sources/configure.ml
@@ -47,7 +47,7 @@ let update name r f =
 
 (* small wrapper around opam var *)
 let opam_var v =
-  let cmd = Format.asprintf "opam var %s" v in
+  let cmd = Format.asprintf "opam config var %s" v in
   let ch = Unix.open_process_in cmd in
   let s = input_line ch in
   let _ = Unix.close_process_in ch in


### PR DESCRIPTION
The `configure.ml` script added with the switch to dune unfortunately assumed at least opam 2 (because it used the `opam var` command). This add back support for `opam < 2` by using the `opam config var` command instead.
This should solve #254 