### PR TITLE
Fix #504 and #509

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,26 +103,26 @@ gui: gen
 # fm-simplex plugin
 fm-simplex:
 	$(DUNE) build $(DUNE_FLAGS) \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/fm-simplex-plugin.cma \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/fm-simplex-plugin.cmxs
-	ln -sf $(INSTALL_DIR)/default/share/alt-ergo/plugins/fm-simplex-plugin.cma fm-simplex-plugin.cma
-	ln -sf $(INSTALL_DIR)/default/share/alt-ergo/plugins/fm-simplex-plugin.cmxs fm-simplex-plugin.cmxs
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/fm-simplex-plugin.cma \
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/fm-simplex-plugin.cmxs
+	ln -sf $(INSTALL_DIR)/default/lib/alt-ergo/plugins/fm-simplex-plugin.cma fm-simplex-plugin.cma
+	ln -sf $(INSTALL_DIR)/default/lib/alt-ergo/plugins/fm-simplex-plugin.cmxs fm-simplex-plugin.cmxs
 
 # Ab-Why3 plugin
 AB-Why3:
 	$(DUNE) build $(DUNE_FLAGS) \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/AB-Why3-plugin.cma \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/AB-Why3-plugin.cmxs
-	ln -sf $(INSTALL_DIR)/default/share/alt-ergo/plugins/AB-Why3-plugin.cma AB-Why3-plugin.cma
-	ln -sf $(INSTALL_DIR)/default/share/alt-ergo/plugins/AB-Why3-plugin.cmxs AB-Why3-plugin.cmxs
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/AB-Why3-plugin.cma \
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/AB-Why3-plugin.cmxs
+	ln -sf $(INSTALL_DIR)/default/lib/alt-ergo/plugins/AB-Why3-plugin.cma AB-Why3-plugin.cma
+	ln -sf $(INSTALL_DIR)/default/lib/alt-ergo/plugins/AB-Why3-plugin.cmxs AB-Why3-plugin.cmxs
 
 # Build all plugins
 plugins:
 	$(DUNE) build $(DUNE_FLAGS) \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/fm-simplex-plugin.cma \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/fm-simplex-plugin.cmxs \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/AB-Why3-plugin.cma \
-		$(INSTALL_DIR)/default/share/alt-ergo/plugins/AB-Why3-plugin.cmxs
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/fm-simplex-plugin.cma \
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/fm-simplex-plugin.cmxs \
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/AB-Why3-plugin.cma \
+		$(INSTALL_DIR)/default/lib/alt-ergo/plugins/AB-Why3-plugin.cmxs
 
 # Alias to build all targets using dune
 # Hopefully more efficient than making "all" depend

--- a/configure.ml
+++ b/configure.ml
@@ -160,7 +160,7 @@ let datadir =
   abs_exe_path
   |> Filename.dirname
   |> follow Filename.parent_dir_name
-  |> follow "share"
+  |> follow "lib"
   |> follow "alt-ergo"
 
 let pluginsdir = datadir |> follow "plugins"

--- a/docs/sphinx_docs/Usage/index.md
+++ b/docs/sphinx_docs/Usage/index.md
@@ -78,10 +78,10 @@ executable, as well as preludes and plugins, can be relocated.
 
 For instance, on a Linux system, assuming the `alt-ergo` executable is at some path
 `some/path/bin/alt-ergo`, theses directories are respectively located at
-`some/path/share/alt-ergo/plugins/` and `some/path/share/alt-ergo/preludes/`.
+`some/path/lib/alt-ergo/plugins/` and `some/path/lib/alt-ergo/preludes/`.
 On windows, a binary at path `Z:\some\path\bin\alt-ergo` will look for preludes and
-plugins in `Z:\some\path\share\alt-ergo\preludes` and
-`Z:\some\path\share\alt-ergo\plugins` respectively.
+plugins in `Z:\some\path\lib\alt-ergo\preludes` and
+`Z:\some\path\lib\alt-ergo\plugins` respectively.
 
 ## Javascript
 

--- a/non-regression/non-regression.sh
+++ b/non-regression/non-regression.sh
@@ -16,4 +16,4 @@ echo "===== [ with Tableaux-CDCL ] =============================================
 ./main_script.sh "--sat-solver Tableaux-CDCL"
 
 echo "===== [ WITH FM-SIMPLEX ] ====================================================================================";
-./main_script.sh "--inequalities-plugin `pwd`/../sources/_build/install/default/share/plugins/fm-simplex-plugin.cmxs"
+./main_script.sh "--inequalities-plugin `pwd`/../sources/_build/install/default/lib/plugins/fm-simplex-plugin.cmxs"

--- a/src/plugins/AB-Why3/dune
+++ b/src/plugins/AB-Why3/dune
@@ -18,7 +18,7 @@
 
 (install
   (package alt-ergo)
-  (section share)
+  (section lib)
   (files
     (ABWhy3Plugin.cma as plugins/AB-Why3-plugin.cma)
     (ABWhy3Plugin.cmxs as plugins/AB-Why3-plugin.cmxs)

--- a/src/plugins/fm-simplex/dune
+++ b/src/plugins/fm-simplex/dune
@@ -11,7 +11,7 @@
 
 (install
   (package alt-ergo)
-  (section share)
+  (section lib)
   (files
     (FmSimplexPlugin.cma as plugins/fm-simplex-plugin.cma)
     (FmSimplexPlugin.cmxs as plugins/fm-simplex-plugin.cmxs)

--- a/src/preludes/dune
+++ b/src/preludes/dune
@@ -1,7 +1,7 @@
 
 (install
   (package alt-ergo)
-  (section share)
+  (section lib)
   (files
     (b-set-theory-prelude-2018-09-28.ae as preludes/b-set-theory-prelude-2018-09-28.ae)
     (b-set-theory-prelude-2020-02-28.ae as preludes/b-set-theory-prelude-2020-02-28.ae)


### PR DESCRIPTION
Changing the installation section for plugins and preludes from `share` to `lib` (to fix issues #504 and #509).
If some users use the plugins and look for them in `/usr/share` they won't find them, so if this PR is merged it needs to be clearly stated in the next release that the installation section for plugins and preludes was changed.