### PR TITLE
Fix verbose for unsupported command in psmt2-frontend

### DIFF
--- a/src/parsers/psmt2_to_alt_ergo.ml
+++ b/src/parsers/psmt2_to_alt_ergo.ml
@@ -349,7 +349,8 @@ module Translate = struct
     with Invalid_argument _ -> assert false
 
   let not_supported s =
-    Format.eprintf "; %S : Not yet supported@." s
+    if Options.get_verbose () then
+      Format.eprintf "; %S : Not yet supported@." s
 
   let translate_command acc command =
     match command.c with


### PR DESCRIPTION
This modification is mandatory for smtcomp2020 since no output can be print on stderr