### PR TITLE
Add greedier instantiation round in both sat solver

### DIFF
--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1346,29 +1346,35 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
   let greedy_instantiation env =
     if get_greedy () then return_answer env 1 (fun e -> raise (I_dont_know e));
-    let gre_inst =
-      ME.fold
-        (fun f (gf,_,_,_) inst ->
-           Inst.add_terms inst (E.max_ground_terms_rec_of_form f) gf)
-        env.gamma env.inst
+    let rec greedy_instantiation_aux env greedier =
+      let gre_inst =
+        ME.fold
+          (fun f (gf,_,_,_) inst ->
+             Inst.add_terms inst (E.max_ground_terms_rec_of_form f) gf)
+          env.gamma env.inst
+      in
+      let env = new_inst_level env in
+      let mconf =
+        {Util.nb_triggers = max 10 (get_nb_triggers () * 10);
+         no_ematching = false;
+         triggers_var = if greedier then true else get_triggers_var ();
+         use_cs = true;
+         backward = Util.Normal;
+         greedy = true;
+        }
+      in
+      let env, ok1 = inst_and_assume mconf env inst_predicates gre_inst in
+      let env, ok2 = inst_and_assume mconf env inst_lemmas gre_inst in
+      let env, ok3 = syntactic_th_inst env gre_inst ~rm_clauses:false in
+      let env, ok4 = semantic_th_inst  env gre_inst ~rm_clauses:false ~loop:4 in
+      let env = do_case_split env Util.AfterMatching in
+      if ok1 || ok2 || ok3 || ok4 then env
+      else if not greedier then greedy_instantiation_aux env true
+      else
+        return_answer env 1
+          (fun e -> raise (I_dont_know e))
     in
-    let env = new_inst_level env in
-    let mconf =
-      {Util.nb_triggers = max 10 (get_nb_triggers () * 10);
-       no_ematching = false;
-       triggers_var = true;
-       use_cs = true;
-       backward = Util.Normal;
-       greedy = true;
-      }
-    in
-    let env, ok1 = inst_and_assume mconf env inst_predicates gre_inst in
-    let env, ok2 = inst_and_assume mconf env inst_lemmas gre_inst in
-    let env, ok3 = syntactic_th_inst env gre_inst ~rm_clauses:false in
-    let env, ok4 = semantic_th_inst  env gre_inst ~rm_clauses:false ~loop:4 in
-    let env = do_case_split env Util.AfterMatching in
-    if ok1 || ok2 || ok3 || ok4 then env
-    else return_answer env 1 (fun e -> raise (I_dont_know e))
+    greedy_instantiation_aux env false
 
   let normal_instantiation env try_greedy =
     Debug.print_nb_related env;

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -884,11 +884,21 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let greedy_mconf () =
     {Util.nb_triggers = Stdlib.max 10 (get_nb_triggers () * 10);
      no_ematching = false;
+     triggers_var = get_triggers_var ();
+     use_cs = true;
+     backward = Util.Normal;
+     greedy = true;
+    }
+
+  let greedier_mconf () =
+    {Util.nb_triggers = Stdlib.max 10 (get_nb_triggers () * 10);
+     no_ematching = false;
      triggers_var = true;
      use_cs = true;
      backward = Util.Normal;
      greedy = true;
     }
+
 
   let do_instantiation env sa mconf msg ~dec_lvl =
     Debug.new_instances msg env;
@@ -929,7 +939,8 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
         )(env, false)
         [ frugal_mconf (), "frugal-inst", false, true ;
           normal_mconf (), "normal-inst", false, false;
-          greedy_mconf (), "greedy-inst", true , false ]
+          greedy_mconf (), "greedy-inst", true , false;
+          greedier_mconf (), "greedier-inst", true, false ]
 
 
   let rec unsat_rec env ~first_call:_ : unit =

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -899,7 +899,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
      greedy = true;
     }
 
-
   let do_instantiation env sa mconf msg ~dec_lvl =
     Debug.new_instances msg env;
     let l = instantiate_ground_preds env [] sa in


### PR DESCRIPTION
The goal of this PR is to delay the triggers-vars heuristic when Alt-Ergo perform a greedy instantiation round. This heuristic can be costly (time) but in certain cases allow a faster resolution.

This changes has been tested for both SAT. The global performance (time) has been improved