### PR TITLE
Bugfix: type variables are not quantified in prenex form in Functions declarations of type bool

### DIFF
--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -2188,11 +2188,16 @@ let rec type_decl (acc, env) d =
   | Predicate_def(loc,n,l,e)
   | Function_def(loc,n,l,_,e) ->
     check_duplicate_params l;
-    let ty =
+    let infix, ty  =
       let l = List.map (fun (_,_,x) -> x) l in
       match d with
-      | Function_def(_,_,_,t,_) -> PFunction(l,t)
-      | Predicate_def _ -> PPredicate l
+      | Function_def(_,_,_,PPTbool,_) ->
+        (* cast functions that returns bools into predicates *)
+        PPiff, PPredicate l
+      | Function_def(_,_,_,t,_) ->
+        PPeq, PFunction(l,t)
+      | Predicate_def _ ->
+        PPiff, PPredicate l
       | _ -> assert false
     in
     let l = List.map (fun (_,x,t) -> (x,t)) l in
@@ -2202,7 +2207,6 @@ let rec type_decl (acc, env) d =
 
     let lvar = List.map (fun (x,_) -> {pp_desc=PPvar x;pp_loc=loc}) l in
     let p = {pp_desc=PPapp(n,lvar) ; pp_loc=loc } in
-    let infix = match d with Function_def _ -> PPeq | _ -> PPiff in
     let f = { pp_desc = PPinfix(p,infix,e) ; pp_loc = loc } in
     let f = make_pred loc [] f l in
     let f = type_form env f in


### PR DESCRIPTION
This PR fixes issue https://github.com/OCamlPro/alt-ergo/issues/290.

### How is this bug triggered

A minimal example that reproduces the bug is the following:
```
type 'a t
logic f : 'a t -> 'a
logic rand : 'a -> bool

function func (x : 'a t) : bool =
  forall i : int. rand(f(x))

logic U : int t

goal g: func(U)
```

During the transformation of the typed AST to expressions of type `Expr.t`, the function declaration becomes:

```
Axiom func:
  forall x : 'a t.
  func(x) = ( forall i : int. rand(f(x)))
```
But, because of a bug during the transformation, the type variable `'a` is (also) quantified/bound in the inner quantification (the inner quantification is seen as toplevel), which is not correct (type variables should be in prenex form). As a consequence:
- When instantiating, the substitution `{x |-> U , 'a |-> int}` fails to replace inner occurences of `'a` in the axiom. The produced instance look like this:
 ```
  func(U) = ( forall i : int. rand(f(U : int) : 'a))
```

- Since `func(U)` is false (we take the negation of the goal to try to deduce a contradiction), the instance is simplified to:
 ```
  (exists i : int. not (rand(f(U : int) : 'a)))
```
The skolemisation fails to produce a ground fact because of the type variable `'a`. This explains the `assert false` in the reported issue.

### Fix 1
The first commit of this PR is a simple fix for this issue. It detects functions that return bools and cast them into predicates.
I think this is a good transformation even if the issue is fixed differently.
 
However, this fix doesn't detect cases where functions declarations return values of type `'a` that becomes `bool` once type-checking is done (hence the second "more global" fix)

### Fix 2
The second commit provides a more global fix. It simply exposes a `~toplevel` flag in `Cnf.make_form` so that function `Cnf.make_term` could set it correctly. In fact, the `toplevel` flag was implicitly/internally set to true when it's called from `make_term`, which is incorrect.




