### PR TITLE
Remove bad cases

### DIFF
--- a/src/bin/gui/main_gui.ml
+++ b/src/bin/gui/main_gui.ml
@@ -456,7 +456,6 @@ let add_inst ({ h; _ } as inst_model) orig =
     | Expr.Lemma _ | Expr.Unit _ | Expr.Clause _ | Expr.Literal _
     | Expr.Skolem _ | Expr.Let _ | Expr.Iff _ | Expr.Xor _ ->
       string_of_int id
-    | Expr.Not_a_form -> assert false
   in
   let r, n, limit, to_add =
     try

--- a/src/lib/reasoners/ccx.ml
+++ b/src/lib/reasoners/ccx.ml
@@ -128,7 +128,6 @@ module Main : S = struct
       | E.Pred _ | E.Eq _ | E.Eql _ -> Queue.push e facts.equas
       | E.Distinct _ -> Queue.push e facts.diseqs
       | E.Builtin _  -> Queue.push e facts.ineqs
-      | E.Not_a_lit _ -> assert false
 
   (*BISECT-IGNORE-BEGIN*)
   module Debug = struct
@@ -288,7 +287,6 @@ module Main : S = struct
 
   let view find va ex_a =
     match va with
-    | E.Not_a_lit _ -> assert false
     | E.Pred (t1, b) ->
       let r1, ex1 = find t1 in
       let ex = Ex.union ex1 ex_a in
@@ -502,7 +500,6 @@ module Main : S = struct
 
   let add env facts a ex =
     match E.lit_view a with
-    | E.Not_a_lit _ -> assert false
     | E.Pred (t1, _) ->
       add_term env facts t1 ex
     | E.Eq (t1, t2) ->

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -230,7 +230,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     let is_it_unsat gf =
       let s =
         match E.form_view gf.E.ff with
-        | E.Not_a_form -> assert false
         | E.Lemma _   -> "lemma"
         | E.Clause _  -> "clause"
         | E.Unit _    -> "conjunction"
@@ -265,16 +264,15 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
           ~module_name:"Fun_sat" ~function_name:"assume"
           "at level (%d, %d) I assume a @ " env.dlevel env.plevel;
         begin match E.form_view f with
-          | E.Not_a_form -> assert false
           | E.Literal a ->
             let n = match lem with
               | None -> ""
-              | Some ff ->
-                (match E.form_view ff with
-                 | E.Lemma xx -> xx.E.name
-                 | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-                 | E.Let _ | E.Iff _ | E.Xor _ -> ""
-                 | E.Not_a_form -> assert false)
+              | Some ff -> begin
+                  match E.form_view ff with
+                  | E.Lemma xx -> xx.E.name
+                  | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
+                  | E.Let _ | E.Iff _ | E.Xor _ -> ""
+                end
             in
             print_dbg ~header:false
               "LITERAL (%s : %a) %a@ "
@@ -419,7 +417,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       | E.Lemma _ -> env.add_inst orig
       | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
       | E.Let _ | E.Iff _ | E.Xor _ -> true
-      | E.Not_a_form -> assert false
     end
 
   let inst_predicates mconf env inst tbox selector ilvl =
@@ -443,7 +440,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     | E.Literal _ -> true
     | E.Unit _ | E.Clause _ | E.Lemma _ | E.Skolem _
     | E.Let _ | E.Iff _ | E.Xor _ -> false
-    | E.Not_a_form -> assert false
 
   let extract_prop_model ~complete_model t =
     let s = ref SE.empty in
@@ -625,7 +621,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
              Profiling.conflicting_instance name loc
            | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
            | E.Let _ | E.Iff _ | E.Xor _ -> ()
-           | E.Not_a_form -> assert false
         )(Ex.formulas_of exp)
 
   let do_case_split env origin =
@@ -713,7 +708,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       ans
     | E.Unit _ | E.Clause _ | E.Lemma _ | E.Skolem _
     | E.Let _ | E.Iff _ | E.Xor _ -> None
-    | E.Not_a_form -> assert false
 
   let red tcp_cache tmp_cache ff env tcp =
     let nf = E.neg ff.E.ff in
@@ -736,7 +730,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
           ans, false
         | E.Unit _ | E.Clause _ | E.Lemma _ | E.Skolem _
         | E.Let _ | E.Iff _ | E.Xor _ -> None, false
-        | E.Not_a_form -> assert false
 
   let red tcp_cache tmp_cache ff env tcp =
     match red tcp_cache tmp_cache ff env tcp with
@@ -764,7 +757,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       if Options.get_unsat_core () then Ex.union (Ex.singleton (Ex.Dep f)) dep
       else dep
     | E.Unit _ | E.Lemma _ | E.Skolem _ | E.Let _ | E.Iff _ | E.Xor _ -> dep
-    | E.Not_a_form -> assert false
 
   let rec add_dep_of_formula f dep =
     let dep = add_dep f dep in
@@ -774,7 +766,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       else add_dep_of_formula f2 (add_dep_of_formula f1 dep)
     | E.Lemma _ | E.Clause _ | E.Literal _ | E.Skolem _
     | E.Let _ | E.Iff _ | E.Xor _ -> dep
-    | E.Not_a_form -> assert false
 
   (* currently:
      => this is not done modulo theories
@@ -980,7 +971,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
           in
           let env = update_nb_related env ff in
           match E.form_view f with
-          | E.Not_a_form -> assert false
           | E.Iff (f1, f2) ->
             let id = E.id f in
             let g = E.elim_iff f1 f2 id ~with_conj:true in
@@ -1259,8 +1249,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
              Printer.print_err "Currently, arbitrary formulas in Hyps \
                                 are not Th-reduced";
              assert false
-           | E.Not_a_form ->
-             assert false
         )(dep, acc) hyp
     in
     (gf, dep) :: acc
@@ -1268,7 +1256,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let does_not_contain_a_disjunction =
     let rec aux f =
       match E.form_view f with
-      | E.Not_a_form -> assert false
       | E.Literal _ -> true
       | E.Unit(f1, f2) -> aux f1 && aux f2
       | E.Clause _ | E.Iff _ | E.Xor _ -> false

--- a/src/lib/reasoners/instances.ml
+++ b/src/lib/reasoners/instances.ml
@@ -127,7 +127,6 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
           | E.Lemma { E.name = s; _ } -> s
           | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
           | E.Let _ | E.Iff _ | E.Xor _ -> "!(no-name)"
-          | E.Not_a_form -> assert false
         in
         print_dbg
           ~module_name:"Instances" ~function_name:"new_facts_of_axiom"
@@ -196,7 +195,7 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
         predicates = ME.add f (guard, age, ex) env.predicates;
         guards = ME.add guard ((f, false) :: guarded) env.guards
       }
-    | E.Not_a_form | E.Unit _ | E.Clause _ | E.Xor _
+    | E.Unit _ | E.Clause _ | E.Xor _
     | E.Skolem _ | E.Let _ ->
       assert false
 
@@ -228,7 +227,7 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     | E.Lemma { E.name; loc; _ } ->
       Profiling.new_instance_of name f loc accepted
     | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-    | E.Let _ | E.Iff _ | E.Xor _ | E.Not_a_form -> assert false
+    | E.Let _ | E.Iff _ | E.Xor _ -> assert false
 
   let profile_produced_terms env lorig nf s trs =
     let st0 =
@@ -238,7 +237,7 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     let name, loc, _ = match Expr.form_view lorig with
       | E.Lemma { E.name; main; loc; _ } -> name, loc, main
       | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-      | E.Let _ | E.Iff _ | E.Xor _ | E.Not_a_form -> assert false
+      | E.Let _ | E.Iff _ | E.Xor _ -> assert false
     in
     let st1 = E.max_ground_terms_rec_of_form nf in
     let diff = Expr.Set.diff st1 st0 in
@@ -355,7 +354,6 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
       | E.Unit(f1,f2) -> max (size f1) (size f2)
       | E.Lemma _ | E.Clause _ | E.Literal _ | E.Skolem _
       | E.Let _ | E.Iff _ | E.Xor _ -> E.size f
-      | E.Not_a_form -> assert false
     in
     fun lf ->
       List.fast_sort

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2259,7 +2259,7 @@ let record_this_instance f accepted lorig =
     | E.Lemma { E.name; loc; _ } ->
       Profiling.new_instance_of name f loc accepted
     | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-    | E.Let _ | E.Iff _ | E.Xor _ | E.Not_a_form -> assert false
+    | E.Let _ | E.Iff _ | E.Xor _ -> assert false
 
 let profile_produced_terms menv lorig nf s trs =
   if Options.get_profiling() then
@@ -2270,7 +2270,7 @@ let profile_produced_terms menv lorig nf s trs =
     let name, loc, _ = match E.form_view lorig with
       | E.Lemma { E.name; main; loc; _ } -> name, loc, main
       | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-      | E.Let _ | E.Iff _ | E.Xor _ | E.Not_a_form -> assert false
+      | E.Let _ | E.Iff _ | E.Xor _ -> assert false
     in
     let st1 = E.max_ground_terms_rec_of_form nf in
     let diff = SE.diff st1 st0 in
@@ -2440,7 +2440,7 @@ let separate_semantic_triggers =
       match E.form_view th_form with
       | E.Lemma q -> q
       | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-      | E.Let _ | E.Iff _ | E.Xor _ | E.Not_a_form -> assert false
+      | E.Let _ | E.Iff _ | E.Xor _ -> assert false
     in
     let r_triggers =
       List.rev_map

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -691,7 +691,7 @@ module Make (X : Arg) : S with type theory = X.t = struct
              ) env tgs
 
          | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-         | E.Let _ | E.Iff _ | E.Xor _ | E.Not_a_form -> assert false
+         | E.Let _ | E.Iff _ | E.Xor _ -> assert false
       ) formulas env
 
   let terms_info env = env.info, env.fils

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -115,8 +115,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       let { E.ff = f; lem; from_terms = terms; _ } = gf in
       if Options.get_debug_sat () then begin
         match E.form_view f with
-        | E.Not_a_form -> assert false
-
         | E.Unit _ -> ()
 
         | E.Clause _ ->
@@ -131,12 +129,12 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
         | E.Literal a ->
           let n = match lem with
             | None -> ""
-            | Some ff ->
-              (match E.form_view ff with
-               | E.Lemma xx -> xx.E.name
-               | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-               | E.Let _ | E.Iff _ | E.Xor _ -> ""
-               | E.Not_a_form -> assert false)
+            | Some ff -> begin
+                match E.form_view ff with
+                | E.Lemma xx -> xx.E.name
+                | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
+                | E.Let _ | E.Iff _ | E.Xor _ -> ""
+              end
           in
           print_dbg ~module_name:"Satml_frontend" ~function_name:"assume"
             "@[<v 0>I assume a literal (%s : %a) %a@,\
@@ -329,7 +327,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       | E.Lemma _ -> env.add_inst orig
       | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
       | E.Let _ | E.Iff _ | E.Xor _ -> true
-      | E.Not_a_form -> assert false
     end
 
   (* <begin> copied from sat_solvers.ml *)
@@ -464,7 +461,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       let ded = match E.neg f |> E.form_view with
         | E.Skolem q -> E.skolemize q
         | E.Unit _ | E.Clause _ | E.Literal _ | E.Lemma _
-        | E.Let _ | E.Iff _ | E.Xor _ | E.Not_a_form -> assert false
+        | E.Let _ | E.Iff _ | E.Xor _ -> assert false
       in
       (*XXX TODO: internal skolems*)
       let f = E.mk_or lat ded false 0 in
@@ -750,7 +747,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
           (* This assert is not true assert (dec_lvl = 0); *)
           axiom_def env gf Ex.empty, {acc with updated = true}
 
-        | E.Not_a_form -> assert false
         | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
         | E.Let _ | E.Iff _ | E.Xor _ ->
           let ff, axs, new_vars =

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -526,7 +526,6 @@ module Main_Default : S = struct
          match a with
          | LTerm r -> begin
              match E.lit_view r with
-             | E.Not_a_lit _ -> assert false
              | E.Eq (t1, t2) ->
                SE.add t1 (SE.add t2 acc)
              | E.Eql l | E.Distinct l | E.Builtin (_, _, l) ->

--- a/src/lib/structures/explanation.ml
+++ b/src/lib/structures/explanation.ml
@@ -155,7 +155,6 @@ let bj_formulas_of s =
     ) s E.Set.empty
 
 let rec literals_of_acc lit fs f acc = match E.form_view f with
-  | E.Not_a_form -> assert false
   | E.Literal _ ->
     if lit then f :: acc else acc
   | E.Iff(f1, f2) ->

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2226,7 +2226,11 @@ module Triggers = struct
          }
       ) l
 
-  let is_literal e = try let _ = lit_view e in true with Failure _ -> false
+  (* Should return false iff lit_view fails with Failure _, but this version
+     does not build the literal view. *)
+  let is_literal e =
+    e.ty == Ty.Tbool &&
+    match e.f with Sy.Form _ -> false | _ -> true
 
   let trs_in_scope full_trs f =
     STRS.filter

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -123,7 +123,6 @@ type form_view =
   | Lemma of quantified   (* a lemma *)
   | Skolem of quantified  (* lazy skolemization *)
   | Let of letin (* a binding of an expr *)
-  | Not_a_form
 
 
 (** Comparison and hashing functions *)
@@ -307,48 +306,6 @@ module F_Htbl : Hashtbl.S with type key = t =
     let equal = equal
   end)
 
-(** different views of an expression *)
-
-let lit_view t =
-  let { f; xs; ty; _ } = t in
-  if ty != Ty.Tbool then
-    Util.failwith "Calling lit_view on a non boolean expression"
-  else
-    match f with
-    | Sy.Form _  ->
-      Util.failwith "Calling lit_view on a formula"
-    | Sy.Lit lit ->
-      begin match lit, xs with
-        | (Sy.L_eq | Sy.L_neg_eq), ([] | [_]) -> assert false
-        | Sy.L_eq, [a;b] -> Eq (a, b)
-        | Sy.L_eq, l     -> Eql l
-        | Sy.L_neg_eq, l -> Distinct l
-        | Sy.L_built x, l -> Builtin(true, x, l)
-        | Sy.L_neg_built x, l -> Builtin(false, x, l)
-        | Sy.L_neg_pred, [a] -> Pred(a, true)
-        | Sy.L_neg_pred, _ -> assert false
-      end
-    | _ -> Pred(t, false)
-
-let form_view t =
-  let { f; xs; bind; _ } = t in
-  if t.ty != Ty.Tbool then Not_a_form
-  else
-    match f, xs, bind with
-    | Sy.Form (Sy.F_Unit _), [a;b], _ -> Unit (a, b)
-    | Sy.Form (Sy.F_Clause i), [a;b], _ -> Clause (a, b, i)
-    | Sy.Form Sy.F_Iff, [a;b], _ -> Iff(a, b)
-    | Sy.Form Sy.F_Xor, [a;b], _ -> Xor(a, b)
-    | Sy.Form Sy.F_Lemma, [], B_lemma lem -> Lemma lem
-    | Sy.Form Sy.F_Skolem, [], B_skolem sko -> Skolem sko
-    | Sy.Lit (Sy.L_eq | Sy.L_neg_eq | Sy.L_neg_pred |
-              Sy.L_built _ | Sy.L_neg_built _), _, _ ->
-      Literal t
-    | Sy.Let, [], B_let ({ is_bool = true; _ } as x) -> Let x
-
-    | _ -> Literal t
-
-let[@inline always] term_view t = t
 
 (** pretty printing *)
 
@@ -739,6 +696,51 @@ let print_triggers fmt =
 let print_list_sep sep = Util.print_list ~sep ~pp:print
 
 let print_list fmt = print_list_sep "," fmt
+
+(** different views of an expression *)
+
+let lit_view t =
+  let { f; xs; ty; _ } = t in
+  if ty != Ty.Tbool then
+    Util.failwith "Calling lit_view on a non boolean expression %a"
+      print t
+  else
+    match f with
+    | Sy.Form _  ->
+      Util.failwith "Calling lit_view on a formula %a" print t
+    | Sy.Lit lit ->
+      begin match lit, xs with
+        | (Sy.L_eq | Sy.L_neg_eq), ([] | [_]) -> assert false
+        | Sy.L_eq, [a;b] -> Eq (a, b)
+        | Sy.L_eq, l     -> Eql l
+        | Sy.L_neg_eq, l -> Distinct l
+        | Sy.L_built x, l -> Builtin(true, x, l)
+        | Sy.L_neg_built x, l -> Builtin(false, x, l)
+        | Sy.L_neg_pred, [a] -> Pred(a, true)
+        | Sy.L_neg_pred, _ -> assert false
+      end
+    | _ -> Pred(t, false)
+
+let form_view t =
+  let { f; xs; bind; _ } = t in
+  if t.ty != Ty.Tbool then
+    Util.failwith "Term %a is not a formula" print t
+  else
+    match f, xs, bind with
+    | Sy.Form (Sy.F_Unit _), [a;b], _ -> Unit (a, b)
+    | Sy.Form (Sy.F_Clause i), [a;b], _ -> Clause (a, b, i)
+    | Sy.Form Sy.F_Iff, [a;b], _ -> Iff(a, b)
+    | Sy.Form Sy.F_Xor, [a;b], _ -> Xor(a, b)
+    | Sy.Form Sy.F_Lemma, [], B_lemma lem -> Lemma lem
+    | Sy.Form Sy.F_Skolem, [], B_skolem sko -> Skolem sko
+    | Sy.Lit (Sy.L_eq | Sy.L_neg_eq | Sy.L_neg_pred |
+              Sy.L_built _ | Sy.L_neg_built _), _, _ ->
+      Literal t
+    | Sy.Let, [], B_let ({ is_bool = true; _ } as x) -> Let x
+
+    | _ -> Literal t
+
+let[@inline always] term_view t = t
 
 (** Some auxiliary functions *)
 
@@ -1440,7 +1442,6 @@ and find_particular_subst =
      x can be replaced with 1 *)
   let rec find_subst v tv f =
     match form_view f with
-    | Not_a_form -> assert false
     | Unit _ | Lemma _ | Skolem _ | Let _ | Iff _ | Xor _ -> ()
     | Clause(f1, f2,_) -> find_subst v tv f1; find_subst v tv f2
     | Literal a ->
@@ -1559,7 +1560,6 @@ let max_ground_terms_of_lit =
 let atoms_rec_of_form =
   let rec atoms only_ground acc f =
     match form_view f with
-    | Not_a_form -> assert false
     | Literal a ->
       if not only_ground || is_ground a then TSet.add a acc else acc
 
@@ -1626,7 +1626,6 @@ let sub_terms_of_formula f =
       let acc = aux xx.in_e acc in
       if type_info xx.let_e == Ty.Tbool then aux xx.let_e acc
       else sub_terms acc xx.let_e
-    | Not_a_form -> assert false
   in
   aux f TSet.empty
 

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -111,7 +111,7 @@ type lit_view = private
   | Distinct of t list
   | Builtin of bool * Symbols.builtin * t list
   | Pred of t * bool
-  | Not_a_lit of { is_form : bool }
+  (* | Not_a_lit of { is_form : bool } *)
 
 type form_view = private
   | Unit of t*t  (* unit clauses *)

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -111,7 +111,6 @@ type lit_view = private
   | Distinct of t list
   | Builtin of bool * Symbols.builtin * t list
   | Pred of t * bool
-  (* | Not_a_lit of { is_form : bool } *)
 
 type form_view = private
   | Unit of t*t  (* unit clauses *)
@@ -122,7 +121,6 @@ type form_view = private
   | Lemma of quantified   (* a lemma *)
   | Skolem of quantified  (* lazy skolemization *)
   | Let of letin (* a binding of an expr *)
-  | Not_a_form
 
 (** different views of an expression *)
 

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -855,7 +855,6 @@ module Flat_Formula : FLAT_FORMULA = struct
     let new_vars = ref new_vars in
     let rec simp topl ~parent_disj f =
       match E.form_view f with
-      | E.Not_a_form -> assert false
       | E.Literal a ->
         let ff, l = mk_lit hcons a !new_vars in
         new_vars := l;
@@ -1016,6 +1015,4 @@ module Proxy_formula = struct
         | E.Let _ | E.Skolem _ | E.Lemma _ | E.Literal _ | E.Iff _
         | E.Xor _ ->
           a, (proxies, inv_proxies, new_vars, cnf)
-
-        | E.Not_a_form -> assert false
 end

--- a/src/lib/util/util.ml
+++ b/src/lib/util/util.ml
@@ -154,3 +154,4 @@ let rec print_list_pp ~sep ~pp fmt = function
     Format.fprintf fmt "%a %a" pp x sep ();
     print_list_pp ~sep ~pp fmt l
 
+let failwith msg = Format.kasprintf failwith msg

--- a/src/lib/util/util.mli
+++ b/src/lib/util/util.mli
@@ -95,3 +95,5 @@ val print_list_pp:
   sep:(Format.formatter -> unit -> unit) ->
   pp:(Format.formatter -> 'a -> unit) ->
   Format.formatter -> 'a list -> unit
+
+val failwith: ('a, Format.formatter, unit, 'b) format4 -> 'a


### PR DESCRIPTION
Some types in `expr.ml` are unnecessarily complicated. This PR follows #520's cleaning of the AST.