### PR TITLE
Fix opam call in configure.ml

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -52,7 +52,7 @@ let update name r f =
 
 (* small wrapper around opam var *)
 let opam_var v =
-  let cmd = Format.asprintf "opam config var %s" v in
+  let cmd = Format.asprintf "opam config var --readonly %s" v in
   let ch = Unix.open_process_in cmd in
   let s = input_line ch in
   let _ = Unix.close_process_in ch in


### PR DESCRIPTION
it's bad practice to call `opam` without `--readonly` from within an opam package, and could cause failures or deadlocks.