### PR TITLE
disable deductions by congruence closure on record symbols

### DIFF
--- a/src/lib/reasoners/records.ml
+++ b/src/lib/reasoners/records.ml
@@ -242,9 +242,11 @@ module Shostak (X : ALIEN) = struct
 
   let subst p v r = is_mine (subst_rec p v r)
 
-  let is_mine_symb sy _ty = match sy with
+  let is_mine_symb_aux sy = match sy with
     | Symbols.Op (Symbols.Record | Symbols.Access _) -> true
     | _ -> false
+
+  let is_mine_symb sy _ty = is_mine_symb_aux sy
 
   let abstract_access field e ty acc =
     let xe = is_mine e in
@@ -322,7 +324,7 @@ module Shostak (X : ALIEN) = struct
      | Other _ -> e
   *)
 
-  let fully_interpreted _ = false
+  let fully_interpreted = is_mine_symb_aux
 
   let rec term_extract r =
     match X.extract r with


### PR DESCRIPTION
These deductions should already be done by Shostak solver