### PR TITLE
Add option to remove autoformatting from Format. This option is usefu…

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -32,7 +32,7 @@ license: [
 ]
 
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/alt-ergo-parsers.opam
+++ b/alt-ergo-parsers.opam
@@ -31,7 +31,7 @@ license: [
 ]
 
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/alt-ergo.opam
+++ b/alt-ergo.opam
@@ -29,7 +29,7 @@ license: [
 ]
 
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/altgr-ergo.opam
+++ b/altgr-ergo.opam
@@ -31,7 +31,7 @@ license: [
 ]
 
 build: [
-  ["./configure" name]
+  ["ocaml" "unix.cma" "configure.ml" name]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -196,11 +196,13 @@ let mk_context_opt replay replay_all_used_context replay_used_context
 
 let mk_execution_opt frontend input_format parse_only parsers
     preludes no_locs_in_answers no_colors_in_output no_headers_in_output
+    no_formatting_in_output
     type_only type_smt2
   =
   let answers_with_loc = not no_locs_in_answers in
   let output_with_colors = not no_colors_in_output in
   let output_with_headers = not no_headers_in_output in
+  let output_with_formatting = not no_formatting_in_output in
   set_infer_input_format input_format;
   let input_format = match input_format with
     | None -> Native
@@ -209,6 +211,7 @@ let mk_execution_opt frontend input_format parse_only parsers
   set_answers_with_loc answers_with_loc;
   set_output_with_colors output_with_colors;
   set_output_with_headers output_with_headers;
+  set_output_with_formatting output_with_formatting;
   set_input_format input_format;
   set_parse_only parse_only;
   set_parsers parsers;
@@ -731,6 +734,11 @@ let parse_execution_opt =
       "Do not print output with headers." in
     Arg.(value & flag & info ["no-headers-in-output"] ~docs ~doc) in
 
+  let no_formatting_in_output =
+    let doc =
+      "Do not use any formatting rule in output." in
+    Arg.(value & flag & info ["no-formatting-in-output"] ~docs ~doc) in
+
   let type_only =
     let doc = "Stop after typing." in
     Arg.(value & flag & info ["type-only"] ~docs ~doc) in
@@ -743,7 +751,7 @@ let parse_execution_opt =
   Term.(ret (const mk_execution_opt $
              frontend $ input_format $ parse_only $ parsers $ preludes $
              no_locs_in_answers $ no_colors_in_output $ no_headers_in_output $
-             type_only $ type_smt2
+             no_formatting_in_output $ type_only $ type_smt2
             ))
 
 let parse_halt_opt =

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -213,6 +213,7 @@ let get_save_used_context () = !save_used_context
 let answers_with_loc = ref true
 let output_with_colors = ref true
 let output_with_headers = ref true
+let output_with_formatting = ref true
 let frontend = ref "legacy"
 let input_format = ref Native
 let infer_input_format = ref true
@@ -225,6 +226,7 @@ let type_smt2 = ref false
 let set_answers_with_loc b = answers_with_loc := b
 let set_output_with_colors b = output_with_colors := b
 let set_output_with_headers b = output_with_headers := b
+let set_output_with_formatting b = output_with_formatting := b
 let set_frontend f = frontend := f
 let set_input_format f = input_format := f
 let set_infer_input_format f = infer_input_format := (f = None)
@@ -237,6 +239,7 @@ let set_type_smt2 b = type_smt2 := b
 let get_answers_with_locs () = !answers_with_loc
 let get_output_with_colors () = !output_with_colors
 let get_output_with_headers () = !output_with_headers
+let get_output_with_formatting () = !output_with_formatting
 let get_frontend () = !frontend
 let get_input_format () = !input_format
 let get_infer_input_format () = !infer_input_format

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -297,6 +297,10 @@ val set_output_with_colors : bool -> unit
 (** Set [output_with_headers] accessible with {!val:get_output_with_headers} *)
 val set_output_with_headers : bool -> unit
 
+(** Set [output_with_formatting] accessible with
+    {!val:get_output_with_formatting} *)
+val set_output_with_formatting : bool -> unit
+
 (** Set [infer_input_format] accessible with {!val:get_infer_input_format} *)
 val set_infer_input_format : 'a option -> unit
 
@@ -559,6 +563,10 @@ val get_output_with_colors  : unit -> bool
 
 (** [true] if the outputs are printed with headers *)
 val get_output_with_headers  : unit -> bool
+(** Default to [true] *)
+
+(** [true] if the outputs are printed with formatting rules *)
+val get_output_with_formatting  : unit -> bool
 (** Default to [true] *)
 
 (** Valuget_e of the currently selected parsing and typing frontend. *)

--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -159,9 +159,9 @@ let add_smt formatter =
 let remove_formatting formatter =
   let old_fs = Format_shims.pp_get_formatter_out_functions formatter () in
   let out_newline () = old_fs.out_string "" 0 0 in
-  let out_indent _n = old_fs.out_indent 0 in
-  Format_shims.pp_set_formatter_out_functions formatter
-    { old_fs with out_newline; out_indent }
+  let out_spaces _n = old_fs.out_spaces 0 in
+  Format.pp_set_formatter_out_functions formatter
+    { old_fs with out_newline; out_spaces }
 
 (* This function is used to force a newline when the option removing the
    formatting is enable *)

--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -156,6 +156,24 @@ let add_smt formatter =
   Format_shims.pp_set_formatter_out_functions formatter
     { old_fs with out_newline }
 
+let remove_formatting formatter =
+  let old_fs = Format_shims.pp_get_formatter_out_functions formatter () in
+  let out_newline () = old_fs.out_string "" 0 0 in
+  let out_indent _n = old_fs.out_indent 0 in
+  Format_shims.pp_set_formatter_out_functions formatter
+    { old_fs with out_newline; out_indent }
+
+(* This function is used to force a newline when the option removing the
+   formatting is enable *)
+let force_new_line formatter =
+  if not (Options.get_output_with_formatting ()) then
+    let old_fs = Format_shims.pp_get_formatter_out_functions formatter () in
+    let out_newline () = old_fs.out_string "\n" 0 1 in
+    Format_shims.pp_set_formatter_out_functions formatter
+      { old_fs with out_newline };
+    Format.fprintf formatter "@.";
+    remove_formatting formatter
+
 let init_output_format () =
   match Options.get_output_format () with
   | Smtlib2 ->
@@ -218,6 +236,8 @@ let print_dbg ?(flushed=true) ?(header=(Options.get_output_with_headers ()))
       then ""
       else sprintf "[%s]" module_name
     in
+    (* we force a newline to split the print at every print with header *)
+    force_new_line fmt;
     if Options.get_output_with_colors () then
       fprintf fmt
         "@{<fg_blue>@{<bold>[Debug]%s%s@}@}@,@[<v 0>"
@@ -227,6 +247,7 @@ let print_dbg ?(flushed=true) ?(header=(Options.get_output_with_headers ()))
         "[Debug]%s%s@,@[<v 0>" mname fname
   end;
   if flushed then kfprintf flush fmt s else fprintf fmt s
+
 
 let print_fmt ?(flushed=true) fmt s =
   if flushed then kfprintf flush fmt s else fprintf fmt s


### PR DESCRIPTION
…ll for logging debug informations. Only new debug line are formatted with a new line

see the following example : 
- normal printing :
```
[Debug][IntervalCalculus][assume]
We assume:  X1(arith):[0 [int]] <> X1(arith):[1*FT:[(z : int)] 1*FT:[(y : int)] 0 [int]]
  explanations: {}
[Debug][IntervalCalculus][env]

------------ FM: inequations-------------------------

------------ FM: monomes ----------------------------
FT:[(y : int)] : ]-inf;+inf[ |-use-> {}
FT:[(z : int)] : ]-inf;+inf[ |-use-> {}
FT:[(x : int)] : ]-inf;+inf[ |-use-> {}
FT:[(t : int)] : ]-inf;+inf[ |-use-> {}
------------ FM: polynomes---------------------------
1*FT:[(z : int)] 1*FT:[(y : int)] 0 [int] : ]-inf;-1] U [1;+inf[
-----------------------------------------------------
[Debug][IntervalCalculus][implied_equalities]
 0 implied equalities 
```

- with `--no-formatting-output` option : 
``` 
[Debug][IntervalCalculus][assume]We assume:  X1(arith):[0 [int]] <> X1(arith):[1*FT:[(z : int)] 1*FT:[(y : int)] 0 [int]]explanations: {}
[Debug][IntervalCalculus][env]------------ FM: inequations------------------------------------- FM: monomes ----------------------------FT:[(y : int)] : ]-inf;+inf[ |-use-> {}FT:[(z : int)] : ]-inf;+inf[ |-use-> {}FT:[(x : int)] : ]-inf;+inf[ |-use-> {}FT:[(t : int)] : ]-inf;+inf[ |-use-> {}------------ FM: polynomes---------------------------1*FT:[(z : int)] 1*FT:[(y : int)] 0 [int] : ]-inf;-1] U [1;+inf[-----------------------------------------------------
[Debug][IntervalCalculus][implied_equalities] 0 implied equalities 
```