### PR TITLE
Fix dune warning flags

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,16 +1,13 @@
 (env
- (dev
-  ;; This profil is used (default) to dev without optimisation and blocking warnings.
+ (dev ;; This profil is used (default) to dev without optimisation and blocking warnings.
   (flags
    (:standard -bin-annot -w -22 -warn-error -A))
   (ocamlopt_flags -g))
- (warnings
-  ;; This profile can be used to simply enable all warnings.
+ (warnings ;; This profile can be used to simply enable all warnings.
   (flags
    (:standard -bin-annot -w +A -warn-error -A))
   (ocamlopt_flags -g))
- (release
-  ;; The release profile has optimisation enable.
+ (release ;; The release profile has optimisation enable.
   (flags
    (:standard -bin-annot))
   (ocamlopt_flags -O3 -unbox-closures))

--- a/src/dune
+++ b/src/dune
@@ -12,6 +12,6 @@
  (release
   ;; The release profile has optimisation enable.
   (flags
-   (:standard -bin-annot -w -A+K+X+Y+Z-22 -warn-error +X+K+Y+Z))
+   (:standard -bin-annot))
   (ocamlopt_flags -O3 -unbox-closures))
 )

--- a/src/dune
+++ b/src/dune
@@ -1,9 +1,17 @@
 (env
  (dev
+  ;; This profil is used (default) to dev without optimisation and blocking warnings.
   (flags
-   (:standard -bin-annot -w -22))
-  (ocamlopt_flags -g -O3 -unbox-closures))
+   (:standard -bin-annot -w -22 -warn-error -A))
+  (ocamlopt_flags -g))
+ (warnings
+  ;; This profile can be used to simply enable all warnings.
+  (flags
+   (:standard -bin-annot -w +A -warn-error -A))
+  (ocamlopt_flags -g))
  (release
+  ;; The release profile has optimisation enable.
   (flags
-   (:standard -bin-annot -w -22))
-  (ocamlopt_flags -O3 -unbox-closures)))
+   (:standard -bin-annot -w -A+K+X+Y+Z-22 -warn-error +X+K+Y+Z))
+  (ocamlopt_flags -O3 -unbox-closures))
+)

--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,7 @@
   (flags
    (:standard -bin-annot -w +A -warn-error -A))
   (ocamlopt_flags -g))
- (release ;; The release profile has optimisation enable.
+ (release ;; The release profile has optimizations enabled.
   (flags
    (:standard -bin-annot))
   (ocamlopt_flags -O3 -unbox-closures))


### PR DESCRIPTION
Disable warning as error and optimisation for the dune dev profile. Add new profile to enable all warnings. Add some known warning flag as error in release profile since this warnings should be resolve for release