### PR TITLE
[WIP][Don't merge] re-implement all-models feature differently

### DIFF
--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -289,7 +289,8 @@ let mk_limit_opt age_bound fm_cross_limit timelimit_interpretation
     `Ok()
 
 let mk_output_opt interpretation use_underscore
-    objectives_in_interpretation unsat_core output_format
+    objectives_in_interpretation all_models show_prop_model
+    unsat_core output_format
   =
   set_infer_output_format output_format;
   let output_format = match output_format with
@@ -299,6 +300,8 @@ let mk_output_opt interpretation use_underscore
   set_interpretation interpretation;
   set_interpretation_use_underscore use_underscore;
   set_objectives_in_interpretation objectives_in_interpretation;
+  set_all_models all_models;
+  set_show_prop_model show_prop_model;
   set_unsat_core unsat_core;
   set_output_format output_format;
   `Ok()
@@ -930,7 +933,19 @@ let parse_output_opt =
     Arg.(value & flag & info
            ["objectives-in-interpretation";"objectives-in-model";
             "obj-in-interpretation";"obj-in-model"] ~doc) in
-
+  let all_models =
+    let doc = " enable all-models (or all-sat) feature, in which case, \
+               all possible boolean models will be explored. If \
+               --interpretation is also set, an interpretation for \
+               each boolean model will also be displayed. Note that \
+               timeouts are set per model/SAT branch in this case." in
+    Arg.(value & flag & info
+           ["all-models"; "all-sat"] ~doc) in
+  let show_prop_model =
+    let doc = " also show the propositional if a model is requested \
+               (with --interpretation or with --all-models options)." in
+    Arg.(value & flag & info
+           ["show-prop-model"; "show-propositional-model"] ~doc) in
 
   let unsat_core =
     let doc = "Experimental support for computing and printing unsat-cores." in
@@ -955,8 +970,8 @@ let parse_output_opt =
 
   Term.(ret (const mk_output_opt $
              interpretation $ use_underscore $
-             objectives_in_interpretation $ unsat_core $
-             output_format
+             objectives_in_interpretation $ all_models $ show_prop_model $
+             unsat_core $ output_format
             ))
 
 let parse_profiling_opt =

--- a/src/bin/text/main_text.ml
+++ b/src/bin/text/main_text.ml
@@ -103,7 +103,7 @@ let typed_loop all_context state td =
       begin match kind with
         | Typed.Check
         | Typed.Cut -> { state with local = []; }
-        | Typed.Thm | Typed.Sat -> { state with global = []; local = []; }
+        | Typed.Thm | Typed.Sat | Typed.AllSat _ -> { state with global = []; local = []; }
       end
     | Typed.TAxiom (_, s, _, _) when Typed.is_global_hyp s ->
       let cnf = Cnf.make state.global td in

--- a/src/lib/frontend/models.ml
+++ b/src/lib/frontend/models.ml
@@ -473,10 +473,10 @@ module Why3CounterExample = struct
 end
 (* of module Why3CounterExample *)
 
-let output_concrete_model fmt m =
+let output_concrete_model ~pp_prop_model fmt m =
   if get_interpretation () then begin
     Printer.print_fmt ~flushed:false fmt "@[<v 2>(model@,";
-    if Options.get_output_format () == Why3 then begin
+    if pp_prop_model || Options.get_output_format () == Why3 then begin
       Why3CounterExample.output_constraints fmt m.propositional
     end;
 

--- a/src/lib/frontend/models.mli
+++ b/src/lib/frontend/models.mli
@@ -28,6 +28,7 @@ type t = {
 (** Print the given counterexample on the given formatter with the
     corresponding format setted with Options.get_output_format *)
 val output_concrete_model :
+  pp_prop_model:bool ->
   Format.formatter ->
   t ->
   unit

--- a/src/lib/frontend/parsed_interface.ml
+++ b/src/lib/frontend/parsed_interface.ml
@@ -73,6 +73,9 @@ let mk_goal loc name expr =
 let mk_check_sat loc name expr =
   Check_sat (loc, name, expr)
 
+let mk_check_all_sat loc name llexpr =
+  Check_all_sat (loc, name, llexpr)
+
 (** Declaration of theories, generic axioms and rewriting rules **)
 
 let mk_theory loc name ext expr =

--- a/src/lib/frontend/parsed_interface.mli
+++ b/src/lib/frontend/parsed_interface.mli
@@ -52,6 +52,8 @@ val mk_goal : Loc.t -> string -> lexpr -> decl
 
 val mk_check_sat : Loc.t -> string -> lexpr -> decl
 
+val mk_check_all_sat : Loc.t -> string -> string list -> decl
+
 (** Declaration of theories, generic axioms and rewriting rules **)
 
 val mk_theory : Loc.t -> string -> string -> decl list -> decl

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -2014,6 +2014,7 @@ let type_one_th_decl env e =
   | Rewriting(loc, _, _)
   | Goal(loc, _, _)
   | Check_sat(loc, _, _)
+  | Check_all_sat(loc, _, _)
   | Predicate_def(loc,_,_,_)
   | Function_def(loc,_,_,_,_)
   | TypeDecl ((loc, _, _, _)::_)
@@ -2236,6 +2237,14 @@ let rec type_decl (acc, env) d assertion_stack =
     (*let f = move_up f in*)
     let f = alpha_renaming_env env f in
     type_and_intro_goal acc env Sat n f, env
+
+  | Check_all_sat(loc, n, l) ->
+    Options.tool_req 1 "TR-Typing-CheckAllSatDecl$_F$";
+    let f = { pp_loc = loc; pp_desc = PPconst ConstFalse} in
+    List.iter (fun s ->
+        ignore (type_form env {pp_desc = PPapp(s,[]); pp_loc = loc})
+      ) l;
+    type_and_intro_goal acc env (AllSat l) n f, env
 
   | Predicate_def(loc,n,l,e)
   | Function_def(loc,n,l,_,e) ->

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1851,4 +1851,14 @@ are not Th-reduced";
   (** returns the latest model stored in the env if any *)
   let get_model env = !(env.last_saved_model)
 
+  let get_propositional_model env =
+    ME.fold (fun f _ acc ->
+        match E.lit_view f with
+        | E.Not_a_lit _ -> acc
+        | _ -> E.Set.add f acc
+      ) env.gamma E.Set.empty
+
+  let reset_last_saved_model env =
+    { env with last_saved_model = ref None}
+
 end

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -77,6 +77,12 @@ module type S = sig
   (** returns the latest model stored in the env, if any *)
   val get_model: t -> Models.t Lazy.t option
 
+  (** returns the latest solver's boolean assignation for literals
+     that is validated by the theories *)
+  val get_propositional_model: t -> Expr.Set.t
+
+  (** reset last saved model, if any *)
+  val reset_last_saved_model: t -> t
 end
 
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -73,6 +73,13 @@ module type S = sig
 
   (** returns the latest model stored in the env if any *)
   val get_model: t -> Models.t Lazy.t option
+
+  (** returns the latest solver's boolean assignation for literals
+     that is validated by the theories *)
+  val get_propositional_model: t -> Expr.Set.t
+
+  (** reset last saved model, if any *)
+  val reset_last_saved_model: t -> t
 end
 
 

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1254,6 +1254,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
                     (E.max_ground_terms_rec_of_form gf.E.ff) gf}
     in
     try
+      SAT.cancel_until env.satml 0;
       assert (SAT.decision_level env.satml == 0);
       let env, _updated = assume_aux ~dec_lvl:0 env [gf] in
       let max_t = max_term_depth_in_sat env in
@@ -1317,7 +1318,14 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     SAT.assume_th_elt env.satml th_elt dep;
     env
 
-  let get_model env = !(env.last_saved_model);
+  let get_model env = !(env.last_saved_model)
+
+  let get_propositional_model env =
+    let tbox = SAT.current_tbox env.satml in
+    Th.get_assumed tbox
+
+  let reset_last_saved_model env =
+    { env with last_saved_model = ref None}
 
 end
 

--- a/src/lib/structures/parsed.ml
+++ b/src/lib/structures/parsed.ml
@@ -269,6 +269,7 @@ type decl =
   | Rewriting of Loc.t * string * lexpr list
   | Goal of Loc.t * string * lexpr
   | Check_sat of Loc.t * string * lexpr
+  | Check_all_sat of Loc.t * string * string list
   | Logic of Loc.t * Symbols.name_kind * (string * string) list * plogic_type
   | Predicate_def of
       Loc.t * (string * string) *

--- a/src/lib/structures/parsed.mli
+++ b/src/lib/structures/parsed.mli
@@ -123,6 +123,7 @@ type decl =
   | Rewriting of Loc.t * string * lexpr list
   | Goal of Loc.t * string * lexpr
   | Check_sat of Loc.t * string * lexpr
+  | Check_all_sat of Loc.t * string * string list
   | Logic of Loc.t * Symbols.name_kind * (string * string) list * plogic_type
   | Predicate_def of
       Loc.t * (string * string) *

--- a/src/lib/structures/typed.ml
+++ b/src/lib/structures/typed.ml
@@ -151,13 +151,14 @@ let print_rwt pp fmt r =
 
 (** Goal sort *)
 
-type goal_sort = Cut | Check | Thm | Sat
+type goal_sort = Cut | Check | Thm | Sat | AllSat of string list
 
 let print_goal_sort fmt = function
   | Cut -> Format.fprintf fmt "cut"
   | Check -> Format.fprintf fmt "check"
   | Thm -> Format.fprintf fmt "thm"
   | Sat -> Format.fprintf fmt "sat"
+  | AllSat _ -> Format.fprintf fmt "all-sat"
 
 
 (** Logic type *)

--- a/src/lib/structures/typed.mli
+++ b/src/lib/structures/typed.mli
@@ -246,6 +246,10 @@ type goal_sort =
   (** The goal to be proved valid *)
   | Sat
   (** The goal to be proved satisfiable *)
+  | AllSat of string list
+  (** Rather generate all models involving the given list of
+     propositional variables *)
+
 (** Goal sort. Used in typed declarations. *)
 
 val fresh_hypothesis_name : goal_sort -> string

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -296,6 +296,8 @@ let get_timelimit_per_goal () = !timelimit_per_goal
 let interpretation = ref INone
 let interpretation_use_underscore = ref false
 let objectives_in_interpretation = ref false
+let all_models = ref false
+let show_prop_model = ref false
 let output_format = ref Native
 let infer_output_format = ref true
 let unsat_core = ref false
@@ -303,6 +305,8 @@ let unsat_core = ref false
 let set_interpretation b = interpretation := b
 let set_interpretation_use_underscore b = interpretation_use_underscore := b
 let set_objectives_in_interpretation b = objectives_in_interpretation := b
+let set_all_models b = all_models := b
+let set_show_prop_model b = show_prop_model := b
 let set_output_format b = output_format := b
 let set_infer_output_format f = infer_output_format := f = None
 let set_unsat_core b = unsat_core := b
@@ -313,6 +317,8 @@ let get_every_interpretation () = !interpretation = IEvery
 let get_last_interpretation () = !interpretation = ILast
 let get_interpretation_use_underscore () = !interpretation_use_underscore
 let get_objectives_in_interpretation () = !objectives_in_interpretation
+let get_all_models () = !all_models
+let get_show_prop_model () = !show_prop_model
 let get_output_format () = !output_format
 let get_output_smtlib () =
   (!output_format = Smtlib2) || (!output_format = Why3)

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -213,6 +213,14 @@ val set_interpretation_use_underscore : bool -> unit
     {!val:get_objectives_in_interpretation} *)
 val set_objectives_in_interpretation : bool -> unit
 
+(** Set [all_models] accessible with
+    {!val:get_all_models} *)
+val set_all_models : bool -> unit
+
+(** Set [show_prop_model] accessible with
+    {!val:get_show_prop_model} *)
+val set_show_prop_model : bool -> unit
+
 (** Set [max_split] accessible with {!val:get_max_split} *)
 val set_max_split : Numbers.Q.t -> unit
 
@@ -726,6 +734,16 @@ val get_interpretation_use_underscore : unit -> bool
     be shrunk or not accurate if some expressions to optimize are
     unbounded. *)
 val get_objectives_in_interpretation : unit -> bool
+(** Default to [false] *)
+
+(** [true] if the all_models flag is set to generate all propositional
+   models *)
+val get_all_models : unit -> bool
+(** Default to [false] *)
+
+(** [true] if the show_prop_model flag is set to also output the
+   propositional model, when a model is requested *)
+val get_show_prop_model : unit -> bool
 (** Default to [false] *)
 
 (** Value specifying the default output format. possible values are

--- a/src/parsers/psmt2_to_alt_ergo.ml
+++ b/src/parsers/psmt2_to_alt_ergo.ml
@@ -379,6 +379,13 @@ module Translate = struct
 
   let count_goals = ref 0
 
+  let translate_check_all_sat command l =
+    let loc = pos command in
+    incr count_goals;
+    let gname = "g_" ^ (string_of_int !count_goals) in
+    let l = List.rev_map (fun symb -> symb.c) (List.rev l) in
+    mk_check_all_sat loc gname l
+
   let translate_check_sat command l =
     let loc = pos command in
     incr count_goals;
@@ -423,6 +430,8 @@ module Translate = struct
       (translate_check_sat command []) :: acc
     | Cmd_CheckSatAssum l ->
       (translate_check_sat command l) :: acc
+    | Cmd_CheckAllSat l ->
+      (translate_check_all_sat command l) :: acc
     | Cmd_DeclareConst(symbol,const_dec) ->
       (translate_decl_fun symbol [] (translate_const_dec const_dec)) :: acc
     | Cmd_DeclareDataType(symbol,datatype_dec) ->


### PR DESCRIPTION
This PR partially rely on a modification in psmt2-frontend.

- two new options (files option.ml*, parse_command.ml and models.ml):
  + all-models: to enable generation of all (propositional) models (+ concrete theories interpretation if --interpretation is set)
  + show-propositional-model: to enable display of propositional when --interpretation or --all-models are enabled
 the first option is not used in models.ml

- cleaning in theory.ml now that we're able to filter the boolean model from the SAT (in case of check-all-sat SMT2 command),

- add a function get_propositional_model in SAT solvers (used when all-models in set but not --interpretation) (sat_solver_sig.ml*, fun_sat.ml, satml_frontend.ml)

- other modified files, except frontend.ml: modifications to support the new SMT2 command `(check-all-sat <list of boolean variables>)` added to psmt2-frontend. This command is not part of the standard, but is implemented in MathSAT5. Useful to generate all models by filtering by the set of given bool variables.

- file frontend.ml contains the main modification to implement the feature.
+ the function `process_decl` is now recursive. It doesn't directly return on SAT/Unknown, but calls an auxiliary function `process_unknown` to analyze the situation:

1. check if we are in `all-sat` mode (in which case, return `Some {set of filter}`) or not (in which case, return `None`),
2. get the computed model if any (a Model.t computed with --interpretation, or a partial Model.t containing only the propositional part if in --all-sat mode).
3. the model is filtered, if in `all-sat mode` and some filter is given.
4. the filtered model is printed
5. if in `all-sat mode`, function `process_decl` is called recursively on the negation of the filtered propositional model to force the SAT to explore more branchs.

done: Would be nice to go beyond timeouts in interpretations generation (can be caused by loops due to non-linear arithmetic), and continue exploring other branches,

TODO:
- Not working with Fun_sat
- Some extensions needed in the GUI for modifications made in the frontend