### PR TITLE
Fix solver output

### DIFF
--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -264,20 +264,15 @@ let print_status_loc loc =
         "%a@,"
         Loc.report loc
 
-let print_status_value v color =
-  if Options.get_output_with_colors () then
-    fprintf (Options.get_fmt_std ())
-      "@{<%s>@{<bold>%s@}@}"
-      color v
-  else fprintf (Options.get_fmt_std ())
-      "%s" v
+let print_status_value v =
+  fprintf (Options.get_fmt_std ()) "%s" v
 
 let print_status ?(validity_mode=true)
-    (validity_status,unsat_status) loc time steps goal color =
+    (validity_status,unsat_status) loc time steps goal =
   pp_std_smt ();
   begin if validity_mode then begin
       print_status_loc loc;
-      print_status_value validity_status color;
+      print_status_value validity_status;
       fprintf (Options.get_fmt_std ())
         "%s%s%s"
         (status_time time)
@@ -285,40 +280,40 @@ let print_status ?(validity_mode=true)
         (status_goal goal);
     end
     else
-      print_status_value unsat_status color
+      print_status_value unsat_status
   end;
   fprintf (Options.get_fmt_std ()) "@."
 
 let print_status_unsat ?(validity_mode=true) loc
     time steps goal =
   print_status ~validity_mode ("Valid","unsat") loc
-    time steps goal "fg_green"
+    time steps goal
 
 let print_status_sat ?(validity_mode=true) loc
     time steps goal =
   print_status ~validity_mode ("Invalid","sat") loc
-    time steps goal "fg_cyan"
+    time steps goal
 
 let print_status_inconsistent ?(validity_mode=true) loc
     time steps goal =
   print_status ~validity_mode
     ("Inconsistent assumption","") loc
-    time steps goal "fg_red"
+    time steps goal
 
 let print_status_unknown ?(validity_mode=true) loc
     time steps goal =
   print_status ~validity_mode
     ("I don't know","unknown") loc
-    time steps goal "fg_blue"
+    time steps goal
 
 let print_status_timeout ?(validity_mode=true) loc
     time steps goal =
   print_status ~validity_mode
     ("Timeout","timeout") loc
-    time steps goal "fg_orange"
+    time steps goal
 
 let print_status_preprocess ?(validity_mode=true)
     time steps =
   print_status ~validity_mode
     ("Preprocessing","") None
-    time steps None "fg_magenta"
+    time steps None

--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -266,9 +266,9 @@ let print_status_value fmt v =
   fprintf fmt "%s" v
 
 let print_status ?(validity_mode=true)
+    ?(formatter=Options.get_fmt_std ())
     (validity_status,unsat_status) loc time steps goal =
   pp_std_smt ();
-  let formatter = (Options.get_fmt_std ()) in
   let native_output_fmt, comment_if_smt2 =
     if validity_mode then formatter, ""
     else (Options.get_fmt_dbg ()), "; "
@@ -299,6 +299,7 @@ let print_status_sat ?(validity_mode=true) loc
 let print_status_inconsistent ?(validity_mode=true) loc
     time steps goal =
   print_status ~validity_mode
+    ~formatter:(Options.get_fmt_dbg ())
     ("Inconsistent assumption","") loc
     time steps goal
 
@@ -317,5 +318,6 @@ let print_status_timeout ?(validity_mode=true) loc
 let print_status_preprocess ?(validity_mode=true)
     time steps =
   print_status ~validity_mode
+    ~formatter:(Options.get_fmt_dbg ())
     ("Preprocessing","") None
     time steps None

--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -255,34 +255,35 @@ let status_goal g =
     None -> ""
   | Some g -> sprintf " (goal %s)" g
 
-let print_status_loc loc =
+let print_status_loc fmt loc =
   match loc with
   | None -> ()
   | Some loc ->
     if Options.get_answers_with_locs () then
-      fprintf (Options.get_fmt_std ())
+      fprintf fmt
         "%a@,"
         Loc.report loc
 
-let print_status_value v =
-  fprintf (Options.get_fmt_std ()) "%s" v
+let print_status_value fmt v =
+  fprintf fmt "%s" v
 
 let print_status ?(validity_mode=true)
     (validity_status,unsat_status) loc time steps goal =
   pp_std_smt ();
+  let formatter = (Options.get_fmt_std ()) in
   begin if validity_mode then begin
-      print_status_loc loc;
-      print_status_value validity_status;
-      fprintf (Options.get_fmt_std ())
-        "%s%s%s"
+      fprintf formatter
+        "%a%a%s%s%s"
+        print_status_loc loc
+        print_status_value validity_status
         (status_time time)
         (status_steps steps)
         (status_goal goal);
     end
     else
-      print_status_value unsat_status
+      print_status_value formatter unsat_status
   end;
-  fprintf (Options.get_fmt_std ()) "@."
+  fprintf formatter "@."
 
 let print_status_unsat ?(validity_mode=true) loc
     time steps goal =


### PR DESCRIPTION
fixes https://github.com/OCamlPro/alt-ergo/issues/333

4 commits, 4 (small) changes in printer.ml

- no ANSI color in solver's final answer
- refactoring: provide the fmt for print_status_loc and print_status_value
- refactor print_status to show stats even in unsat mode (commented and in std_err)
    eg.
```   
    ; File "foo.smt2", line 1, characters 1-17: Inconsistent assumption (0.0040) (0 steps)
    ; File "foo.smt2", line 2, characters 1-12: Valid (0.0041) (0 steps) (goal g)
    unsat
```    
   where the two first lines are commented and printed to std debug/err.

- [printer] log print_status_{inconsistent, preprocess} in fmt_dbg instead of fmt_std
    For instance, if we have something like:
 ```
    File "bar.ae", line 2, characters 1-14: Inconsistent assumption (0.0010) (0 steps)
    File "bar.ae", line 2, characters 1-14: Valid (0.0010) (0 steps) (goal g)
```
  The first line is written to fmt_dbg (= std_err in default settings)