### PR TITLE
Add explicit prefix in configure steps in opam files

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -33,7 +33,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/alt-ergo-lib.opam.template
+++ b/alt-ergo-lib.opam.template
@@ -6,7 +6,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/alt-ergo-parsers.opam
+++ b/alt-ergo-parsers.opam
@@ -32,7 +32,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/alt-ergo-parsers.opam.template
+++ b/alt-ergo-parsers.opam.template
@@ -6,7 +6,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/alt-ergo.opam
+++ b/alt-ergo.opam
@@ -30,7 +30,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/alt-ergo.opam.template
+++ b/alt-ergo.opam.template
@@ -7,7 +7,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/altgr-ergo.opam
+++ b/altgr-ergo.opam
@@ -32,7 +32,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/altgr-ergo.opam.template
+++ b/altgr-ergo.opam.template
@@ -6,7 +6,7 @@ license: [
 ]
 
 build: [
-  ["ocaml" "unix.cma" "configure.ml" name "--libdir" lib "--mandir" man]
+  ["ocaml" "unix.cma" "configure.ml" name "--prefix" prefix "--libdir" lib "--mandir" man]
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
This should make it so that the configure step does not need to call opam.

Should fix #463 