### PR TITLE
[models] add case-split on internal bool terms

### DIFF
--- a/rsc/extra/test_lib.sh
+++ b/rsc/extra/test_lib.sh
@@ -23,7 +23,7 @@ echo "content of lib == $x"
 # Compile the lib_usage caml file
 cd $git_repo/examples
 ocamlfind ocamlopt -linkpkg -package \
-	  stdlib-shims,num,zarith,ocplib-simplex,psmt2-frontend,unix,str,zip,dynlink,cmdliner \
+	  stdlib-shims,num,zarith,ocplib-simplex,psmt2-frontend,unix,str,zip,dynlink,cmdliner,seq \
 	  -o lib_usage \
 	  -I $lib_path AltErgoLib.cmxa \
 	  lib_usage.ml

--- a/src/lib/models/models.ml
+++ b/src/lib/models/models.ml
@@ -107,10 +107,12 @@ end
 
 let constraints = ref Sorts.empty
 
-let assert_has_depth_one (e, _) =
+let assert_has_depth_one_at_most (e, _) =
   match X.term_extract e with
-  | Some t, true -> assert (E.depth t = 1);
-  | _ -> ()
+  | Some t, true ->
+    assert (E.depth t <= 1); (* true and false have depth = -1 *)
+  | _ ->
+    ()
 
 module AECounterExample = struct
 
@@ -160,7 +162,7 @@ module AECounterExample = struct
                 Printer.print_fmt ~flushed:false fmt
                   "((s: %a, args: %a) rep: %a)@ "
                   (print_symb ty) f print_args xs x_print rep;
-                List.iter (fun (_,x) -> assert_has_depth_one x) xs;
+                List.iter (fun (_,x) -> assert_has_depth_one_at_most x) xs;
              )st;
            Printer.print_fmt ~flushed:false fmt "@]@ ";
         ) fprofs;
@@ -183,7 +185,7 @@ module AECounterExample = struct
                   Printer.print_fmt ~flushed:false fmt
                     "((%a %a) %a)@ "
                     (print_symb ty) f print_args xs x_print rep;
-                  List.iter (fun (_,x) -> assert_has_depth_one x) xs;
+                  List.iter (fun (_,x) -> assert_has_depth_one_at_most x) xs;
                )st;
              Printer.print_fmt ~flushed:false fmt "@]@ ";
            | _ -> assert false


### PR DESCRIPTION
Fixes https://github.com/OCamlPro/alt-ergo/issues/384

(The first example was already fixed in `models` branch)