### PR TITLE
Bug fix in intervals deduction from FM results

### DIFF
--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -425,6 +425,9 @@ let generic_find xp env =
     let p0 = poly_of xp in
     let p, c = P.separate_constant p0 in
     let p, c0, d = P.normal_form_pos p in
+    (* in case we are on integers, c, may be rational (eg, coming from
+       Fourier-Motzkin.*)
+    let c = if P.type_info p == Ty.Tint then Q.floor c else c in
     Printer.print_dbg ~flushed:false ~header:false ~debug:(get_debug_fm ())
       "normalized into %a + %a * %a@ "
       Q.print c Q.print d P.print p;


### PR DESCRIPTION
In some situations, the constant c in an inequatily on integers:
p + c <= 0, is not an integer. In this case, it should be replaced with:
p + floor(c) <= 0

fixes https://github.com/OCamlPro/alt-ergo/issues/340