### PR TITLE
Added contex reinitialisation functions

### DIFF
--- a/src/bin/gui/connected_ast.ml
+++ b/src/bin/gui/connected_ast.ml
@@ -826,9 +826,7 @@ and triggers_callback t qid env sbuf ~origin:y z i =
           let menu = GMenu.menu () in
           let menu_item = GMenu.menu_item ~packing:menu#append () in
           let vbox = GPack.hbox ~packing:menu_item#add () in
-          let _ =
-            GMisc.label ~text:"Add trigger(s) ..." ~packing:vbox#add ()
-          in
+          let _ = GMisc.label ~text:"Add trigger(s) ..." ~packing:vbox#add () in
           let _ =
             GMisc.image ~stock:`ADD ~icon_size:`MENU ~packing:vbox#add ()
           in
@@ -979,18 +977,15 @@ let show_used_lemmas env expl =
   clear_used_lemmas_tags env;
   let max_mul = MTag.fold (fun _ m acc -> max acc m) ftags 0 in
   let green_0 =
-    Gdk.Color.color_parse (
-      Gui_util.dec_to_hex_color (65535*3/4) 65535 (65535*3/4)
-    )
+    Gdk.Color.color_parse
+      (Gui_util.dec_to_hex_color (65535*3/4) 65535 (65535*3/4))
   in
   List.iter (fun t -> t#set_property (`BACKGROUND_GDK green_0)) atags;
   MTag.iter (fun t m ->
       let perc = ((max_mul - m) * 65535) / max_mul in
-      let green_n = Gdk.Color.color_parse
-          (Gui_util.dec_to_hex_color
-             (perc*1/2)
-             ((perc + 2*65535) /3) (perc*1/2)
-          )
+      let green_n =
+        Gdk.Color.color_parse @@
+        Gui_util.dec_to_hex_color (perc*1/2) ((perc + 2*65535) /3) (perc*1/2)
       in
       t#set_property (`BACKGROUND_GDK green_n)) ftags;
   env.proof_tags <- ftags;

--- a/src/bin/gui/connected_ast.ml
+++ b/src/bin/gui/connected_ast.ml
@@ -826,7 +826,9 @@ and triggers_callback t qid env sbuf ~origin:y z i =
           let menu = GMenu.menu () in
           let menu_item = GMenu.menu_item ~packing:menu#append () in
           let vbox = GPack.hbox ~packing:menu_item#add () in
-          let _ = GMisc.label ~text:"Add trigger(s) ..." ~packing:vbox#add () in
+          let _ =
+            GMisc.label ~text:"Add trigger(s) ..." ~packing:vbox#add ()
+          in
           let _ =
             GMisc.image ~stock:`ADD ~icon_size:`MENU ~packing:vbox#add ()
           in
@@ -977,15 +979,18 @@ let show_used_lemmas env expl =
   clear_used_lemmas_tags env;
   let max_mul = MTag.fold (fun _ m acc -> max acc m) ftags 0 in
   let green_0 =
-    Gdk.Color.color_parse
-      (Gui_util.dec_to_hex_color (65535*3/4) 65535 (65535*3/4))
+    Gdk.Color.color_parse (
+      Gui_util.dec_to_hex_color (65535*3/4) 65535 (65535*3/4)
+    )
   in
   List.iter (fun t -> t#set_property (`BACKGROUND_GDK green_0)) atags;
   MTag.iter (fun t m ->
       let perc = ((max_mul - m) * 65535) / max_mul in
-      let green_n =
-        Gdk.Color.color_parse @@
-        Gui_util.dec_to_hex_color (perc*1/2) ((perc + 2*65535) /3) (perc*1/2)
+      let green_n = Gdk.Color.color_parse
+          (Gui_util.dec_to_hex_color
+             (perc*1/2)
+             ((perc + 2*65535) /3) (perc*1/2)
+          )
       in
       t#set_property (`BACKGROUND_GDK green_n)) ftags;
   env.proof_tags <- ftags;

--- a/src/bin/gui/gui_util.mli
+++ b/src/bin/gui/gui_util.mli
@@ -28,6 +28,7 @@
 (******************************************************************************)
 
 (** Convert RGB color given in the decimal format (red, green, blue) where
-    red, green and blue are integers between 0 and 65535 to RGB color
-    in hexadecimal format #rrrrggggbbbb where r, g, b are hexadecimal digits. *)
+    red, green and blue are integers between 0 and 65535
+    to RGB color in hexadecimal format #rrrrggggbbbb where r, g, b are
+    hexadecimal digits. *)
 val dec_to_hex_color : int -> int -> int -> string

--- a/src/bin/gui/gui_util.mli
+++ b/src/bin/gui/gui_util.mli
@@ -28,7 +28,6 @@
 (******************************************************************************)
 
 (** Convert RGB color given in the decimal format (red, green, blue) where
-    red, green and blue are integers between 0 and 65535
-    to RGB color in hexadecimal format #rrrrggggbbbb where r, g, b are
-    hexadecimal digits. *)
+    red, green and blue are integers between 0 and 65535 to RGB color
+    in hexadecimal format #rrrrggggbbbb where r, g, b are hexadecimal digits. *)
 val dec_to_hex_color : int -> int -> int -> string

--- a/src/bin/gui/main_gui.ml
+++ b/src/bin/gui/main_gui.ml
@@ -231,8 +231,10 @@ let pop_model sat_env () =
       ~hpolicy:`AUTOMATIC
       ~packing:pop_w#vbox#add () in
   let buf1 = GSourceView3.source_buffer () in
-  let tv1 = GSourceView3.source_view ~source_buffer:buf1 ~packing:(sw1#add)
-      ~wrap_mode:`CHAR () in
+  let tv1 =
+    GSourceView3.source_view
+      ~source_buffer:buf1 ~packing:(sw1#add) ~wrap_mode:`CHAR ()
+  in
   let _ = tv1#misc#modify_font font in
   let _ = tv1#set_editable false in
   let model_text = asprintf "%a@." (SAT.print_model ~header:false) sat_env in
@@ -1165,21 +1167,17 @@ let start_gui all_used_context =
              st_ctx annoted_ast dep actions resulting_ids in
          connect env;
 
-         let remove_ctx_button =
-           GButton.toggle_tool_button ~label:" Remove context"
-             ~stock:`CUT ~packing:toolbar#insert ()
-         in
+         let remove_ctx_button = GButton.toggle_tool_button
+             ~label:" Remove context" ~stock:`CUT ~packing:toolbar#insert () in
          ignore (
-           remove_ctx_button#connect#clicked ~callback:(remove_context env)
+           remove_ctx_button#connect#clicked ~callback:(remove_context env);
          );
-
-         let run_button = GButton.tool_button ~label:" Run Alt-Ergo"
-             ~stock:`EXECUTE () in
+         let run_button =
+           GButton.tool_button ~label:" Run Alt-Ergo" ~stock:`EXECUTE () in
          toolbar#insert run_button;
 
          let stop_button =
-           GButton.tool_button ~label:" Abort" ~stock:`STOP ()
-         in
+           GButton.tool_button ~label:" Abort" ~stock:`STOP () in
          stop_button#misc#hide ();
 
          (* TODO: Use toolbar#insert instead of insert_space *)
@@ -1195,33 +1193,27 @@ let start_gui all_used_context =
          ignore(toolbar#insert tool_item);
 
          let clean_button =
-           GButton.tool_button ~label:" Clean unused" ~stock:`CLEAR ()
-         in
+           GButton.tool_button ~label:" Clean unused" ~stock:`CLEAR () in
          toolbar#insert clean_button;
          clean_button#misc#hide ();
 
          let toolsearch =
-           GButton.toolbar
-             (*~tooltips:true*)
-             ~packing:(toolbox#pack ~fill:true)
-             ()
+           GButton.toolbar (*~tooltips:true*)
+             ~packing:(toolbox#pack ~fill:true) ()
          in
          toolsearch#set_icon_size `DIALOG;
 
          let tool_item = GButton.tool_item ~packing:toolsearch#insert () in
          let search_box =
-           GPack.hbox ~spacing:5 ~border_width:5 ~packing:tool_item#add ()
-         in
+           GPack.hbox ~spacing:5 ~border_width:5 ~packing:tool_item#add () in
          ignore(GMisc.image ~icon_size:`LARGE_TOOLBAR
                   ~stock:`FIND ~packing:search_box#add ());
          let search_entry = GEdit.entry ~packing:search_box#add () in
 
          let search_forw_button =
-           GButton.tool_button ~stock:`GO_DOWN ~packing:toolsearch#insert ()
-         in
+           GButton.tool_button ~stock:`GO_DOWN ~packing:toolsearch#insert () in
          let search_back_button =
-           GButton.tool_button ~stock:`GO_UP ~packing:toolsearch#insert ()
-         in
+           GButton.tool_button ~stock:`GO_UP ~packing:toolsearch#insert () in
 
          let found_all_tag = buf1#create_tag [`BACKGROUND "yellow"] in
          let found_tag = buf1#create_tag [`BACKGROUND "orange"] in
@@ -1275,8 +1267,7 @@ let start_gui all_used_context =
 
          ignore(run_button#connect#clicked
                   ~callback:(
-                    run
-                      run_button stop_button clean_button inst_model
+                    run run_button stop_button clean_button inst_model
                       timers_model result_image result_label thread env
                       used_context));
 

--- a/src/bin/gui/main_gui.ml
+++ b/src/bin/gui/main_gui.ml
@@ -231,10 +231,8 @@ let pop_model sat_env () =
       ~hpolicy:`AUTOMATIC
       ~packing:pop_w#vbox#add () in
   let buf1 = GSourceView3.source_buffer () in
-  let tv1 =
-    GSourceView3.source_view
-      ~source_buffer:buf1 ~packing:(sw1#add) ~wrap_mode:`CHAR ()
-  in
+  let tv1 = GSourceView3.source_view ~source_buffer:buf1 ~packing:(sw1#add)
+      ~wrap_mode:`CHAR () in
   let _ = tv1#misc#modify_font font in
   let _ = tv1#set_editable false in
   let model_text = asprintf "%a@." (SAT.print_model ~header:false) sat_env in
@@ -1167,17 +1165,21 @@ let start_gui all_used_context =
              st_ctx annoted_ast dep actions resulting_ids in
          connect env;
 
-         let remove_ctx_button = GButton.toggle_tool_button
-             ~label:" Remove context" ~stock:`CUT ~packing:toolbar#insert () in
+         let remove_ctx_button =
+           GButton.toggle_tool_button ~label:" Remove context"
+             ~stock:`CUT ~packing:toolbar#insert ()
+         in
          ignore (
-           remove_ctx_button#connect#clicked ~callback:(remove_context env);
+           remove_ctx_button#connect#clicked ~callback:(remove_context env)
          );
-         let run_button =
-           GButton.tool_button ~label:" Run Alt-Ergo" ~stock:`EXECUTE () in
+
+         let run_button = GButton.tool_button ~label:" Run Alt-Ergo"
+             ~stock:`EXECUTE () in
          toolbar#insert run_button;
 
          let stop_button =
-           GButton.tool_button ~label:" Abort" ~stock:`STOP () in
+           GButton.tool_button ~label:" Abort" ~stock:`STOP ()
+         in
          stop_button#misc#hide ();
 
          (* TODO: Use toolbar#insert instead of insert_space *)
@@ -1193,27 +1195,33 @@ let start_gui all_used_context =
          ignore(toolbar#insert tool_item);
 
          let clean_button =
-           GButton.tool_button ~label:" Clean unused" ~stock:`CLEAR () in
+           GButton.tool_button ~label:" Clean unused" ~stock:`CLEAR ()
+         in
          toolbar#insert clean_button;
          clean_button#misc#hide ();
 
          let toolsearch =
-           GButton.toolbar (*~tooltips:true*)
-             ~packing:(toolbox#pack ~fill:true) ()
+           GButton.toolbar
+             (*~tooltips:true*)
+             ~packing:(toolbox#pack ~fill:true)
+             ()
          in
          toolsearch#set_icon_size `DIALOG;
 
          let tool_item = GButton.tool_item ~packing:toolsearch#insert () in
          let search_box =
-           GPack.hbox ~spacing:5 ~border_width:5 ~packing:tool_item#add () in
+           GPack.hbox ~spacing:5 ~border_width:5 ~packing:tool_item#add ()
+         in
          ignore(GMisc.image ~icon_size:`LARGE_TOOLBAR
                   ~stock:`FIND ~packing:search_box#add ());
          let search_entry = GEdit.entry ~packing:search_box#add () in
 
          let search_forw_button =
-           GButton.tool_button ~stock:`GO_DOWN ~packing:toolsearch#insert () in
+           GButton.tool_button ~stock:`GO_DOWN ~packing:toolsearch#insert ()
+         in
          let search_back_button =
-           GButton.tool_button ~stock:`GO_UP ~packing:toolsearch#insert () in
+           GButton.tool_button ~stock:`GO_UP ~packing:toolsearch#insert ()
+         in
 
          let found_all_tag = buf1#create_tag [`BACKGROUND "yellow"] in
          let found_tag = buf1#create_tag [`BACKGROUND "orange"] in
@@ -1267,7 +1275,8 @@ let start_gui all_used_context =
 
          ignore(run_button#connect#clicked
                   ~callback:(
-                    run run_button stop_button clean_button inst_model
+                    run
+                      run_button stop_button clean_button inst_model
                       timers_model result_image result_label thread env
                       used_context));
 

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1987,7 +1987,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     Shostak.Combine.reinit_cache ();
     Uf.reinit_cache ()
 
-  let _ =
+  let () =
     Steps.save_steps ();
     Var.save_cnt ();
     Expr.save_cache ();

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1969,20 +1969,30 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     {env with tbox = Th.assume_th_elt env.tbox th_elt dep}
 
   let reinit_ctx () =
+    all_models_sat_env := None;
+    latest_saved_env := None;
+    terminated_normally := false;
+    Steps.reinit_steps ();
     clear_instances_cache ();
-    reset_refs ();
-    Th.reset_cpt ();
-    Symbols.reset_fresh_sy_cpt ();
+    Th.reinit_cpt ();
+    Symbols.reinit_fresh_sy_cpt ();
     Symbols.clear_labels ();
-    Var.reset_cnt ();
-    Satml_types.Flat_Formula.reset_cpt ();
+    Var.reinit_cnt ();
+    Satml_types.Flat_Formula.reinit_cpt ();
     Ty.reinit_decls ();
-    IntervalCalculus.reinit ();
-    Inst.reset_em_cache ();
-    (* the following four calls must be done in that order *)
-    Expr.reinit ();
-    Hstring.reinit ();
-    Shostak.Combine.empty_cache ();
-    Uf.reinit ()
+    IntervalCalculus.reinit_cache ();
+    Inst.reinit_em_cache ();
+    Expr.reinit_cache ();
+    Hstring.reinit_cache ();
+    Shostak.Combine.reinit_cache ();
+    Uf.reinit_cache ()
+
+  let _ =
+    Steps.save_steps ();
+    Var.save_cnt ();
+    Expr.save_cache ();
+    Hstring.save_cache ();
+    Shostak.Combine.save_cache ();
+    Uf.save_cache ()
 
 end

--- a/src/lib/reasoners/inequalities.ml
+++ b/src/lib/reasoners/inequalities.ml
@@ -79,6 +79,8 @@ module type S = sig
     ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
+  val reset_age_cpt : unit -> unit
+
 end
 
 module type Container_SIG = sig
@@ -352,6 +354,9 @@ module Container : Container_SIG = struct
       failwith msg
 
     let available = fourierMotzkin
+
+    let reset_age_cpt () =
+      age_cpt := Z.zero
 
   end
 end

--- a/src/lib/reasoners/inequalities.mli
+++ b/src/lib/reasoners/inequalities.mli
@@ -71,6 +71,9 @@ module type S = sig
     ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
+  val reset_age_cpt : unit -> unit
+  (** Resets the age counter to zero *)
+
 end
 
 

--- a/src/lib/reasoners/instances.ml
+++ b/src/lib/reasoners/instances.ml
@@ -75,6 +75,8 @@ module type S = sig
   val matching_terms_info :
     t -> Matching_types.info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t
 
+  val reset_em_cache : unit -> unit
+
 end
 
 module Make(X : Theory.S) : S with type tbox = X.t = struct
@@ -470,5 +472,7 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     else m_predicates env tbox selector ilvl mconf
 
   let matching_terms_info env = EM.terms_info env.matching
+
+  let reset_em_cache () = EM.reinit_caches ()
 
 end

--- a/src/lib/reasoners/instances.ml
+++ b/src/lib/reasoners/instances.ml
@@ -75,7 +75,7 @@ module type S = sig
   val matching_terms_info :
     t -> Matching_types.info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t
 
-  val reset_em_cache : unit -> unit
+  val reinit_em_cache : unit -> unit
 
 end
 
@@ -473,6 +473,6 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
 
   let matching_terms_info env = EM.terms_info env.matching
 
-  let reset_em_cache () = EM.reinit_caches ()
+  let reinit_em_cache () = EM.reinit_caches ()
 
 end

--- a/src/lib/reasoners/instances.mli
+++ b/src/lib/reasoners/instances.mli
@@ -70,6 +70,9 @@ module type S = sig
   val matching_terms_info :
     t -> Matching_types.info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t
 
+  val reset_em_cache : unit -> unit
+  (** Empties the e-matching functor instance's inner cache *)
+
 end
 
 module Make (X : Theory.S) : S with type tbox = X.t

--- a/src/lib/reasoners/instances.mli
+++ b/src/lib/reasoners/instances.mli
@@ -70,8 +70,8 @@ module type S = sig
   val matching_terms_info :
     t -> Matching_types.info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t
 
-  val reset_em_cache : unit -> unit
-  (** Empties the e-matching functor instance's inner cache *)
+  val reinit_em_cache : unit -> unit
+  (** Reinitializes the E-matching functor instance's inner cache *)
 
 end
 

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2503,6 +2503,6 @@ let instantiate ~do_syntactic_matching env uf selector =
       raise e
   else instantiate ~do_syntactic_matching env uf selector
 
-let reinit () =
+let reinit_cache () =
   Oracle.reset_age_cpt ();
   EM.reinit_caches ()

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2502,3 +2502,7 @@ let instantiate ~do_syntactic_matching env uf selector =
       Timers.exec_timer_pause Timers.M_Arith Timers.F_instantiate;
       raise e
   else instantiate ~do_syntactic_matching env uf selector
+
+let reinit () =
+  Oracle.reset_age_cpt ();
+  EM.reinit_caches ()

--- a/src/lib/reasoners/intervalCalculus.mli
+++ b/src/lib/reasoners/intervalCalculus.mli
@@ -28,6 +28,6 @@
 
 include Sig_rel.RELATION
 
-val reinit : unit -> unit
-(** Empties the e-matching functor instance's inner cache
+val reinit_cache : unit -> unit
+(** Reinitializes the E-matching functor instance's inner cache
     And resets the Inequalities module counter to zero *)

--- a/src/lib/reasoners/intervalCalculus.mli
+++ b/src/lib/reasoners/intervalCalculus.mli
@@ -27,3 +27,7 @@
 (******************************************************************************)
 
 include Sig_rel.RELATION
+
+val reinit : unit -> unit
+(** Empties the e-matching functor instance's inner cache
+    And resets the Inequalities module counter to zero *)

--- a/src/lib/reasoners/matching.mli
+++ b/src/lib/reasoners/matching.mli
@@ -48,6 +48,9 @@ module type S = sig
   val query :
     Util.matching_env -> t -> theory -> (trigger_info * gsubst list) list
 
+  val reinit_caches : unit -> unit
+  (** Empties the e-matching caches *)
+
 end
 
 

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -69,6 +69,11 @@ module type S = sig
   val print_model : header:bool -> Format.formatter -> t -> unit
 
   val reset_refs : unit -> unit
+
+  (** [reinit_ctx ()] reinitializes the resolution context.
+      The order in which the calls are done is important. *)
+  val reinit_ctx : unit -> unit
+
 end
 
 

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -70,8 +70,7 @@ module type S = sig
 
   val reset_refs : unit -> unit
 
-  (** [reinit_ctx ()] reinitializes the solving context.
-      The order in which the calls are done is important. *)
+  (** [reinit_ctx ()] reinitializes the solving context. *)
   val reinit_ctx : unit -> unit
 
 end

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -70,7 +70,7 @@ module type S = sig
 
   val reset_refs : unit -> unit
 
-  (** [reinit_ctx ()] reinitializes the resolution context.
+  (** [reinit_ctx ()] reinitializes the solving context.
       The order in which the calls are done is important. *)
   val reinit_ctx : unit -> unit
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -70,6 +70,11 @@ module type S = sig
   val print_model : header:bool -> Format.formatter -> t -> unit
 
   val reset_refs : unit -> unit
+
+  (** [reinit_ctx ()] reinitializes the resolution context.
+      The order in which the calls are done is important. *)
+  val reinit_ctx : unit -> unit
+
 end
 
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -71,7 +71,7 @@ module type S = sig
 
   val reset_refs : unit -> unit
 
-  (** [reinit_ctx ()] reinitializes the resolution context.
+  (** [reinit_ctx ()] reinitializes the solving context.
       The order in which the calls are done is important. *)
   val reinit_ctx : unit -> unit
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -71,8 +71,7 @@ module type S = sig
 
   val reset_refs : unit -> unit
 
-  (** [reinit_ctx ()] reinitializes the solving context.
-      The order in which the calls are done is important. *)
+  (** [reinit_ctx ()] reinitializes the solving context. *)
   val reinit_ctx : unit -> unit
 
 end

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1159,6 +1159,22 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     SAT.assume_th_elt env.satml th_elt dep;
     env
 
+  let reinit_ctx () =
+    reset_refs ();
+    Th.reset_cpt ();
+    Symbols.reset_fresh_sy_cpt ();
+    Symbols.clear_labels ();
+    Var.reset_cnt ();
+    Satml_types.Flat_Formula.reset_cpt ();
+    Ty.reinit_decls ();
+    IntervalCalculus.reinit ();
+    Inst.reset_em_cache ();
+    (* the following four calls must be done in that order *)
+    Expr.reinit ();
+    Hstring.reinit ();
+    Shostak.Combine.empty_cache ();
+    Uf.reinit ()
+
 end
 
 (*

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1160,20 +1160,27 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     env
 
   let reinit_ctx () =
-    reset_refs ();
-    Th.reset_cpt ();
-    Symbols.reset_fresh_sy_cpt ();
+    Steps.reinit_steps ();
+    Th.reinit_cpt ();
+    Symbols.reinit_fresh_sy_cpt ();
     Symbols.clear_labels ();
-    Var.reset_cnt ();
-    Satml_types.Flat_Formula.reset_cpt ();
+    Var.reinit_cnt ();
+    Satml_types.Flat_Formula.reinit_cpt ();
     Ty.reinit_decls ();
-    IntervalCalculus.reinit ();
-    Inst.reset_em_cache ();
-    (* the following four calls must be done in that order *)
-    Expr.reinit ();
-    Hstring.reinit ();
-    Shostak.Combine.empty_cache ();
-    Uf.reinit ()
+    IntervalCalculus.reinit_cache ();
+    Inst.reinit_em_cache ();
+    Expr.reinit_cache ();
+    Hstring.reinit_cache ();
+    Shostak.Combine.reinit_cache ();
+    Uf.reinit_cache ()
+
+  let _ =
+    Steps.save_steps ();
+    Var.save_cnt ();
+    Expr.save_cache ();
+    Hstring.save_cache ();
+    Shostak.Combine.save_cache ();
+    Uf.save_cache ()
 
 end
 

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1174,7 +1174,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     Shostak.Combine.reinit_cache ();
     Uf.reinit_cache ()
 
-  let _ =
+  let () =
     Steps.save_steps ();
     Var.save_cnt ();
     Expr.save_cache ();

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -121,8 +121,8 @@ struct
   let save_cache () =
     HC.save_cache ()
 
-    let reinit_cache () =
-      HC.reinit_cache ()
+  let reinit_cache () =
+    HC.reinit_cache ()
 
   let hcons v = HC.make v
 

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -752,8 +752,8 @@ module Combine = struct
       empty_cache ();
       H.clear cache;
       (* the next line is necessary to reset the cache and Hconsing cache to
-        their initial states. It has to be done after reinitialising
-        the Expr and Symbols modules *)
+         their initial states. It has to be done after reinitialising
+         the Expr and Symbols modules *)
       ignore @@ make (Expr.mk_term (Symbols.name "@bottom") [] Ty.Tint)
     in
     make, empty

--- a/src/lib/reasoners/sig.mli
+++ b/src/lib/reasoners/sig.mli
@@ -94,8 +94,11 @@ end
 module type X = sig
   type r
 
-  val empty_cache : unit -> unit
-  (** empties the module's cache *)
+  val save_cache : unit -> unit
+  (** saves the module's current cache *)
+
+  val reinit_cache : unit -> unit
+  (** restores the module's cache *)
 
   val make : Expr.t -> r * Expr.t list
 

--- a/src/lib/reasoners/sig.mli
+++ b/src/lib/reasoners/sig.mli
@@ -94,6 +94,9 @@ end
 module type X = sig
   type r
 
+  val empty_cache : unit -> unit
+  (** empties the module's cache *)
+
   val make : Expr.t -> r * Expr.t list
 
   val type_info : r -> Ty.t

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -75,6 +75,8 @@ module type S = sig
 
   val get_assumed : t -> E.Set.t
 
+  val reset_cpt : unit -> unit
+
 end
 
 module Main_Default : S = struct
@@ -216,9 +218,9 @@ module Main_Default : S = struct
       print_types_decls ~header types;
       print_logics ~header logics
 
-    let assumed =
+    let assumed, reset_cpt =
       let cpt = ref 0 in
-      fun l ->
+      let assumed l =
         if get_debug_cc () then begin
           print_dbg ~module_name:"Theory" ~function_name:"assumed"
             "Assumed facts (in this order):";
@@ -246,6 +248,11 @@ module Main_Default : S = struct
             ) (List.rev l);
           print_dbg ~header:false "false";
         end
+      in
+      let reset_cpt () =
+        cpt := 0
+      in
+      assumed, reset_cpt
 
     let theory_of k = match k with
       | Th_util.Th_arith  -> "Th_arith "
@@ -745,6 +752,9 @@ module Main_Default : S = struct
 
   let get_assumed env = env.assumed_set
 
+  let reset_cpt () =
+    Debug.reset_cpt ()
+
 end
 
 module Main_Empty : S = struct
@@ -780,4 +790,7 @@ module Main_Empty : S = struct
   let assume_th_elt e _ _ = e
   let theories_instances ~do_syntactic_matching:_ _ e _ _ _ = e, []
   let get_assumed env = env.assumed_set
+
+  let reset_cpt () = ()
+
 end

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -75,7 +75,7 @@ module type S = sig
 
   val get_assumed : t -> E.Set.t
 
-  val reset_cpt : unit -> unit
+  val reinit_cpt : unit -> unit
 
 end
 
@@ -218,7 +218,7 @@ module Main_Default : S = struct
       print_types_decls ~header types;
       print_logics ~header logics
 
-    let assumed, reset_cpt =
+    let assumed, reinit_cpt =
       let cpt = ref 0 in
       let assumed l =
         if get_debug_cc () then begin
@@ -249,10 +249,10 @@ module Main_Default : S = struct
           print_dbg ~header:false "false";
         end
       in
-      let reset_cpt () =
+      let reinit_cpt () =
         cpt := 0
       in
-      assumed, reset_cpt
+      assumed, reinit_cpt
 
     let theory_of k = match k with
       | Th_util.Th_arith  -> "Th_arith "
@@ -752,8 +752,8 @@ module Main_Default : S = struct
 
   let get_assumed env = env.assumed_set
 
-  let reset_cpt () =
-    Debug.reset_cpt ()
+  let reinit_cpt () =
+    Debug.reinit_cpt ()
 
 end
 
@@ -791,6 +791,6 @@ module Main_Empty : S = struct
   let theories_instances ~do_syntactic_matching:_ _ e _ _ _ = e, []
   let get_assumed env = env.assumed_set
 
-  let reset_cpt () = ()
+  let reinit_cpt () = ()
 
 end

--- a/src/lib/reasoners/theory.mli
+++ b/src/lib/reasoners/theory.mli
@@ -59,8 +59,8 @@ module type S = sig
 
   val get_assumed : t -> Expr.Set.t
 
-  val reset_cpt : unit -> unit
-  (** resets the counter to zero *)
+  val reinit_cpt : unit -> unit
+  (** reinitializes the counter to zero *)
 
 end
 

--- a/src/lib/reasoners/theory.mli
+++ b/src/lib/reasoners/theory.mli
@@ -58,6 +58,10 @@ module type S = sig
     int -> int -> t * Sig_rel.instances
 
   val get_assumed : t -> Expr.Set.t
+
+  val reset_cpt : unit -> unit
+  (** resets the counter to zero *)
+
 end
 
 module Main_Default : S

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -1280,3 +1280,8 @@ let output_concrete_model ({ make; _ } as env) =
       SMT2LikeModelOutput.output_arrays_model arrays;
       Printer.print_fmt (get_fmt_mdl ()) ")";
     end
+
+let reinit () =
+  LX.reinit ();
+  (* the next line is necessary to put the module back to its initial state *)
+  (ignore @@ distinct (empty ()) [X.bot () ;X.top ()] Ex.empty)

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -1281,7 +1281,9 @@ let output_concrete_model ({ make; _ } as env) =
       Printer.print_fmt (get_fmt_mdl ()) ")";
     end
 
-let reinit () =
-  LX.reinit ();
-  (* the next line is necessary to put the module back to its initial state *)
-  (ignore @@ distinct (empty ()) [X.bot () ;X.top ()] Ex.empty)
+let save_cache () =
+  LX.save_cache ()
+
+let reinit_cache () =
+  LX.reinit_cache ()
+

--- a/src/lib/reasoners/uf.mli
+++ b/src/lib/reasoners/uf.mli
@@ -67,3 +67,6 @@ val is_normalized : t -> r -> bool
 
 val assign_next : t -> (r Xliteral.view * bool * Th_util.lit_origin) list * t
 val output_concrete_model : t -> unit
+
+val reinit : unit -> unit
+(** reintialises the module *)

--- a/src/lib/reasoners/uf.mli
+++ b/src/lib/reasoners/uf.mli
@@ -68,5 +68,8 @@ val is_normalized : t -> r -> bool
 val assign_next : t -> (r Xliteral.view * bool * Th_util.lit_origin) list * t
 val output_concrete_model : t -> unit
 
-val reinit : unit -> unit
-(** reintialises the module *)
+val save_cache : unit -> unit
+(* saves the module's cache *)
+
+val reinit_cache : unit -> unit
+(** reinitializes the module's cache with the saved one *)

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -27,7 +27,6 @@
 (******************************************************************************)
 
 open Format
-open Hconsing
 open Options
 
 module Sy = Symbols
@@ -305,7 +304,7 @@ module H = struct
 end
 
 module Labels = Hashtbl.Make(H)
-module HC = Make(H)
+module HC = Hconsing.Make(H)
 module Hsko = Hashtbl.Make(H)
 
 module F_Htbl : Hashtbl.S with type key = t =
@@ -553,9 +552,9 @@ let type_info t = t.ty
    | _ -> true (* bool vars are terms *)
 *)
 
-let mk_binders =
+let mk_binders, reset_mk_binders_cpt =
   let cpt = ref 0 in
-  fun st ->
+  let mk_binders st =
     TSet.fold
       (fun t sym ->
          incr cpt;
@@ -563,6 +562,11 @@ let mk_binders =
          | { f = (Sy.Var _) as v; ty; _ } -> SMap.add v (ty, !cpt) sym
          | _ -> assert false
       )st SMap.empty
+  in
+  let reset_mk_binders_cpt () =
+    cpt := 0
+  in
+  mk_binders, reset_mk_binders_cpt
 
 
 let merge_vars acc b =
@@ -1305,9 +1309,9 @@ and find_particular_subst =
       end
 
 
-let apply_subst =
+let apply_subst, clear_apply_subst_cache =
   let (cache : t Msbty.t Msbt.t TMap.t ref) = ref TMap.empty in
-  fun ((sbt, sbty) as s) f ->
+  let apply_subst ((sbt, sbty) as s) f =
     let ch = !cache in
     try TMap.find f ch |> Msbt.find sbt |> Msbty.find sbty
     with Not_found ->
@@ -1316,6 +1320,11 @@ let apply_subst =
       let c_sbty = try Msbt.find sbt c_sbt with Not_found -> Msbty.empty in
       cache := TMap.add f (Msbt.add sbt (Msbty.add sbty nf c_sbty) c_sbt) ch;
       nf
+  in
+  let clear_apply_subst_cache () =
+    cache := TMap.empty
+  in
+  apply_subst, clear_apply_subst_cache
 
 let apply_subst s t =
   if Options.get_timers() then
@@ -2567,3 +2576,22 @@ type th_elt =
 
 let print_th_elt fmt t =
   Format.fprintf fmt "%s/%s: @[<hov>%a@]" t.th_name t.ax_name print t.ax_form
+
+let reinit () =
+  reset_mk_binders_cpt ();
+  clear_apply_subst_cache ();
+  Labels.clear labels;
+  (*
+    "~n:14" because of the constants initialized in:
+    expr.ml: vrai, faux, void
+    fpa_rounding.ml:
+      NearestTiesToEven, ToZero, Up, Down, NearestTiesToAway,
+      Aw, Od, No, Nz, Nd, Nu
+    ccx.ml, use.ml: one
+
+    next_id is not incremented when the "one" constant
+      is created the second time.
+    The value is not reset to 15 because the next_id is incremented in
+    the call to Hconsing.make in Shostak.Combine.empty.
+  *)
+  HC.reinit ~n:14 ()

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -319,3 +319,6 @@ val is_pure : t -> bool
 
 val const_term : t -> bool
 (** return true iff the given argument is a term without arguments *)
+
+val reinit : unit -> unit
+(** Clears the caches of the module *)

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -320,5 +320,8 @@ val is_pure : t -> bool
 val const_term : t -> bool
 (** return true iff the given argument is a term without arguments *)
 
-val reinit : unit -> unit
-(** Clears the caches of the module *)
+val save_cache: unit -> unit
+(** Saves the modules cache *)
+
+val reinit_cache: unit -> unit
+(** Reinitializes the module's cache *)

--- a/src/lib/structures/fpa_rounding.ml
+++ b/src/lib/structures/fpa_rounding.ml
@@ -264,3 +264,6 @@ let float_of_rational prec exp mode x =
 
 let round_to_integer mode q =
   Q.from_z (round_big_int (mode_of_term mode) q)
+
+let empty_cache () =
+  cache := MQ.empty

--- a/src/lib/structures/fpa_rounding.mli
+++ b/src/lib/structures/fpa_rounding.mli
@@ -65,3 +65,6 @@ val float_of_rational :
 (** [round_to_integer mode x] rounds the rational [x] to an integer
     depending on the rounding mode [mode] *)
 val round_to_integer:  Expr.t -> Numbers.Q.t -> Numbers.Q.t
+
+(** Empties the module's inner cache *)
+val empty_cache : unit -> unit

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -466,6 +466,8 @@ module type FLAT_FORMULA = sig
     Atom.atom list list ->
     Atom.atom * Atom.atom list * bool -> Atom.atom list list
 
+  val reset_cpt : unit -> unit
+
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t
 end
@@ -960,6 +962,9 @@ module Flat_Formula : FLAT_FORMULA = struct
     abstr f [] proxies_mp new_vars
 
   let get_atom hcons a = Atom.get_atom hcons.atoms a
+
+  let reset_cpt () =
+    cpt := 0
 
   module Set = Set.Make(struct type t'=t type t=t' let compare=compare end)
   module Map = Map.Make(struct type t'=t type t=t' let compare=compare end)

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -466,7 +466,7 @@ module type FLAT_FORMULA = sig
     Atom.atom list list ->
     Atom.atom * Atom.atom list * bool -> Atom.atom list list
 
-  val reset_cpt : unit -> unit
+  val reinit_cpt : unit -> unit
 
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t
@@ -963,7 +963,7 @@ module Flat_Formula : FLAT_FORMULA = struct
 
   let get_atom hcons a = Atom.get_atom hcons.atoms a
 
-  let reset_cpt () =
+  let reinit_cpt () =
     cpt := 0
 
   module Set = Set.Make(struct type t'=t type t=t' let compare=compare end)

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -144,7 +144,7 @@ module type FLAT_FORMULA = sig
     Atom.atom list list ->
     Atom.atom * Atom.atom list * bool -> Atom.atom list list
 
-  val reset_cpt : unit -> unit
+  val reinit_cpt : unit -> unit
   (** Resets to 0 the counter *)
 
   module Set : Set.S with type elt = t

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -144,6 +144,9 @@ module type FLAT_FORMULA = sig
     Atom.atom list list ->
     Atom.atom * Atom.atom list * bool -> Atom.atom list list
 
+  val reset_cpt : unit -> unit
+  (** Resets to 0 the counter *)
+
   module Set : Set.S with type elt = t
   module Map : Map.S with type key = t
 end

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -316,7 +316,7 @@ let print_clean fmt s = Format.fprintf fmt "%s" (to_string_clean s)
 let print fmt s = Format.fprintf fmt "%s" (to_string s)
 
 
-let fresh, reset_fresh_sy_cpt =
+let fresh, reinit_fresh_sy_cpt =
   let cpt = ref 0 in
   let fresh ?(is_var=false) s =
     incr cpt;
@@ -324,10 +324,10 @@ let fresh, reset_fresh_sy_cpt =
     let s = (Format.sprintf "!?__%s%i" s (!cpt)) in
     if is_var then var @@ Var.of_string s else name s
   in
-  let reset_fresh_sy_cpt () =
+  let reinit_fresh_sy_cpt () =
     cpt := 0
   in
-  fresh, reset_fresh_sy_cpt
+  fresh, reinit_fresh_sy_cpt
 
 let is_get f = equal f (Op Get)
 let is_set f = equal f (Op Set)

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -316,13 +316,18 @@ let print_clean fmt s = Format.fprintf fmt "%s" (to_string_clean s)
 let print fmt s = Format.fprintf fmt "%s" (to_string s)
 
 
-let fresh =
+let fresh, reset_fresh_sy_cpt =
   let cpt = ref 0 in
-  fun ?(is_var=false) s ->
+  let fresh ?(is_var=false) s =
     incr cpt;
     (* garder le suffixe "__" car cela influence l'ordre *)
     let s = (Format.sprintf "!?__%s%i" s (!cpt)) in
     if is_var then var @@ Var.of_string s else name s
+  in
+  let reset_fresh_sy_cpt () =
+    cpt := 0
+  in
+  fresh, reset_fresh_sy_cpt
 
 let is_get f = equal f (Op Get)
 let is_set f = equal f (Op Set)
@@ -346,6 +351,8 @@ let labels = Labels.create 107
 let add_label lbl t = Labels.replace labels t lbl
 
 let label t = try Labels.find labels t with Not_found -> Hstring.empty
+
+let clear_labels () = Labels.clear labels
 
 module Set : Set.S with type elt = t =
   Set.Make (struct type t=s let compare=compare end)

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -110,6 +110,9 @@ val print_clean : Format.formatter -> t -> unit
 
 val fresh : ?is_var:bool -> string -> t
 
+val reset_fresh_sy_cpt : unit -> unit
+(** Resets to 0 the fresh symbol counter *)
+
 val is_get : t -> bool
 val is_set : t -> bool
 
@@ -124,6 +127,9 @@ val label : t -> Hstring.t
 
 val print_bound : Format.formatter -> bound -> unit
 val string_of_bound : bound -> string
+
+val clear_labels : unit -> unit
+(** Empties the labels Hashtable *)
 
 module Set : Set.S with type elt = t
 

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -110,7 +110,7 @@ val print_clean : Format.formatter -> t -> unit
 
 val fresh : ?is_var:bool -> string -> t
 
-val reset_fresh_sy_cpt : unit -> unit
+val reinit_fresh_sy_cpt : unit -> unit
 (** Resets to 0 the fresh symbol counter *)
 
 val is_get : t -> bool

--- a/src/lib/structures/ty.ml
+++ b/src/lib/structures/ty.ml
@@ -467,6 +467,9 @@ module Decls = struct
     with Not_found ->
       Printer.print_err "%a not found" Hstring.print name;
       assert false
+
+  let reinit () = decls := MH.empty
+
 end
 
 let type_body name args = Decls.body name args
@@ -662,3 +665,5 @@ let print_subst fmt sbt =
 
 let print_full =
   fst (print_generic (Some type_body)) (Some type_body)
+
+let reinit_decls () = Decls.reinit ()

--- a/src/lib/structures/ty.mli
+++ b/src/lib/structures/ty.mli
@@ -266,3 +266,5 @@ val monomorphize: t -> t
 (** Return a monomorphized variant of the given type, where
     type variable without values have been replaced by abstract types. *)
 
+val reinit_decls : unit -> unit
+(** Empties the decls cache *)

--- a/src/lib/structures/var.ml
+++ b/src/lib/structures/var.ml
@@ -49,5 +49,7 @@ let to_string {hs ; id} =
 let print fmt v =
   fprintf fmt "%s" (to_string v)
 
+let reset_cnt () = cpt := 1
+
 module Set = Set.Make(struct type t = view let compare = compare end)
 module Map = Map.Make(struct type t = view let compare = compare end)

--- a/src/lib/structures/var.ml
+++ b/src/lib/structures/var.ml
@@ -49,7 +49,16 @@ let to_string {hs ; id} =
 let print fmt v =
   fprintf fmt "%s" (to_string v)
 
-let reset_cnt () = cpt := 1
+let save_cnt, reinit_cnt =
+  let saved_cnt = ref 0 in
+  let save_cnt () =
+    saved_cnt := !cpt
+  in
+  let reinit_cnt () =
+    cpt := !saved_cnt
+  in
+  save_cnt, reinit_cnt
+
 
 module Set = Set.Make(struct type t = view let compare = compare end)
 module Map = Map.Make(struct type t = view let compare = compare end)

--- a/src/lib/structures/var.mli
+++ b/src/lib/structures/var.mli
@@ -28,9 +28,13 @@ val print : Format.formatter -> t -> unit
 
 val to_string : t -> string
 
-val reset_cnt : unit -> unit
-(** resets the counter to 1, because after intializing the modules it is set to
-    1 when initializing the [underscore] constant in the Symbols module *)
+val save_cnt: unit -> unit
+(** Saves the values of the counter  *)
+
+val reinit_cnt: unit -> unit
+(** Reinitializes the counter to the saved value with [save_cnt], 1 if no value
+    is saved, since after the initialization of the modules [cnt] is set to 1
+    when initializing the [underscore] constant in the Symbols module *)
 
 module Map : Map.S with type key = t
 

--- a/src/lib/structures/var.mli
+++ b/src/lib/structures/var.mli
@@ -28,6 +28,10 @@ val print : Format.formatter -> t -> unit
 
 val to_string : t -> string
 
+val reset_cnt : unit -> unit
+(** resets the counter to 1, because after intializing the modules it is set to
+    1 when initializing the [underscore] constant in the Symbols module *)
+
 module Map : Map.S with type key = t
 
 module Set : Set.S with type elt = t

--- a/src/lib/structures/xliteral.ml
+++ b/src/lib/structures/xliteral.ml
@@ -87,7 +87,9 @@ module type S = sig
   val uid : t -> int
   val elements : t -> elt list
 
-  val reinit : unit -> unit
+  val save_cache : unit -> unit
+
+  val reinit_cache : unit -> unit
 
   module Map : Map.S with type key = t
   module Set : Set.S with type elt = t
@@ -322,8 +324,11 @@ module Make (X : OrderedType) : S with type elt = X.t = struct
     | PR a, _    -> [a]
     | BT (_,l), _ | EQ_LIST l, _ -> l
 
-  let reinit () =
-    HC.reinit ();
+  let save_cache () =
+    HC.save_cache ()
+
+  let reinit_cache () =
+    HC.reinit_cache ();
     Labels.clear labels
 
 end

--- a/src/lib/structures/xliteral.ml
+++ b/src/lib/structures/xliteral.ml
@@ -26,7 +26,6 @@
 (*                                                                            *)
 (******************************************************************************)
 
-open Hconsing
 open Options
 
 
@@ -87,6 +86,8 @@ module type S = sig
   val hash : t -> int
   val uid : t -> int
   val elements : t -> elt list
+
+  val reinit : unit -> unit
 
   module Map : Map.S with type key = t
   module Set : Set.S with type elt = t
@@ -227,7 +228,7 @@ module Make (X : OrderedType) : S with type elt = X.t = struct
 
   end
 
-  module H = Make(V)
+  module HC = Hconsing.Make(V)
 
   let normalize_eq_bool t1 t2 is_neg =
     if X.compare t1 (X.bot()) = 0 then Pred(t2, not is_neg)
@@ -255,7 +256,7 @@ module Make (X : OrderedType) : S with type elt = X.t = struct
 
   let make_aux av is_neg =
     let av = {value = av; uid = -1} in
-    let at = H.make av in
+    let at = HC.make av in
     if is_neg then
       {at = at; neg = is_neg; tpos = 2*at.uid+1; tneg = 2*at.uid}
     else
@@ -320,5 +321,9 @@ module Make (X : OrderedType) : S with type elt = X.t = struct
     | EQ(a,b), _ -> [a;b]
     | PR a, _    -> [a]
     | BT (_,l), _ | EQ_LIST l, _ -> l
+
+  let reinit () =
+    HC.reinit ();
+    Labels.clear labels
 
 end

--- a/src/lib/structures/xliteral.mli
+++ b/src/lib/structures/xliteral.mli
@@ -86,6 +86,10 @@ module type S = sig
   val uid : t -> int
   val elements : t -> elt list
 
+  val reinit : unit -> unit
+  (** Clears the labels hash table and empties the hashconsing functor
+      instance's cache *)
+
   module Map : Map.S with type key = t
   module Set : Set.S with type elt = t
 end

--- a/src/lib/structures/xliteral.mli
+++ b/src/lib/structures/xliteral.mli
@@ -89,7 +89,7 @@ module type S = sig
   val save_cache : unit -> unit
   (** Saves the modules cache  *)
 
-  val reinit_cnt: unit -> unit
+  val reinit_cache: unit -> unit
   (** Reinitializes the module's cache *)
 
   module Map : Map.S with type key = t

--- a/src/lib/structures/xliteral.mli
+++ b/src/lib/structures/xliteral.mli
@@ -86,9 +86,11 @@ module type S = sig
   val uid : t -> int
   val elements : t -> elt list
 
-  val reinit : unit -> unit
-  (** Clears the labels hash table and empties the hashconsing functor
-      instance's cache *)
+  val save_cache : unit -> unit
+  (** Saves the modules cache  *)
+
+  val reinit_cnt: unit -> unit
+  (** Reinitializes the module's cache *)
 
   module Map : Map.S with type key = t
   module Set : Set.S with type elt = t

--- a/src/lib/util/hconsing.ml
+++ b/src/lib/util/hconsing.ml
@@ -42,6 +42,7 @@ end
 module type S =
 sig
   type t
+  val reinit : ?n:int -> unit -> unit
   val make : t -> t
   val elements : unit -> t list
 end
@@ -61,6 +62,11 @@ struct
   let retain_list = ref []
 
   let next_id = ref 0
+
+  let reinit ?(n = 0) () =
+    next_id := n;
+    retain_list := [];
+    HWeak.clear storage
 
   let make d =
     let d = Hashed.set_id !next_id d in

--- a/src/lib/util/hconsing.mli
+++ b/src/lib/util/hconsing.mli
@@ -76,6 +76,11 @@ module type S = sig
   type t
   (** The type of value used. *)
 
+  val reinit : ?n:int -> unit -> unit
+  (** Resets the hashconsing storage, the retain_list
+      and sets the value of next_id to n which is
+      equal to zero by default *)
+
   val make : t -> t
   (** Hashcons a value [t], either returning [t], or a value equal
       to [t] that was hashconsed previously. *)

--- a/src/lib/util/hconsing.mli
+++ b/src/lib/util/hconsing.mli
@@ -76,10 +76,11 @@ module type S = sig
   type t
   (** The type of value used. *)
 
-  val reinit : ?n:int -> unit -> unit
-  (** Resets the hashconsing storage, the retain_list
-      and sets the value of next_id to n which is
-      equal to zero by default *)
+  val save_cache: unit -> unit
+  (** Saves the module's cache *)
+
+  val reinit_cache: unit -> unit
+  (** Reinitializes the module's cache *)
 
   val make : t -> t
   (** Hashcons a value [t], either returning [t], or a value equal

--- a/src/lib/util/hstring.ml
+++ b/src/lib/util/hstring.ml
@@ -30,7 +30,7 @@ open Options
 
 type t = { content : string ; id : int}
 
-module S =
+module HC =
   Hconsing.Make(struct
     type elt = t
     let hash s = Hashtbl.hash s.content
@@ -40,7 +40,7 @@ module S =
     let disable_weaks () = Options.get_disable_weaks ()
   end)
 
-let make s = S.make {content = s; id = - 1}
+let make s = HC.make {content = s; id = - 1}
 
 let view s = s.content
 
@@ -81,23 +81,11 @@ let is_fresh_skolem s =
     assert (String.compare s "index out of bounds" = 0);
     false
 
-let reinit () =
-  (*
-    "~n:25" because of the constants initialized in:
-        hstring.ml:           empty
-        ty.ml:                tunit
-        symbols.ml:           underscore, fake_eq, fake_neq, fake_lt, fake_le
-        fpa_rounding.ml:      fpa_rounding_mode (mode_constrs (x11), mode_ty),
-                              _No__rounding_mode
-        arith.ml:             mod_symb
-        intervals.ml:         is_question_mark
-        intervalCalculus.ml:  not_theory_const, is_theory_const, linear_dep
-        ccx.ml, use.ml:       one
+let save_cache () =
+  HC.save_cache ()
 
-    The value is not reset to 26 because the next_id is incremented in
-    the call to Hconsing.make in Shostak.Combine.empty.
-  *)
-  S.reinit ~n:25 ();
+let reinit_cache () =
+  HC.reinit_cache ();
   reset_fresh_string_cpt ()
 
 module Arg = struct type t'= t type t = t' let compare = compare end

--- a/src/lib/util/hstring.ml
+++ b/src/lib/util/hstring.ml
@@ -58,11 +58,16 @@ let rec list_assoc x = function
   | [] -> raise Not_found
   | (y, v) :: l -> if equal x y then v else list_assoc x l
 
-let fresh_string =
+let fresh_string, reset_fresh_string_cpt =
   let cpt = ref 0 in
-  fun () ->
+  let fresh_string () =
     incr cpt;
     "!k" ^ (string_of_int !cpt)
+  in
+  let reset_fresh_string_cpt () =
+    cpt := 0
+  in
+  fresh_string, reset_fresh_string_cpt
 
 let is_fresh_string s =
   try s.[0] == '!' && s.[1] == 'k'
@@ -75,6 +80,25 @@ let is_fresh_skolem s =
   with Invalid_argument s ->
     assert (String.compare s "index out of bounds" = 0);
     false
+
+let reinit () =
+  (*
+    "~n:25" because of the constants initialized in:
+        hstring.ml:           empty
+        ty.ml:                tunit
+        symbols.ml:           underscore, fake_eq, fake_neq, fake_lt, fake_le
+        fpa_rounding.ml:      fpa_rounding_mode (mode_constrs (x11), mode_ty),
+                              _No__rounding_mode
+        arith.ml:             mod_symb
+        intervals.ml:         is_question_mark
+        intervalCalculus.ml:  not_theory_const, is_theory_const, linear_dep
+        ccx.ml, use.ml:       one
+
+    The value is not reset to 26 because the next_id is incremented in
+    the call to Hconsing.make in Shostak.Combine.empty.
+  *)
+  S.reinit ~n:25 ();
+  reset_fresh_string_cpt ()
 
 module Arg = struct type t'= t type t = t' let compare = compare end
 module Set : Set.S with type elt = t = Set.Make(Arg)

--- a/src/lib/util/hstring.mli
+++ b/src/lib/util/hstring.mli
@@ -50,9 +50,11 @@ val is_fresh_string : string -> bool
 
 val is_fresh_skolem : string -> bool
 
-val reinit : unit -> unit
-(** Sets the module Hstring counter to 0 and empties its
-    Hachconsing functor instance *)
+val save_cache : unit -> unit
+(** Saves the module's cache *)
+
+val reinit_cache : unit -> unit
+(** Reinitializes the module's cache *)
 
 module Set : Set.S with type elt = t
 module Map : Map.S with type key = t

--- a/src/lib/util/hstring.mli
+++ b/src/lib/util/hstring.mli
@@ -50,5 +50,9 @@ val is_fresh_string : string -> bool
 
 val is_fresh_skolem : string -> bool
 
+val reinit : unit -> unit
+(** Sets the module Hstring counter to 0 and empties its
+    Hachconsing functor instance *)
+
 module Set : Set.S with type elt = t
 module Map : Map.S with type key = t

--- a/src/lib/util/steps.ml
+++ b/src/lib/util/steps.ml
@@ -130,6 +130,25 @@ let reset_steps () =
   mult_b := 0;
   mult_a := 0
 
+let save_steps, reinit_steps =
+  let saved_mult_uf = ref 0 in
+  (* only [mult_uf] is non-zero after initializing the solver modules *)
+  let save_steps () =
+    saved_mult_uf := !mult_uf
+  in
+  let reinit_steps () =
+    Stack.clear all_steps;
+    naive_steps := 0;
+    steps := 0;
+    mult_f := 0;
+    mult_m := 0;
+    mult_s := 0;
+    mult_uf := !saved_mult_uf;
+    mult_b := 0;
+    mult_a := 0
+  in
+  save_steps, reinit_steps
+
 (* Return the max steps between naive and refine steps counting. Both counter
  * are compute at execution. The first one count the number of terms sent to the
  * theories environment, the second one count steps depending of the theories

--- a/src/lib/util/steps.mli
+++ b/src/lib/util/steps.mli
@@ -57,6 +57,12 @@ val incr  : incr_kind -> unit
 val reset_steps : unit -> unit
 (** Reset the global steps counter *)
 
+val save_steps : unit -> unit
+(** Saves the step counters *)
+
+val reinit_steps : unit -> unit
+(** Reinitializes the step counters *)
+
 val get_steps : unit -> int
 (** Return the number of steps *)
 


### PR DESCRIPTION
The purpose of this PR is to add the necessary functions to allow resolution context re-initialization in Alt-Ergo.
Since Alt-Ergo internally relies on side effects through references and hash-tables, A user that uses it as a library might want to reset the resolution context to its initial state, aka the state in which the modules are after their initialization.
The current version re-initializes some of the refs with hard-coded values which is not ideal but it works.