### PR TITLE
Improve multi triggers inference

### DIFF
--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1855,7 +1855,7 @@ module Triggers = struct
         let llt, llt_ok =
           SLLT.fold
             (fun (l, bv2, vty2) (llt, llt_ok) ->
-               if SSet.equal bv1 bv2 && Svty.equal vty1 vty2 then
+               if SSet.subset bv1 bv2 && Svty.subset vty1 vty2 then
                  (* t doesn't bring new vars *)
                  llt, llt_ok
                else

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1855,17 +1855,18 @@ module Triggers = struct
         let llt, llt_ok =
           SLLT.fold
             (fun (l, bv2, vty2) (llt, llt_ok) ->
-               let bv3 = SSet.union bv2 bv1 in
-               let vty3 = Svty.union vty2 vty1 in
-               let e = t::l, bv3, vty3 in
                if SSet.equal bv1 bv2 && Svty.equal vty1 vty2 then
                  (* t doesn't bring new vars *)
                  llt, llt_ok
                else
-               if SSet.subset bv bv3 && Svty.subset vty vty3 then
-                 llt, SLLT.add e llt_ok
-               else
-                 SLLT.add e llt, llt_ok)
+                 let bv3 = SSet.union bv2 bv1 in
+                 let vty3 = Svty.union vty2 vty1 in
+                 let e = t::l, bv3, vty3 in
+                 if SSet.subset bv bv3 && Svty.subset vty vty3 then
+                   llt, SLLT.add e llt_ok
+                 else
+                   SLLT.add e llt, llt_ok
+            )
             llt (llt, llt_ok)
         in
         parties_rec (SLLT.add ([t], bv1, vty1) llt, llt_ok) l


### PR DESCRIPTION
This PR fixes the `Stack Overflow` in https://github.com/OCamlPro/alt-ergo/issues/315

As said in that issue, the `Stack Overflow` is raised when trying to infer multi-triggers for a big axiom, with the following characteristics:
```
4 bound vars:
  'p1~3818'
  'p2~3819'
  'p3~3820'
  'c~3821'
number of (non-var) terms containing these vars 31
size of powerset from these terms 1584291
size of smalltest multi-trigger = 3
size of biggest multi-trigger = 20
```
Since we have 4 bound vars (and no type variables), we expect the biggest multi-trigger that covers all these variables to have at most 4 elements. But here, a debug trace showed that `size of biggest multi-trigger = 20`.

This situation is due to the use of functions `Set.equal` (in `  if SSet.equal bv1 bv2 && Svty.equal vty1 vty2 then`) to test if a term `t` covers new variables (or type variables) of a multi-trigger that is being constructed (ie. partial). Actually, the test should be:
`  if SSet.subset bv1 bv2 && Svty.subset vty1 vty2 then`

```
     | (t, bv1, vty1)::l ->
        let llt, llt_ok =
          SLLT.fold
            (fun (l, bv2, vty2) (llt, llt_ok) ->
               if SSet.equal bv1 bv2 && Svty.equal vty1 vty2 then
                 (* t doesn't bring new vars *)
                 llt, llt_ok
               else
```

With this fix, we see in the logs that things are better: 

```
bound vars:
  'p1~3818'
  'p2~3819'
  'p3~3820'
  'c~3821'
number of terms containing these vars 35
size of powerset from these terms 3627
size of smalltest multi-trigger = 3
size of biggest multi-trigger = 4
```

**TODO*:* Test this PR on our internal testsuite before/after merging it. It may improve performances, but it may also cause regressions!
