### PR TITLE
imporve backward-like reasoning in Tableaux

### DIFF
--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -658,16 +658,16 @@ module Make (X : Arg) : S with type theory = X.t = struct
       (fun lem (age, dep) env ->
          match E.form_view lem with
          | E.Lemma ({ E.main = f; name; _ } as q) ->
-           let tgs =
+           let tgs, kind =
              match mconf.Util.backward with
-             | Util.Normal   -> triggers_of q mconf
-             | Util.Backward -> backward_triggers q
-             | Util.Forward  -> forward_triggers q
+             | Util.Normal   -> triggers_of q mconf, "Normal"
+             | Util.Backward -> backward_triggers q, "Backward"
+             | Util.Forward  -> forward_triggers q, "Forward"
            in
            Printer.print_dbg ~debug:(Options.get_debug_triggers ())
              ~module_name:"Matching" ~function_name:"add_triggers"
-             "@[<v 2>triggers of %s are:@ %a@]"
-             name E.print_triggers tgs;
+             "@[<v 2>%s triggers of %s are:@ %a@]"
+             kind name E.print_triggers tgs;
            List.fold_left
              (fun env tr ->
                 let info =


### PR DESCRIPTION
Now, we can easily detect Defns and Iff in Expr. Improve backward triggers for these constructs.

**Motivation:**
- Alt-Ergo (CDCL) timeouts after 3600 seconds on `p9_11-B_translation-OBF__hhgg_1.ae`
- Alt-Ergo (Tableaux) with this extension proves the formula in seconds with just backward (-like) reasoning