### PR TITLE
ignore _opam dir if present (gitignore + make emacs-edit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ mlw
 tmp/
 *.tmp
 alt-ergo/tmp/
+_opam

--- a/Makefile
+++ b/Makefile
@@ -365,4 +365,4 @@ release-distclean:
 .PHONY: generated-clean dune-clean makefile-distclean release-distclean
 
 emacs-edit:
-	emacs `find . -name '*'.ml* | grep -v _build` &
+	emacs `find . -name '*'.ml* | grep -v _build | grep -v _opam` &


### PR DESCRIPTION
Useful for people using local opam switchs. Otherwise, make emacs edit tries to open all ml* files in _opam sub-dirs