### PR TITLE
Removed the installation of deps in ```./configure.ml``` that uses ```dune external-lib-deps ...```

### DIFF
--- a/configure.ml
+++ b/configure.ml
@@ -7,8 +7,6 @@
    - parse command line options
    - compute actual config options
    - output these config options in Makefile.config
-   - check dune is present
-   - ask dune to check the external deps
 *)
 
 (* configuration options *)
@@ -57,8 +55,8 @@ let () =
     match !pkg with
     | "" -> pkg := s
     | _ ->
-        Format.eprintf "Anonymous argument ignored: '%s'@." s;
-        exit 1
+      Format.eprintf "Anonymous argument ignored: '%s'@." s;
+      exit 1
   in
   let usage = "./configure [options]" in
   Arg.parse args anon_fun usage
@@ -136,7 +134,7 @@ let () =
 
   let () = Format.fprintf fmt {|type numbers_lib = | Nums | Zarith@.|} in
   let () = Format.fprintf fmt {|let numbers_lib = %s@.|}
-    (print_numbers_lib !numbers_lib) in
+      (print_numbers_lib !numbers_lib) in
 
   let () = Format.fprintf fmt {|
 (* Dynamic configuration, relative to the executable path *)
@@ -193,31 +191,5 @@ let () =
   let () = close_out ch in
   let () = Format.printf "done.@." in
   ()
-
-(* check that dune is present *)
-let () =
-  let cmd = Format.asprintf "which dune" in
-  let ch = Unix.open_process_in cmd in
-  let _ = read_all ch in
-  let res = Unix.close_process_in ch in
-  match res with
-  | Unix.WEXITED 0 -> Format.printf "Found dune in path.@."
-  | _ -> Format.eprintf "ERROR: Couldn't find dune in env@.";
-    exit 1
-
-(* run dune to check that dependencies are installed *)
-let () =
-  let p_opt = match !pkg with "" -> "" | s -> Format.asprintf "-p %s" s in
-  let cmd =
-    Format.asprintf
-      "dune external-lib-deps --display=quiet --missing %s @install" p_opt
-  in
-  let ch = Unix.open_process_in cmd in
-  let _ = read_all ch in
-  let res = Unix.close_process_in ch in
-  match res with
-  | Unix.WEXITED 0 -> Format.printf "All deps are installed.@."
-  (* dune already prints the missing libs on stderr *)
-  | _ -> exit 2
 
 let () = Format.printf "Good to go!@."

--- a/docs/sphinx_docs/Install/index.md
+++ b/docs/sphinx_docs/Install/index.md
@@ -45,8 +45,8 @@ To compile the sources, you will need the following libraries :
 
 To compile the GUI you will also need
 ```
-  lablgtk2
-  gtksourceview2
+  lablgtk # includes lablgtk2 and gtksourceview2
+  conf-gtksourceview
 ```
 You may need superuser permissions to perform the installation.
 


### PR DESCRIPTION
Removed the installation of deps in ```./configure.ml``` that uses ```dune external-lib-deps ...```, because dune's command line option ```external-lib-deps``` will be deprecated in the next version, and updated the list of deps in the docs.