### PR TITLE
Enable type inference for Menhir.

### DIFF
--- a/src/plugins/AB-Why3/dune
+++ b/src/plugins/AB-Why3/dune
@@ -6,7 +6,6 @@
 (ocamllex (modules why3_lexer))
 
 (menhir
-  (infer    false)
   (flags    --fixed-exception)
   (modules  why3_parser)
 )

--- a/src/plugins/AB-Why3/why3_parser.mly
+++ b/src/plugins/AB-Why3/why3_parser.mly
@@ -218,6 +218,14 @@ open Parsed
 %nonassoc prec_prefix_op
 %nonassoc OPPREF
 
+(* Type declarations. *)
+
+(* The symbol [clone_subst] is strange, as its type is underspecified:
+   it is [_ option] for an arbitrary type [_]. This can cause Menhir to
+   fail. To work around the problem, we declare an arbitrary type. The
+   symbol [use] exhibits the same problem. *)
+%type<unit option> clone_subst use
+
 (* Entry points *)
 
 %type <AltErgoLib.Parsed.lexpr list * bool> trigger_parser

--- a/src/plugins/AB-Why3/why3_parser.mly
+++ b/src/plugins/AB-Why3/why3_parser.mly
@@ -218,14 +218,6 @@ open Parsed
 %nonassoc prec_prefix_op
 %nonassoc OPPREF
 
-(* Type declarations. *)
-
-(* The symbol [clone_subst] is strange, as its type is underspecified:
-   it is [_ option] for an arbitrary type [_]. This can cause Menhir to
-   fail. To work around the problem, we declare an arbitrary type. The
-   symbol [use] exhibits the same problem. *)
-%type<unit option> clone_subst use
-
 (* Entry points *)
 
 %type <AltErgoLib.Parsed.lexpr list * bool> trigger_parser
@@ -282,21 +274,21 @@ use_clone:
 
 use:
 | boption(IMPORT) tqualid
-    { None }
+    { () }
 | boption(IMPORT) tqualid AS uident
-    { None }
+    { () }
 | EXPORT tqualid
-    { None }
+    { () }
 
 clone_subst:
-| NAMESPACE ns EQUAL ns         { None }
-| TYPE qualid ty_var* EQUAL ty  { None }
-| CONSTANT  qualid EQUAL qualid { None }
-| FUNCTION  qualid EQUAL qualid { None }
-| PREDICATE qualid EQUAL qualid { None }
-| VAL       qualid EQUAL qualid { None }
-| LEMMA     qualid              { None }
-| GOAL      qualid              { None }
+| NAMESPACE ns EQUAL ns         { () }
+| TYPE qualid ty_var* EQUAL ty  { () }
+| CONSTANT  qualid EQUAL qualid { () }
+| FUNCTION  qualid EQUAL qualid { () }
+| PREDICATE qualid EQUAL qualid { () }
+| VAL       qualid EQUAL qualid { () }
+| LEMMA     qualid              { () }
+| GOAL      qualid              { () }
 
 ns:
 | uqualid { Some $1 }


### PR DESCRIPTION
This is required for compatibility with Menhir 20211215.