### PR TITLE
Fix lifting/purification of expressions with let-in

### DIFF
--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2298,6 +2298,15 @@ let is_pure e = e.pure
 
 module Purification = struct
 
+  (* lets_counter is used to order 'let' constructs before they are added to the
+     'lets' map. This way, we keep their order in the original expression, and
+     reconstruct them correctly in mk_lifted. *)
+  let lets_counter = ref 0
+
+  let add_let sy e lets =
+    incr lets_counter;
+    SMap.add sy (e, !lets_counter) lets
+
   let rec purify_term t lets =
     if t.pure then t, lets
     else
@@ -2305,11 +2314,11 @@ module Purification = struct
       | Sy.Let, B_let { let_v; let_e; in_e; _ } ->
         let let_e, lets = purify_term let_e lets in
         let in_e , lets = purify_term in_e  lets in
-        in_e, SMap.add let_v let_e lets
+        in_e, add_let let_v let_e lets
 
       | (Sy.Lit _ | Sy.Form _), _ ->
         let fresh_sy = Sy.fresh ~is_var:true "Pur-F" in
-        mk_term fresh_sy [] t.ty , SMap.add fresh_sy t lets
+        mk_term fresh_sy [] t.ty , add_let fresh_sy t lets
 
       | _ -> (* detect ITEs *)
         match term_view t with
@@ -2318,7 +2327,7 @@ module Purification = struct
           match t.xs with
           | [_;_;_] when is_ite t.f ->
             let fresh_sy = Sy.fresh ~is_var:true "Pur-Ite" in
-            mk_term fresh_sy [] t.ty , SMap.add fresh_sy t lets
+            mk_term fresh_sy [] t.ty , add_let fresh_sy t lets
 
           | _ ->
             let xs, lets =
@@ -2443,13 +2452,17 @@ module Purification = struct
         end
 
   and mk_lifted e lets =
-    SMap.fold (*beware of ordering: to be checked *)
-      (fun let_v let_e acc ->
+    let ord_lets =  (*beware of ordering: to be checked *)
+      List.fast_sort
+        (fun (_, (_,cpt1)) (_,(_,cpt2)) -> cpt1 - cpt2) (SMap.bindings lets)
+    in
+    List.fold_left
+      (fun acc (let_v, (let_e, _cpt)) ->
          let let_e, lets =
            purify_non_toplevel_ite let_e SMap.empty in
          assert (let_e.ty != Ty.Tbool || SMap.is_empty lets);
          mk_lifted (mk_let let_v let_e acc 0) lets
-      )lets e
+      )e ord_lets
 
   and purify_non_toplevel_ite e lets =
     match e.f, e.xs with
@@ -2464,8 +2477,15 @@ module Purification = struct
 
 end
 
-(*let purify_literal = Purification.purify_literal*)
-let purify_form = Purification.purify_form
+(*
+let purify_literal a =
+  Purification.lets_counter := 0;
+  Purification.purify_literal a
+*)
+
+let purify_form f =
+  Purification.lets_counter := 0;
+  Purification.purify_form f
 
 module Set = TSet
 module Map = TMap


### PR DESCRIPTION
Fixes https://github.com/OCamlPro/alt-ergo/issues/335

let-in were not always re-constructed in the correct order.

For instance:

let x = e1 in
let y = h(x, e2) in
f(x,y) < g(y,x)

may become

let y = h(x, e2) in
let x = e1 in
f(x,y) < g(y,x)

which is incorrect, because 'x' escapes its scope.