### PR TITLE
Fix cmdliner man (#429)

### DIFF
--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -943,8 +943,8 @@ let parse_profiling_opt =
   let profiling =
     let doc =
       "Activate the profiling module with the given frequency. \
-       Use Ctrl-C to switch between different views and \\\"Ctrl \
-       + AltGr + \" to exit." in
+       Use Ctrl-C to switch between different views and \"Ctrl \
+       + AltGr + \\\\ \" to exit." in
     let docv = "DELAY" in
     Arg.(value & opt (some float) None & info ["profiling"] ~docv ~docs ~doc) in
 

--- a/src/bin/gui/dune
+++ b/src/bin/gui/dune
@@ -17,7 +17,7 @@
 ; Rule to generate a man page for altgr-ergo
 (rule
   (target  altgr-ergo.1)
-  (action (with-outputs-to %{target} (run altgr-ergo --help=groff)))
+  (action (with-stdout-to %{target} (run altgr-ergo --help=groff)))
 )
 
 ; Install the man page

--- a/src/bin/gui/gui_config.ml
+++ b/src/bin/gui/gui_config.ml
@@ -106,9 +106,6 @@ let init () =
     load ();
   with Sys_error _ -> write ()
 
-
-let () = init ()
-
 let window_width = !window_width
 let window_height = !window_height
 let indent_size = !indent_size

--- a/src/bin/gui/gui_config.mli
+++ b/src/bin/gui/gui_config.mli
@@ -42,6 +42,10 @@ val load : unit -> unit
 (** Write the configuration file to the default location *)
 val write : unit -> unit
 
+(** Try to load the configuration file from the default location,
+    if not present try to write it to the default location *)
+val init : unit -> unit
+
 (** Update the size of the window *)
 val update_window_size : int -> int -> unit
 

--- a/src/bin/gui/main_gui.ml
+++ b/src/bin/gui/main_gui.ml
@@ -1524,6 +1524,7 @@ let start_replay session_cin all_used_context =
 
 
 let () =
+  Gui_config.init ();
   init_gtk ();
   Signals.init_sig_int ();
   Signals.init_sig_alarm ();

--- a/src/bin/text/dune
+++ b/src/bin/text/dune
@@ -15,7 +15,7 @@
 ; Rule to generate a man page for alt-ergo
 (rule
   (target  alt-ergo.1)
-  (action (with-outputs-to %{target} (run alt-ergo --help=groff)))
+  (action (with-stdout-to %{target} (run alt-ergo --help=groff)))
 )
 
 ; Install the man page


### PR DESCRIPTION
* Fix error in parse_command for profiling option documentation

* Use with-stdout-to instead of with-outputs-to in dune command for manpage generation

* Fix Gui configuration file initialisation