### PR TITLE
fix issue 329 that did not differentiate vtalarm and alarm signals.

### DIFF
--- a/src/bin/common/signals.ml
+++ b/src/bin/common/signals.ml
@@ -52,9 +52,16 @@ let init_sig_prof timers =
          )
       )
 
-let init_sig_alarm () =
+let init_sig_vtalarm () =
   if not (get_model ()) then
     try
       Sys.set_signal Sys.sigvtalrm
+        (Sys.Signal_handle (fun _ -> Options.exec_timeout ()))
+    with Invalid_argument _ -> ()
+
+let init_sig_alarm () =
+  if not (get_model ()) then
+    try
+      Sys.set_signal Sys.sigalrm
         (Sys.Signal_handle (fun _ -> Options.exec_timeout ()))
     with Invalid_argument _ -> ()

--- a/src/bin/common/signals.mli
+++ b/src/bin/common/signals.mli
@@ -27,3 +27,6 @@ val init_sig_prof : AltErgoLib.Timers.t -> unit
 
 (** Add signal handler for alarm signal (timeout). Raise timeout *)
 val init_sig_alarm : unit -> unit
+
+(** Add signal handler for virtual alarm signal (timeout). Raise timeout *)
+val init_sig_vtalarm : unit -> unit

--- a/src/bin/text/main_text.ml
+++ b/src/bin/text/main_text.ml
@@ -117,7 +117,7 @@ let typed_loop all_context state td =
 
 let () =
   Signals.init_sig_int ();
-  Signals.init_sig_alarm ();
+  Signals.init_sig_vtalarm ();
   Signals.init_sig_term_quit timers;
   Signals.init_sig_prof timers;
   Gc_debug.init ();


### PR DESCRIPTION
The gui used the vtalarm instead of alarm.
The cmdline used alarm instead of vtalarm.

This should fix #329 