### PR TITLE
[WIP] Attempt to replace a bunch of ugly code by generated code from ppx_compare

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -25,6 +25,7 @@ depends: [
   "zarith"
   "seq"
   "stdlib-shims"
+  "ppx_compare"
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"

--- a/dune-project
+++ b/dune-project
@@ -134,6 +134,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
   zarith
   seq
   stdlib-shims
+  ppx_compare
   (odoc :with-doc)
  )
 )

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -44,7 +44,7 @@
 
   (modules
     ; frontend
-    Cnf Input Frontend Parsed_interface Typechecker Models
+    Cnf Input Frontend Parsed_interface Typechecker Models D_cnf D_loop
     ; reasoners
     Ac Arith Arrays Arrays_rel Bitv Ccx Shostak Relation Enum Enum_rel
     Fun_sat Inequalities Bitv_rel Th_util Adt Adt_rel

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -22,18 +22,29 @@
   (name AltErgoLib)
   (public_name alt-ergo-lib)
 
-  ; external dependencies
   (libraries
-     seq unix num str zarith dynlink ocplib-simplex stdlib-shims
-     dolmen dolmen_type dolmen_loop)
+    seq
+    unix
+    num
+    str
+    zarith
+    dynlink
+    ocplib-simplex
+    stdlib-shims
+    dolmen
+    dolmen_type
+    dolmen_loop
+  )
 
-  ; .mli only modules *also* need to be in this field
-  (modules_without_implementation matching_types numbersInterface sig sig_rel)
+  (modules_without_implementation
+    matching_types
+    numbersInterface
+    sig sig_rel
+  )
 
-  ; modules that make up the lib
   (modules
     ; frontend
-    Cnf D_cnf D_loop Input Frontend Parsed_interface Typechecker Models
+    Cnf Input Frontend Parsed_interface Typechecker Models
     ; reasoners
     Ac Arith Arrays Arrays_rel Bitv Ccx Shostak Relation Enum Enum_rel
     Fun_sat Inequalities Bitv_rel Th_util Adt Adt_rel
@@ -47,9 +58,14 @@
     ; util
     Config Emap Gc_debug Hconsing Hstring Iheap Lists Loc
     MyDynlink MyUnix Numbers NumsNumbers NumbersInterface
-    Options Timers Util Vec Version ZarithNumbers Steps Printer Format_shims)
+    Options Timers Util Vec Version ZarithNumbers Steps Printer Format_shims
+  )
 
- (js_of_ocaml
-  (javascript_files missing_primitives.js)
- )
+  (preprocess
+    (pps ppx_compare)
+  )
+
+  (js_of_ocaml
+    (javascript_files missing_primitives.js)
+  )
 )

--- a/src/lib/frontend/models.ml
+++ b/src/lib/frontend/models.ml
@@ -163,9 +163,9 @@ module Pp_smtlib_term = struct
       else
         fprintf fmt "(%a %a %a)" print e1 Sy.print f print e2
 
-    | Sy.Op Sy.Destruct (hs, grded), [e] ->
+    | Sy.Op Sy.Destruct (guarded, hs), [e] ->
       fprintf fmt "%a#%s%a"
-        print e (if grded then "" else "!") Hstring.print hs
+        print e (if guarded then "" else "!") Hstring.print hs
 
 
     | Sy.In(lb, rb), [t] ->

--- a/src/lib/reasoners/adt.ml
+++ b/src/lib/reasoners/adt.ml
@@ -62,7 +62,7 @@ module Shostak (X : ALIEN) = struct
     not (Options.get_disable_adts ()) &&
     match sy, ty with
     | Sy.Op (Sy.Constr _), Ty.Tadt _ -> true
-    | Sy.Op Sy.Destruct (_,guarded), _ -> not guarded
+    | Sy.Op Sy.Destruct (guarded, _), _ -> not guarded
     | _ -> false
 
   let embed r =
@@ -175,7 +175,7 @@ module Shostak (X : ALIEN) = struct
       in
       is_mine @@ Constr {c_name = hs; c_ty = ty; c_args}, ctx
 
-    | Sy.Op Sy.Destruct (hs, guarded), [e], _ ->
+    | Sy.Op Sy.Destruct (guarded, hs), [e], _ ->
       if not guarded then
         let sel = Select {d_name = hs ; d_arg = e ; d_ty = ty} in
         is_mine sel, ctx

--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -332,7 +332,7 @@ let add_aux env (uf:uf) (r:r) t =
     let { E.f = sy; xs; ty; _ } = E.term_view t in
     let env = add_adt env uf t r sy ty in
     match sy, xs with
-    | Sy.Op Sy.Destruct (hs, true), [e] -> (* guarded *)
+    | Sy.Op Sy.Destruct (true, hs), [e] -> (* guarded *)
       if Options.get_debug_adt () then
         Printer.print_dbg
           ~module_name:"Adt_rel" ~function_name:"add_aux"
@@ -340,7 +340,7 @@ let add_aux env (uf:uf) (r:r) t =
       if (SE.mem t env.seen_destr) then env
       else add_guarded_destr env uf t hs e ty
 
-    | Sy.Op Sy.Destruct (_, false), [_] ->
+    | Sy.Op Sy.Destruct (false, _), [_] ->
       (* not guarded *)
       if Options.get_debug_adt () then
         Printer.print_dbg

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -32,12 +32,12 @@ module SSet = Sy.Set
 
 (** Data structures *)
 
-let compare_list = Stdlib.List.compare
-let compare_bool = Stdlib.Bool.compare
-let compare_int = Stdlib.Int.compare
-let equal_list = Stdlib.List.equal
-let equal_bool = Stdlib.Bool.equal
-let equal_int = Stdlib.Int.equal
+let compare_list = List.compare
+let compare_bool = Bool.compare
+let compare_int = Int.compare
+let equal_list = List.equal
+let equal_bool = Bool.equal
+let equal_int = Int.equal
 
 type binders = (Ty.t * int) SMap.t (*int tag in globally unique *)
 

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -72,7 +72,7 @@ and bind_kind =
 [@@deriving equal, compare]
 
 and quantified = {
-  name : string; [@ignore]
+  name : String.t;
   main : t;
   toplevel : bool;
   user_trs : trigger list;
@@ -483,9 +483,9 @@ module SmtPrinter = struct
     | Sy.Op _, [e1; e2] ->
       fprintf fmt "(%a %a %a)" Sy.print f print e1 print e2
 
-    | Sy.Op Sy.Destruct (hs, grded), [e] ->
+    | Sy.Op Sy.Destruct (guarded, hs), [e] ->
       fprintf fmt "%a#%s%a"
-        print e (if grded then "" else "!") Hstring.print hs
+        print e (if guarded then "" else "!") Hstring.print hs
 
 
     | Sy.In(lb, rb), [t] ->
@@ -664,9 +664,9 @@ module AEPrinter = struct
       else
         fprintf fmt "(%a %a %a)" print e1 Sy.print f print e2
 
-    | Sy.Op Sy.Destruct (hs, grded), [e] ->
+    | Sy.Op Sy.Destruct (guarded, hs), [e] ->
       fprintf fmt "%a#%s%a"
-        print e (if grded then "" else "!") Hstring.print hs
+        print e (if guarded then "" else "!") Hstring.print hs
 
 
     | Sy.In(lb, rb), [t] ->

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -32,12 +32,12 @@ module SSet = Sy.Set
 
 (** Data structures *)
 
-let compare_list = List.compare
-let compare_bool = Bool.compare
-let compare_int = Int.compare
-let equal_list = List.equal
-let equal_bool = Bool.equal
-let equal_int = Int.equal
+let compare_list = Stdlib.List.compare
+let compare_bool = Stdlib.Bool.compare
+let compare_int = Stdlib.Int.compare
+let equal_list = Stdlib.List.equal
+let equal_bool = Stdlib.Bool.equal
+let equal_int = Stdlib.Int.equal
 
 type binders = (Ty.t * int) SMap.t (*int tag in globally unique *)
 

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -44,13 +44,13 @@ type term_view = private {
   xs: t list;
   ty: Ty.t;
   bind : bind_kind;
-  tag: int;
   vars : (Ty.t * int) Symbols.Map.t; (* vars to types and nb of occurences *)
   vty : Ty.Svty.t;
   depth: int;
   nb_nodes : int;
   pure : bool;
-  mutable neg : t option
+  mutable neg : t option;
+  tag: int
 }
 
 and bind_kind =
@@ -63,11 +63,11 @@ and quantified = private {
   name : string;
   main : t;
   toplevel : bool;
-  user_trs : trigger list;
   binders : binders;
   (* These fields should be (ordered) lists ! important for skolemization *)
   sko_v : t list;
   sko_vty : Ty.t list;
+  user_trs : trigger list;
   loc : Loc.t; (* location of the "GLOBAL" axiom containing this quantified
                   formula. It forms with name a unique id *)
   kind : decl_kind;
@@ -90,10 +90,10 @@ and semantic_trigger =
 
 and trigger = (*private*) {
   content : t list;
+  hyp : t list;
   (* this field is filled (with a part of 'content' field) by theories
      when assume_th_elt is called *)
   semantic : semantic_trigger list;
-  hyp : t list;
   t_depth : int;
   from_user : bool;
   guard : t option
@@ -144,8 +144,8 @@ val hash  : t -> int
 val uid   : t -> int
 val compare_subst : subst -> subst -> int
 val equal_subst : subst -> subst -> bool
-val compare_quant : quantified -> quantified -> int
-val compare_let : letin -> letin -> int
+val compare_quantified : quantified -> quantified -> int
+val compare_letin : letin -> letin -> int
 
 (** Some auxiliary functions *)
 

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -29,7 +29,25 @@
 type builtin =
     LE | LT (* arithmetic *)
   | IsConstr of Hstring.t (* ADT tester *)
-[@@deriving compare]
+[@@deriving_inline compare]
+let _ = fun (_ : builtin) -> ()
+let compare_builtin =
+  (fun a__001_ ->
+     fun b__002_ ->
+       if Ppx_compare_lib.phys_equal a__001_ b__002_
+       then 0
+       else
+         (match (a__001_, b__002_) with
+          | (LE, LE) -> 0
+          | (LE, _) -> (-1)
+          | (_, LE) -> 1
+          | (LT, LT) -> 0
+          | (LT, _) -> (-1)
+          | (_, LT) -> 1
+          | (IsConstr _a__003_, IsConstr _b__004_) ->
+            Hstring.compare _a__003_ _b__004_) : builtin -> builtin -> int)
+let _ = compare_builtin
+[@@@end]
 
 type operator =
     Plus | Minus | Mult | Div | Modulo
@@ -42,7 +60,116 @@ type operator =
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Bool.t * Hstring.t
   | Tite
-[@@deriving compare]
+[@@deriving_inline compare]
+let _ = fun (_ : operator) -> ()
+let compare_operator =
+  (fun a__005_ ->
+     fun b__006_ ->
+       if Ppx_compare_lib.phys_equal a__005_ b__006_
+       then 0
+       else
+         (match (a__005_, b__006_) with
+          | (Plus, Plus) -> 0
+          | (Plus, _) -> (-1)
+          | (_, Plus) -> 1
+          | (Minus, Minus) -> 0
+          | (Minus, _) -> (-1)
+          | (_, Minus) -> 1
+          | (Mult, Mult) -> 0
+          | (Mult, _) -> (-1)
+          | (_, Mult) -> 1
+          | (Div, Div) -> 0
+          | (Div, _) -> (-1)
+          | (_, Div) -> 1
+          | (Modulo, Modulo) -> 0
+          | (Modulo, _) -> (-1)
+          | (_, Modulo) -> 1
+          | (Concat, Concat) -> 0
+          | (Concat, _) -> (-1)
+          | (_, Concat) -> 1
+          | (Extract, Extract) -> 0
+          | (Extract, _) -> (-1)
+          | (_, Extract) -> 1
+          | (Get, Get) -> 0
+          | (Get, _) -> (-1)
+          | (_, Get) -> 1
+          | (Set, Set) -> 0
+          | (Set, _) -> (-1)
+          | (_, Set) -> 1
+          | (Fixed, Fixed) -> 0
+          | (Fixed, _) -> (-1)
+          | (_, Fixed) -> 1
+          | (Float, Float) -> 0
+          | (Float, _) -> (-1)
+          | (_, Float) -> 1
+          | (Reach, Reach) -> 0
+          | (Reach, _) -> (-1)
+          | (_, Reach) -> 1
+          | (Access _a__007_, Access _b__008_) ->
+            Hstring.compare _a__007_ _b__008_
+          | (Access _, _) -> (-1)
+          | (_, Access _) -> 1
+          | (Record, Record) -> 0
+          | (Record, _) -> (-1)
+          | (_, Record) -> 1
+          | (Sqrt_real, Sqrt_real) -> 0
+          | (Sqrt_real, _) -> (-1)
+          | (_, Sqrt_real) -> 1
+          | (Abs_int, Abs_int) -> 0
+          | (Abs_int, _) -> (-1)
+          | (_, Abs_int) -> 1
+          | (Abs_real, Abs_real) -> 0
+          | (Abs_real, _) -> (-1)
+          | (_, Abs_real) -> 1
+          | (Real_of_int, Real_of_int) -> 0
+          | (Real_of_int, _) -> (-1)
+          | (_, Real_of_int) -> 1
+          | (Int_floor, Int_floor) -> 0
+          | (Int_floor, _) -> (-1)
+          | (_, Int_floor) -> 1
+          | (Int_ceil, Int_ceil) -> 0
+          | (Int_ceil, _) -> (-1)
+          | (_, Int_ceil) -> 1
+          | (Sqrt_real_default, Sqrt_real_default) -> 0
+          | (Sqrt_real_default, _) -> (-1)
+          | (_, Sqrt_real_default) -> 1
+          | (Sqrt_real_excess, Sqrt_real_excess) -> 0
+          | (Sqrt_real_excess, _) -> (-1)
+          | (_, Sqrt_real_excess) -> 1
+          | (Min_real, Min_real) -> 0
+          | (Min_real, _) -> (-1)
+          | (_, Min_real) -> 1
+          | (Min_int, Min_int) -> 0
+          | (Min_int, _) -> (-1)
+          | (_, Min_int) -> 1
+          | (Max_real, Max_real) -> 0
+          | (Max_real, _) -> (-1)
+          | (_, Max_real) -> 1
+          | (Max_int, Max_int) -> 0
+          | (Max_int, _) -> (-1)
+          | (_, Max_int) -> 1
+          | (Integer_log2, Integer_log2) -> 0
+          | (Integer_log2, _) -> (-1)
+          | (_, Integer_log2) -> 1
+          | (Pow, Pow) -> 0
+          | (Pow, _) -> (-1)
+          | (_, Pow) -> 1
+          | (Integer_round, Integer_round) -> 0
+          | (Integer_round, _) -> (-1)
+          | (_, Integer_round) -> 1
+          | (Constr _a__009_, Constr _b__010_) ->
+            Hstring.compare _a__009_ _b__010_
+          | (Constr _, _) -> (-1)
+          | (_, Constr _) -> 1
+          | (Destruct (_a__011_, _a__013_), Destruct (_b__012_, _b__014_)) ->
+            (match Bool.compare _a__011_ _b__012_ with
+             | 0 -> Hstring.compare _a__013_ _b__014_
+             | n -> n)
+          | (Destruct _, _) -> (-1)
+          | (_, Destruct _) -> 1
+          | (Tite, Tite) -> 0) : operator -> operator -> int)
+let _ = compare_operator
+[@@@end]
 
 type lit =
   (* literals *)
@@ -51,7 +178,34 @@ type lit =
   | L_neg_eq
   | L_neg_built of builtin
   | L_neg_pred
-[@@deriving compare]
+[@@deriving_inline compare]
+let _ = fun (_ : lit) -> ()
+let compare_lit =
+  (fun a__015_ ->
+     fun b__016_ ->
+       if Ppx_compare_lib.phys_equal a__015_ b__016_
+       then 0
+       else
+         (match (a__015_, b__016_) with
+          | (L_eq, L_eq) -> 0
+          | (L_eq, _) -> (-1)
+          | (_, L_eq) -> 1
+          | (L_built _a__017_, L_built _b__018_) ->
+            compare_builtin _a__017_ _b__018_
+          | (L_built _, _) -> (-1)
+          | (_, L_built _) -> 1
+          | (L_neg_eq, L_neg_eq) -> 0
+          | (L_neg_eq, _) -> (-1)
+          | (_, L_neg_eq) -> 1
+          | (L_neg_built _a__019_, L_neg_built _b__020_) ->
+            compare_builtin _a__019_ _b__020_
+          | (L_neg_built _, _) -> (-1)
+          | (_, L_neg_built _) -> 1
+          | (L_neg_pred, L_neg_pred) -> 0) : lit -> lit -> int)
+let _ = compare_lit
+[@@@end]
+
+
 
 type form =
   (* formulas *)
@@ -61,22 +215,118 @@ type form =
   | F_Xor
   | F_Lemma
   | F_Skolem
-[@@deriving compare]
+[@@deriving_inline compare]
+let _ = fun (_ : form) -> ()
+let compare_form =
+  (fun a__021_ ->
+     fun b__022_ ->
+       if Ppx_compare_lib.phys_equal a__021_ b__022_
+       then 0
+       else
+         (match (a__021_, b__022_) with
+          | (F_Unit _a__023_, F_Unit _b__024_) ->
+            Bool.compare _a__023_ _b__024_
+          | (F_Unit _, _) -> (-1)
+          | (_, F_Unit _) -> 1
+          | (F_Clause _a__025_, F_Clause _b__026_) ->
+            Bool.compare _a__025_ _b__026_
+          | (F_Clause _, _) -> (-1)
+          | (_, F_Clause _) -> 1
+          | (F_Iff, F_Iff) -> 0
+          | (F_Iff, _) -> (-1)
+          | (_, F_Iff) -> 1
+          | (F_Xor, F_Xor) -> 0
+          | (F_Xor, _) -> (-1)
+          | (_, F_Xor) -> 1
+          | (F_Lemma, F_Lemma) -> 0
+          | (F_Lemma, _) -> (-1)
+          | (_, F_Lemma) -> 1
+          | (F_Skolem, F_Skolem) -> 0) : form -> form -> int)
+let _ = compare_form
+[@@@end]
 
 type name_kind =
   | Ac
   | Other
-[@@deriving compare]
+[@@deriving_inline compare]
+let _ = fun (_ : name_kind) -> ()
+let compare_name_kind =
+  (Ppx_compare_lib.polymorphic_compare : name_kind -> name_kind -> int)
+let _ = compare_name_kind
+[@@@end]
 
 type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
-[@@deriving equal, compare]
+[@@deriving_inline equal, compare]
+let _ = fun (_ : bound_kind) -> ()
+let equal_bound_kind =
+  (fun a__029_ ->
+     fun b__030_ ->
+       if Ppx_compare_lib.phys_equal a__029_ b__030_
+       then true
+       else
+         (match (a__029_, b__030_) with
+          | (VarBnd _a__031_, VarBnd _b__032_) -> Var.equal _a__031_ _b__032_
+          | (VarBnd _, _) -> false
+          | (_, VarBnd _) -> false
+          | (ValBnd _a__033_, ValBnd _b__034_) ->
+            Numbers.Q.equal _a__033_ _b__034_) : bound_kind ->
+       bound_kind -> bool)
+let _ = equal_bound_kind
+let compare_bound_kind =
+  (fun a__035_ ->
+     fun b__036_ ->
+       if Ppx_compare_lib.phys_equal a__035_ b__036_
+       then 0
+       else
+         (match (a__035_, b__036_) with
+          | (VarBnd _a__037_, VarBnd _b__038_) ->
+            Var.compare _a__037_ _b__038_
+          | (VarBnd _, _) -> (-1)
+          | (_, VarBnd _) -> 1
+          | (ValBnd _a__039_, ValBnd _b__040_) ->
+            Numbers.Q.compare _a__039_ _b__040_) : bound_kind ->
+       bound_kind -> int)
+let _ = compare_bound_kind
+[@@@end]
 
 type bound = {
   sort: Ty.t;
   is_open: Bool.t;
   is_lower: Bool.t;
   kind: bound_kind;
-} [@@deriving equal, compare]
+} [@@deriving_inline equal, compare]
+let _ = fun (_ : bound) -> ()
+let equal_bound =
+  (fun a__041_ ->
+     fun b__042_ ->
+       if Ppx_compare_lib.phys_equal a__041_ b__042_
+       then true
+       else
+         Ppx_compare_lib.(&&) (Ty.equal a__041_.sort b__042_.sort)
+           (Ppx_compare_lib.(&&) (Bool.equal a__041_.is_open b__042_.is_open)
+              (Ppx_compare_lib.(&&)
+                 (Bool.equal a__041_.is_lower b__042_.is_lower)
+                 (equal_bound_kind a__041_.kind b__042_.kind))) : bound ->
+       bound ->
+       bool)
+let _ = equal_bound
+let compare_bound =
+  (fun a__043_ ->
+     fun b__044_ ->
+       if Ppx_compare_lib.phys_equal a__043_ b__044_
+       then 0
+       else
+         (match Ty.compare a__043_.sort b__044_.sort with
+          | 0 ->
+            (match Bool.compare a__043_.is_open b__044_.is_open with
+             | 0 ->
+               (match Bool.compare a__043_.is_lower b__044_.is_lower with
+                | 0 -> compare_bound_kind a__043_.kind b__044_.kind
+                | n -> n)
+             | n -> n)
+          | n -> n) : bound -> bound -> int)
+let _ = compare_bound
+[@@@end]
 
 type t =
   | True
@@ -93,7 +343,66 @@ type t =
   | In of bound * bound
   | MapsTo of Var.t
   | Let
-[@@deriving compare]
+[@@deriving_inline compare]
+let _ = fun (_ : t) -> ()
+let compare =
+  (fun a__045_ ->
+     fun b__046_ ->
+       if Ppx_compare_lib.phys_equal a__045_ b__046_
+       then 0
+       else
+         (match (a__045_, b__046_) with
+          | (True, True) -> 0
+          | (True, _) -> (-1)
+          | (_, True) -> 1
+          | (False, False) -> 0
+          | (False, _) -> (-1)
+          | (_, False) -> 1
+          | (Void, Void) -> 0
+          | (Void, _) -> (-1)
+          | (_, Void) -> 1
+          | (Int _a__047_, Int _b__048_) -> Hstring.compare _a__047_ _b__048_
+          | (Int _, _) -> (-1)
+          | (_, Int _) -> 1
+          | (Real _a__049_, Real _b__050_) ->
+            Hstring.compare _a__049_ _b__050_
+          | (Real _, _) -> (-1)
+          | (_, Real _) -> 1
+          | (Var _a__051_, Var _b__052_) -> Var.compare _a__051_ _b__052_
+          | (Var _, _) -> (-1)
+          | (_, Var _) -> 1
+          | (Name (_a__053_, _a__055_), Name (_b__054_, _b__056_)) ->
+            (match Hstring.compare _a__053_ _b__054_ with
+             | 0 -> compare_name_kind _a__055_ _b__056_
+             | n -> n)
+          | (Name _, _) -> (-1)
+          | (_, Name _) -> 1
+          | (Bitv _a__057_, Bitv _b__058_) ->
+            String.compare _a__057_ _b__058_
+          | (Bitv _, _) -> (-1)
+          | (_, Bitv _) -> 1
+          | (Op _a__059_, Op _b__060_) -> compare_operator _a__059_ _b__060_
+          | (Op _, _) -> (-1)
+          | (_, Op _) -> 1
+          | (Lit _a__061_, Lit _b__062_) -> compare_lit _a__061_ _b__062_
+          | (Lit _, _) -> (-1)
+          | (_, Lit _) -> 1
+          | (Form _a__063_, Form _b__064_) -> compare_form _a__063_ _b__064_
+          | (Form _, _) -> (-1)
+          | (_, Form _) -> 1
+          | (In (_a__065_, _a__067_), In (_b__066_, _b__068_)) ->
+            (match compare_bound _a__065_ _b__066_ with
+             | 0 -> compare_bound _a__067_ _b__068_
+             | n -> n)
+          | (In _, _) -> (-1)
+          | (_, In _) -> 1
+          | (MapsTo _a__069_, MapsTo _b__070_) ->
+            Var.compare _a__069_ _b__070_
+          | (MapsTo _, _) -> (-1)
+          | (_, MapsTo _) -> 1
+          | (Let, Let) -> 0) : t -> t -> int)
+let _ = compare
+[@@@end]
 
 type s = t
 

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -29,6 +29,7 @@
 type builtin =
     LE | LT (* arithmetic *)
   | IsConstr of Hstring.t (* ADT tester *)
+[@@deriving compare]
 
 type operator =
     Plus | Minus | Mult | Div | Modulo
@@ -39,8 +40,9 @@ type operator =
   | Min_real | Min_int | Max_real | Max_int | Integer_log2
   | Pow | Integer_round
   | Constr of Hstring.t (* enums, adts *)
-  | Destruct of Hstring.t * bool
+  | Destruct of Hstring.t * Bool.t
   | Tite
+[@@deriving compare]
 
 type lit =
   (* literals *)
@@ -49,23 +51,32 @@ type lit =
   | L_neg_eq
   | L_neg_built of builtin
   | L_neg_pred
+[@@deriving compare]
 
 type form =
   (* formulas *)
-  | F_Unit of bool
-  | F_Clause of bool
+  | F_Unit of Bool.t
+  | F_Clause of Bool.t
   | F_Iff
   | F_Xor
   | F_Lemma
   | F_Skolem
+[@@deriving compare]
 
-type name_kind = Ac | Other
+type name_kind =
+  | Ac
+  | Other
+[@@deriving compare]
 
 type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
+[@@deriving equal, compare]
 
-type bound = (* private *)
-  { kind : bound_kind; sort : Ty.t; is_open : bool; is_lower : bool }
-
+type bound = {
+  kind: bound_kind;
+  sort: Ty.t;
+  is_open: Bool.t;
+  is_lower: Bool.t
+} [@@deriving equal, compare]
 
 type t =
   | True
@@ -74,7 +85,7 @@ type t =
   | Name of Hstring.t * name_kind
   | Int of Hstring.t
   | Real of Hstring.t
-  | Bitv of string
+  | Bitv of String.t
   | Op of operator
   | Lit of lit
   | Form of form
@@ -82,6 +93,7 @@ type t =
   | In of bound * bound
   | MapsTo of Var.t
   | Let
+[@@deriving compare]
 
 type s = t
 
@@ -110,13 +122,13 @@ let underscore =
   Random.self_init ();
   var @@ Var.of_string @@ Format.sprintf "_%d" (Random.int 1_000_000)
 
-let compare_kinds k1 k2 =
+(*let compare_kinds k1 k2 =
   Util.compare_algebraic k1 k2
     (function
       | _, (Ac | Other) -> assert false
     )
 
-let compare_operators op1 op2 =
+  let compare_operators op1 op2 =
   Util.compare_algebraic op1 op2
     (function
       | Access h1, Access h2 | Constr h1, Constr h2 -> Hstring.compare h1 h2
@@ -132,14 +144,14 @@ let compare_operators op1 op2 =
             | Constr _ | Destruct _ | Tite) -> assert false
     )
 
-let compare_builtin b1 b2 =
+  let compare_builtin b1 b2 =
   Util.compare_algebraic b1 b2
     (function
       | IsConstr h1, IsConstr h2 -> Hstring.compare h1 h2
       | _, (LT | LE | IsConstr _) -> assert false
     )
 
-let compare_lits lit1 lit2 =
+  let compare_lits lit1 lit2 =
   Util.compare_algebraic lit1 lit2
     (function
       | L_built b1, L_built b2 -> compare_builtin b1 b2
@@ -148,7 +160,7 @@ let compare_lits lit1 lit2 =
         assert false
     )
 
-let compare_forms f1 f2 =
+  let compare_forms f1 f2 =
   Util.compare_algebraic f1 f2
     (function
       | F_Unit b1, F_Unit b2
@@ -157,16 +169,17 @@ let compare_forms f1 f2 =
            | F_Iff | F_Xor) ->
         assert false
     )
-
-let compare_bounds_kind a b =
+*)
+(*let compare_bounds_kind a b =
   Util.compare_algebraic a b
     (function
       | VarBnd h1, VarBnd h2 -> Var.compare h1 h2
       | ValBnd q1, ValBnd q2 -> Numbers.Q.compare q1 q2
       | _, (VarBnd _ | ValBnd _) -> assert false
-    )
+    )*)
 
-let compare_bounds a b =
+
+(*let compare_bounds a b =
   let c = Ty.compare a.sort b.sort in
   if c <> 0 then c
   else
@@ -175,9 +188,9 @@ let compare_bounds a b =
     else
       let c = Stdlib.compare a.is_lower b.is_lower in
       if c <> 0 then c
-      else compare_bounds_kind a.kind b.kind
+      else compare_bound_kind a.kind b.kind*)
 
-let compare s1 s2 =
+(*let compare s1 s2 =
   Util.compare_algebraic s1 s2
     (function
       | Int h1, Int h2
@@ -197,7 +210,7 @@ let compare s1 s2 =
         (True | False | Void | Name _ | Int _ | Real _ | Bitv _
         | Op _ | Lit _ | Form _ | Var _ | In _ | MapsTo _ | Let) ->
         assert false
-    )
+    )*)
 
 let equal s1 s2 = compare s1 s2 = 0
 

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -26,28 +26,12 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Ppx_compare_lib.Builtin
+
 type builtin =
     LE | LT (* arithmetic *)
   | IsConstr of Hstring.t (* ADT tester *)
-[@@deriving_inline compare]
-let _ = fun (_ : builtin) -> ()
-let compare_builtin =
-  (fun a__001_ ->
-     fun b__002_ ->
-       if Ppx_compare_lib.phys_equal a__001_ b__002_
-       then 0
-       else
-         (match (a__001_, b__002_) with
-          | (LE, LE) -> 0
-          | (LE, _) -> (-1)
-          | (_, LE) -> 1
-          | (LT, LT) -> 0
-          | (LT, _) -> (-1)
-          | (_, LT) -> 1
-          | (IsConstr _a__003_, IsConstr _b__004_) ->
-            Hstring.compare _a__003_ _b__004_) : builtin -> builtin -> int)
-let _ = compare_builtin
-[@@@end]
+[@@deriving compare, equal]
 
 type operator =
     Plus | Minus | Mult | Div | Modulo
@@ -58,118 +42,9 @@ type operator =
   | Min_real | Min_int | Max_real | Max_int | Integer_log2
   | Pow | Integer_round
   | Constr of Hstring.t (* enums, adts *)
-  | Destruct of Bool.t * Hstring.t
+  | Destruct of bool * Hstring.t
   | Tite
-[@@deriving_inline compare]
-let _ = fun (_ : operator) -> ()
-let compare_operator =
-  (fun a__005_ ->
-     fun b__006_ ->
-       if Ppx_compare_lib.phys_equal a__005_ b__006_
-       then 0
-       else
-         (match (a__005_, b__006_) with
-          | (Plus, Plus) -> 0
-          | (Plus, _) -> (-1)
-          | (_, Plus) -> 1
-          | (Minus, Minus) -> 0
-          | (Minus, _) -> (-1)
-          | (_, Minus) -> 1
-          | (Mult, Mult) -> 0
-          | (Mult, _) -> (-1)
-          | (_, Mult) -> 1
-          | (Div, Div) -> 0
-          | (Div, _) -> (-1)
-          | (_, Div) -> 1
-          | (Modulo, Modulo) -> 0
-          | (Modulo, _) -> (-1)
-          | (_, Modulo) -> 1
-          | (Concat, Concat) -> 0
-          | (Concat, _) -> (-1)
-          | (_, Concat) -> 1
-          | (Extract, Extract) -> 0
-          | (Extract, _) -> (-1)
-          | (_, Extract) -> 1
-          | (Get, Get) -> 0
-          | (Get, _) -> (-1)
-          | (_, Get) -> 1
-          | (Set, Set) -> 0
-          | (Set, _) -> (-1)
-          | (_, Set) -> 1
-          | (Fixed, Fixed) -> 0
-          | (Fixed, _) -> (-1)
-          | (_, Fixed) -> 1
-          | (Float, Float) -> 0
-          | (Float, _) -> (-1)
-          | (_, Float) -> 1
-          | (Reach, Reach) -> 0
-          | (Reach, _) -> (-1)
-          | (_, Reach) -> 1
-          | (Access _a__007_, Access _b__008_) ->
-            Hstring.compare _a__007_ _b__008_
-          | (Access _, _) -> (-1)
-          | (_, Access _) -> 1
-          | (Record, Record) -> 0
-          | (Record, _) -> (-1)
-          | (_, Record) -> 1
-          | (Sqrt_real, Sqrt_real) -> 0
-          | (Sqrt_real, _) -> (-1)
-          | (_, Sqrt_real) -> 1
-          | (Abs_int, Abs_int) -> 0
-          | (Abs_int, _) -> (-1)
-          | (_, Abs_int) -> 1
-          | (Abs_real, Abs_real) -> 0
-          | (Abs_real, _) -> (-1)
-          | (_, Abs_real) -> 1
-          | (Real_of_int, Real_of_int) -> 0
-          | (Real_of_int, _) -> (-1)
-          | (_, Real_of_int) -> 1
-          | (Int_floor, Int_floor) -> 0
-          | (Int_floor, _) -> (-1)
-          | (_, Int_floor) -> 1
-          | (Int_ceil, Int_ceil) -> 0
-          | (Int_ceil, _) -> (-1)
-          | (_, Int_ceil) -> 1
-          | (Sqrt_real_default, Sqrt_real_default) -> 0
-          | (Sqrt_real_default, _) -> (-1)
-          | (_, Sqrt_real_default) -> 1
-          | (Sqrt_real_excess, Sqrt_real_excess) -> 0
-          | (Sqrt_real_excess, _) -> (-1)
-          | (_, Sqrt_real_excess) -> 1
-          | (Min_real, Min_real) -> 0
-          | (Min_real, _) -> (-1)
-          | (_, Min_real) -> 1
-          | (Min_int, Min_int) -> 0
-          | (Min_int, _) -> (-1)
-          | (_, Min_int) -> 1
-          | (Max_real, Max_real) -> 0
-          | (Max_real, _) -> (-1)
-          | (_, Max_real) -> 1
-          | (Max_int, Max_int) -> 0
-          | (Max_int, _) -> (-1)
-          | (_, Max_int) -> 1
-          | (Integer_log2, Integer_log2) -> 0
-          | (Integer_log2, _) -> (-1)
-          | (_, Integer_log2) -> 1
-          | (Pow, Pow) -> 0
-          | (Pow, _) -> (-1)
-          | (_, Pow) -> 1
-          | (Integer_round, Integer_round) -> 0
-          | (Integer_round, _) -> (-1)
-          | (_, Integer_round) -> 1
-          | (Constr _a__009_, Constr _b__010_) ->
-            Hstring.compare _a__009_ _b__010_
-          | (Constr _, _) -> (-1)
-          | (_, Constr _) -> 1
-          | (Destruct (_a__011_, _a__013_), Destruct (_b__012_, _b__014_)) ->
-            (match Bool.compare _a__011_ _b__012_ with
-             | 0 -> Hstring.compare _a__013_ _b__014_
-             | n -> n)
-          | (Destruct _, _) -> (-1)
-          | (_, Destruct _) -> 1
-          | (Tite, Tite) -> 0) : operator -> operator -> int)
-let _ = compare_operator
-[@@@end]
+[@@deriving compare, equal]
 
 type lit =
   (* literals *)
@@ -178,155 +53,32 @@ type lit =
   | L_neg_eq
   | L_neg_built of builtin
   | L_neg_pred
-[@@deriving_inline compare]
-let _ = fun (_ : lit) -> ()
-let compare_lit =
-  (fun a__015_ ->
-     fun b__016_ ->
-       if Ppx_compare_lib.phys_equal a__015_ b__016_
-       then 0
-       else
-         (match (a__015_, b__016_) with
-          | (L_eq, L_eq) -> 0
-          | (L_eq, _) -> (-1)
-          | (_, L_eq) -> 1
-          | (L_built _a__017_, L_built _b__018_) ->
-            compare_builtin _a__017_ _b__018_
-          | (L_built _, _) -> (-1)
-          | (_, L_built _) -> 1
-          | (L_neg_eq, L_neg_eq) -> 0
-          | (L_neg_eq, _) -> (-1)
-          | (_, L_neg_eq) -> 1
-          | (L_neg_built _a__019_, L_neg_built _b__020_) ->
-            compare_builtin _a__019_ _b__020_
-          | (L_neg_built _, _) -> (-1)
-          | (_, L_neg_built _) -> 1
-          | (L_neg_pred, L_neg_pred) -> 0) : lit -> lit -> int)
-let _ = compare_lit
-[@@@end]
-
-
+[@@deriving compare, equal]
 
 type form =
   (* formulas *)
-  | F_Unit of Bool.t
-  | F_Clause of Bool.t
+  | F_Unit of bool
+  | F_Clause of bool
   | F_Iff
   | F_Xor
   | F_Lemma
   | F_Skolem
-[@@deriving_inline compare]
-let _ = fun (_ : form) -> ()
-let compare_form =
-  (fun a__021_ ->
-     fun b__022_ ->
-       if Ppx_compare_lib.phys_equal a__021_ b__022_
-       then 0
-       else
-         (match (a__021_, b__022_) with
-          | (F_Unit _a__023_, F_Unit _b__024_) ->
-            Bool.compare _a__023_ _b__024_
-          | (F_Unit _, _) -> (-1)
-          | (_, F_Unit _) -> 1
-          | (F_Clause _a__025_, F_Clause _b__026_) ->
-            Bool.compare _a__025_ _b__026_
-          | (F_Clause _, _) -> (-1)
-          | (_, F_Clause _) -> 1
-          | (F_Iff, F_Iff) -> 0
-          | (F_Iff, _) -> (-1)
-          | (_, F_Iff) -> 1
-          | (F_Xor, F_Xor) -> 0
-          | (F_Xor, _) -> (-1)
-          | (_, F_Xor) -> 1
-          | (F_Lemma, F_Lemma) -> 0
-          | (F_Lemma, _) -> (-1)
-          | (_, F_Lemma) -> 1
-          | (F_Skolem, F_Skolem) -> 0) : form -> form -> int)
-let _ = compare_form
-[@@@end]
+[@@deriving compare, equal]
 
 type name_kind =
   | Ac
   | Other
-[@@deriving_inline compare]
-let _ = fun (_ : name_kind) -> ()
-let compare_name_kind =
-  (Ppx_compare_lib.polymorphic_compare : name_kind -> name_kind -> int)
-let _ = compare_name_kind
-[@@@end]
+[@@deriving compare, equal]
 
 type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
-[@@deriving_inline equal, compare]
-let _ = fun (_ : bound_kind) -> ()
-let equal_bound_kind =
-  (fun a__029_ ->
-     fun b__030_ ->
-       if Ppx_compare_lib.phys_equal a__029_ b__030_
-       then true
-       else
-         (match (a__029_, b__030_) with
-          | (VarBnd _a__031_, VarBnd _b__032_) -> Var.equal _a__031_ _b__032_
-          | (VarBnd _, _) -> false
-          | (_, VarBnd _) -> false
-          | (ValBnd _a__033_, ValBnd _b__034_) ->
-            Numbers.Q.equal _a__033_ _b__034_) : bound_kind ->
-       bound_kind -> bool)
-let _ = equal_bound_kind
-let compare_bound_kind =
-  (fun a__035_ ->
-     fun b__036_ ->
-       if Ppx_compare_lib.phys_equal a__035_ b__036_
-       then 0
-       else
-         (match (a__035_, b__036_) with
-          | (VarBnd _a__037_, VarBnd _b__038_) ->
-            Var.compare _a__037_ _b__038_
-          | (VarBnd _, _) -> (-1)
-          | (_, VarBnd _) -> 1
-          | (ValBnd _a__039_, ValBnd _b__040_) ->
-            Numbers.Q.compare _a__039_ _b__040_) : bound_kind ->
-       bound_kind -> int)
-let _ = compare_bound_kind
-[@@@end]
+[@@deriving compare, equal]
 
 type bound = {
   sort: Ty.t;
   is_open: Bool.t;
   is_lower: Bool.t;
   kind: bound_kind;
-} [@@deriving_inline equal, compare]
-let _ = fun (_ : bound) -> ()
-let equal_bound =
-  (fun a__041_ ->
-     fun b__042_ ->
-       if Ppx_compare_lib.phys_equal a__041_ b__042_
-       then true
-       else
-         Ppx_compare_lib.(&&) (Ty.equal a__041_.sort b__042_.sort)
-           (Ppx_compare_lib.(&&) (Bool.equal a__041_.is_open b__042_.is_open)
-              (Ppx_compare_lib.(&&)
-                 (Bool.equal a__041_.is_lower b__042_.is_lower)
-                 (equal_bound_kind a__041_.kind b__042_.kind))) : bound ->
-       bound ->
-       bool)
-let _ = equal_bound
-let compare_bound =
-  (fun a__043_ ->
-     fun b__044_ ->
-       if Ppx_compare_lib.phys_equal a__043_ b__044_
-       then 0
-       else
-         (match Ty.compare a__043_.sort b__044_.sort with
-          | 0 ->
-            (match Bool.compare a__043_.is_open b__044_.is_open with
-             | 0 ->
-               (match Bool.compare a__043_.is_lower b__044_.is_lower with
-                | 0 -> compare_bound_kind a__043_.kind b__044_.kind
-                | n -> n)
-             | n -> n)
-          | n -> n) : bound -> bound -> int)
-let _ = compare_bound
-[@@@end]
+} [@@deriving compare, equal]
 
 type t =
   | True
@@ -336,22 +88,22 @@ type t =
   | Real of Hstring.t
   | Var of Var.t
   | Name of Hstring.t * name_kind
-  | Bitv of String.t
+  | Bitv of string
   | Op of operator
   | Lit of lit
   | Form of form
   | In of bound * bound
   | MapsTo of Var.t
   | Let
-[@@deriving_inline compare]
+[@@deriving_inline compare, equal]
 let _ = fun (_ : t) -> ()
 let compare =
-  (fun a__045_ ->
-     fun b__046_ ->
-       if Ppx_compare_lib.phys_equal a__045_ b__046_
+  (fun a__073_ ->
+     fun b__074_ ->
+       if Ppx_compare_lib.phys_equal a__073_ b__074_
        then 0
        else
-         (match (a__045_, b__046_) with
+         (match (a__073_, b__074_) with
           | (True, True) -> 0
           | (True, _) -> (-1)
           | (_, True) -> 1
@@ -361,50 +113,100 @@ let compare =
           | (Void, Void) -> 0
           | (Void, _) -> (-1)
           | (_, Void) -> 1
-          | (Int _a__047_, Int _b__048_) -> Hstring.compare _a__047_ _b__048_
+          | (Int _a__075_, Int _b__076_) -> Hstring.compare _a__075_ _b__076_
           | (Int _, _) -> (-1)
           | (_, Int _) -> 1
-          | (Real _a__049_, Real _b__050_) ->
-            Hstring.compare _a__049_ _b__050_
+          | (Real _a__077_, Real _b__078_) ->
+            Hstring.compare _a__077_ _b__078_
           | (Real _, _) -> (-1)
           | (_, Real _) -> 1
-          | (Var _a__051_, Var _b__052_) -> Var.compare _a__051_ _b__052_
+          | (Var _a__079_, Var _b__080_) -> Var.compare _a__079_ _b__080_
           | (Var _, _) -> (-1)
           | (_, Var _) -> 1
-          | (Name (_a__053_, _a__055_), Name (_b__054_, _b__056_)) ->
-            (match Hstring.compare _a__053_ _b__054_ with
-             | 0 -> compare_name_kind _a__055_ _b__056_
+          | (Name (_a__081_, _a__083_), Name (_b__082_, _b__084_)) ->
+            (match Hstring.compare _a__081_ _b__082_ with
+             | 0 -> compare_name_kind _a__083_ _b__084_
              | n -> n)
           | (Name _, _) -> (-1)
           | (_, Name _) -> 1
-          | (Bitv _a__057_, Bitv _b__058_) ->
-            String.compare _a__057_ _b__058_
+          | (Bitv _a__085_, Bitv _b__086_) ->
+            compare_string _a__085_ _b__086_
           | (Bitv _, _) -> (-1)
           | (_, Bitv _) -> 1
-          | (Op _a__059_, Op _b__060_) -> compare_operator _a__059_ _b__060_
+          | (Op _a__087_, Op _b__088_) -> compare_operator _a__087_ _b__088_
           | (Op _, _) -> (-1)
           | (_, Op _) -> 1
-          | (Lit _a__061_, Lit _b__062_) -> compare_lit _a__061_ _b__062_
+          | (Lit _a__089_, Lit _b__090_) -> compare_lit _a__089_ _b__090_
           | (Lit _, _) -> (-1)
           | (_, Lit _) -> 1
-          | (Form _a__063_, Form _b__064_) -> compare_form _a__063_ _b__064_
+          | (Form _a__091_, Form _b__092_) -> compare_form _a__091_ _b__092_
           | (Form _, _) -> (-1)
           | (_, Form _) -> 1
-          | (In (_a__065_, _a__067_), In (_b__066_, _b__068_)) ->
-            (match compare_bound _a__065_ _b__066_ with
-             | 0 -> compare_bound _a__067_ _b__068_
+          | (In (_a__093_, _a__095_), In (_b__094_, _b__096_)) ->
+            (match compare_bound _a__093_ _b__094_ with
+             | 0 -> compare_bound _a__095_ _b__096_
              | n -> n)
           | (In _, _) -> (-1)
           | (_, In _) -> 1
-          | (MapsTo _a__069_, MapsTo _b__070_) ->
-            Var.compare _a__069_ _b__070_
+          | (MapsTo _a__097_, MapsTo _b__098_) ->
+            Var.compare _a__097_ _b__098_
           | (MapsTo _, _) -> (-1)
           | (_, MapsTo _) -> 1
           | (Let, Let) -> 0) : t -> t -> int)
 let _ = compare
+let equal =
+  (fun a__099_ ->
+     fun b__100_ ->
+       if Ppx_compare_lib.phys_equal a__099_ b__100_
+       then true
+       else
+         (match (a__099_, b__100_) with
+          | (True, True) -> true
+          | (True, _) -> false
+          | (_, True) -> false
+          | (False, False) -> true
+          | (False, _) -> false
+          | (_, False) -> false
+          | (Void, Void) -> true
+          | (Void, _) -> false
+          | (_, Void) -> false
+          | (Int _a__101_, Int _b__102_) -> Hstring.equal _a__101_ _b__102_
+          | (Int _, _) -> false
+          | (_, Int _) -> false
+          | (Real _a__103_, Real _b__104_) -> Hstring.equal _a__103_ _b__104_
+          | (Real _, _) -> false
+          | (_, Real _) -> false
+          | (Var _a__105_, Var _b__106_) -> Var.equal _a__105_ _b__106_
+          | (Var _, _) -> false
+          | (_, Var _) -> false
+          | (Name (_a__107_, _a__109_), Name (_b__108_, _b__110_)) ->
+            Ppx_compare_lib.(&&) (Hstring.equal _a__107_ _b__108_)
+              (equal_name_kind _a__109_ _b__110_)
+          | (Name _, _) -> false
+          | (_, Name _) -> false
+          | (Bitv _a__111_, Bitv _b__112_) -> equal_string _a__111_ _b__112_
+          | (Bitv _, _) -> false
+          | (_, Bitv _) -> false
+          | (Op _a__113_, Op _b__114_) -> equal_operator _a__113_ _b__114_
+          | (Op _, _) -> false
+          | (_, Op _) -> false
+          | (Lit _a__115_, Lit _b__116_) -> equal_lit _a__115_ _b__116_
+          | (Lit _, _) -> false
+          | (_, Lit _) -> false
+          | (Form _a__117_, Form _b__118_) -> equal_form _a__117_ _b__118_
+          | (Form _, _) -> false
+          | (_, Form _) -> false
+          | (In (_a__119_, _a__121_), In (_b__120_, _b__122_)) ->
+            Ppx_compare_lib.(&&) (equal_bound _a__119_ _b__120_)
+              (equal_bound _a__121_ _b__122_)
+          | (In _, _) -> false
+          | (_, In _) -> false
+          | (MapsTo _a__123_, MapsTo _b__124_) -> Var.equal _a__123_ _b__124_
+          | (MapsTo _, _) -> false
+          | (_, MapsTo _) -> false
+          | (Let, Let) -> true) : t -> t -> bool)
+let _ = equal
 [@@@end]
-
-type s = t
 
 let name ?(kind=Other) s = Name (Hstring.make s, kind)
 let var s = Var s
@@ -519,9 +321,9 @@ let underscore =
         (True | False | Void | Name _ | Int _ | Real _ | Bitv _
         | Op _ | Lit _ | Form _ | Var _ | In _ | MapsTo _ | Let) ->
         assert false
-    )*)
+    )
 
-let equal s1 s2 = compare s1 s2 = 0
+  let equal s1 s2 = compare s1 s2 = 0*)
 
 let hash x =
   abs @@
@@ -661,10 +463,8 @@ let fake_neq =  name "@neq"
 let fake_lt  =  name "@lt"
 let fake_le  =  name "@le"
 
-
-
 module Labels = Hashtbl.Make(struct
-    type t = s
+    type nonrec t = t
     let equal = equal
     let hash = hash
   end)
@@ -678,14 +478,14 @@ let label t = try Labels.find labels t with Not_found -> Hstring.empty
 let clear_labels () = Labels.clear labels
 
 module Set : Set.S with type elt = t =
-  Set.Make (struct type t=s let compare=compare end)
+  Set.Make (struct type nonrec t = t let compare=compare end)
 
 module Map : sig
   include Map.S with type key = t
   val print :
     (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 end = struct
-  include Map.Make (struct type t = s let compare = compare end)
+  include Map.Make (struct type nonrec t = t let compare = compare end)
   let print pr_elt fmt sbt =
     iter (fun k v -> Format.fprintf fmt "%a -> %a  " print k pr_elt v) sbt
 end

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -29,6 +29,7 @@
 type builtin =
     LE | LT (* arithmetic *)
   | IsConstr of Hstring.t (* ADT tester *)
+[@@deriving compare]
 
 type operator =
   | Plus | Minus | Mult | Div | Modulo
@@ -41,6 +42,7 @@ type operator =
   | Constr of Hstring.t (* enums, adts *)
   | Destruct of Hstring.t * bool
   | Tite
+[@@deriving compare]
 
 type lit =
   (* literals *)
@@ -49,6 +51,7 @@ type lit =
   | L_neg_eq
   | L_neg_built of builtin
   | L_neg_pred
+[@@deriving compare]
 
 type form =
   (* formulas *)
@@ -58,13 +61,21 @@ type form =
   | F_Xor
   | F_Lemma
   | F_Skolem
+[@@deriving compare]
 
-type name_kind = Ac | Other
+type name_kind =
+  | Ac
+  | Other
+[@@deriving compare]
 
-type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
+type bound_kind =
+  | VarBnd of Var.t
+  | ValBnd of Numbers.Q.t
+[@@deriving compare]
 
 type bound = private
   { kind : bound_kind; sort : Ty.t; is_open : bool; is_lower : bool }
+[@@deriving compare]
 
 type t =
   | True
@@ -81,6 +92,7 @@ type t =
   | In of bound * bound
   | MapsTo of Var.t
   | Let
+[@@deriving compare]
 
 val name : ?kind:name_kind -> string -> t
 val var : Var.t -> t
@@ -97,7 +109,8 @@ val is_ac : t -> bool
 
 val equal : t -> t -> bool
 val compare : t -> t -> int
-val compare_bounds : bound -> bound -> int
+val equal_bound : bound -> bound -> bool
+val compare_bound : bound -> bound -> int
 val hash : t -> int
 
 val to_string : t -> string

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -75,10 +75,10 @@ type bound_kind =
 
 type bound = private {
   sort: Ty.t;
-  is_open: Bool.t;
-  is_lower: Bool.t;
+  is_open: bool;
+  is_lower: bool;
   kind: bound_kind;
-} [@@deriving equal, compare]
+} [@@deriving compare, equal]
 
 type t =
   | True
@@ -95,7 +95,7 @@ type t =
   | In of bound * bound
   | MapsTo of Var.t
   | Let
-[@@deriving compare]
+[@@deriving compare, equal]
 
 val name : ?kind:name_kind -> string -> t
 val var : Var.t -> t
@@ -110,8 +110,6 @@ val mk_maps_to : Var.t -> t
 
 val is_ac : t -> bool
 
-val equal : t -> t -> bool
-val compare : t -> t -> int
 val hash : t -> int
 
 val to_string : t -> string

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -40,7 +40,7 @@ type operator =
   | Min_real | Min_int | Max_real | Max_int | Integer_log2
   | Pow | Integer_round
   | Constr of Hstring.t (* enums, adts *)
-  | Destruct of Hstring.t * bool
+  | Destruct of bool * Hstring.t
   | Tite
 [@@deriving compare]
 
@@ -73,22 +73,25 @@ type bound_kind =
   | ValBnd of Numbers.Q.t
 [@@deriving compare]
 
-type bound = private
-  { kind : bound_kind; sort : Ty.t; is_open : bool; is_lower : bool }
-[@@deriving compare]
+type bound = private {
+  sort: Ty.t;
+  is_open: Bool.t;
+  is_lower: Bool.t;
+  kind: bound_kind;
+} [@@deriving equal, compare]
 
 type t =
   | True
   | False
   | Void
-  | Name of Hstring.t * name_kind
   | Int of Hstring.t
   | Real of Hstring.t
+  | Var of Var.t
+  | Name of Hstring.t * name_kind
   | Bitv of string
   | Op of operator
   | Lit of lit
   | Form of form
-  | Var of Var.t
   | In of bound * bound
   | MapsTo of Var.t
   | Let
@@ -109,8 +112,6 @@ val is_ac : t -> bool
 
 val equal : t -> t -> bool
 val compare : t -> t -> int
-val equal_bound : bound -> bound -> bool
-val compare_bound : bound -> bound -> int
 val hash : t -> int
 
 val to_string : t -> string

--- a/src/lib/util/util.ml
+++ b/src/lib/util/util.ml
@@ -93,7 +93,7 @@ let string_of_th_ext ext =
   | NIA -> "NIA"
   | FPA -> "FPA"
 
-let [@inline always] compare_algebraic s1 s2 f_same_constrs_with_args =
+(*let [@inline always] compare_algebraic s1 s2 f_same_constrs_with_args =
   let r1 = Obj.repr s1 in
   let r2 = Obj.repr s2 in
   match Obj.is_int r1, Obj.is_int r2 with
@@ -102,7 +102,7 @@ let [@inline always] compare_algebraic s1 s2 f_same_constrs_with_args =
   | false, true -> 1
   | false, false ->
     let cmp_tags = Obj.tag r1 - Obj.tag r2 in
-    if cmp_tags <> 0 then cmp_tags else f_same_constrs_with_args (s1, s2)
+    if cmp_tags <> 0 then cmp_tags else f_same_constrs_with_args (s1, s2)*)
 
 let [@inline always] cmp_lists l1 l2 cmp_elts =
   try

--- a/src/lib/util/util.mli
+++ b/src/lib/util/util.mli
@@ -61,7 +61,8 @@ val string_of_th_ext : theories_extensions -> string
    - Stdlib.compare a b is used if
 
 *)
-val [@inline always] compare_algebraic : 'a -> 'a -> (('a * 'a) -> int) -> int
+(*val [@inline always] compare_algebraic:
+  'a -> 'a -> (('a * 'a) -> int) -> int*)
 
 val [@inline always] cmp_lists: 'a list -> 'a list -> ('a -> 'a -> int) -> int
 


### PR DESCRIPTION
This PR is an attempt to replace the current comparisons functions in the module `Symbol` and the comparison of triggers in `Expr` by generated ones with [ppx_compare](https://github.com/janestreet/ppx_compare).

The current code looks like this
```ocaml
  let compare_operators op1 op2 =
  Util.compare_algebraic op1 op2
    (function
      | Access h1, Access h2 | Constr h1, Constr h2 -> Hstring.compare h1 h2
      | Destruct (h1, b1), Destruct(h2, b2) ->
        let c = Stdlib.compare b1 b2 in
        if c <> 0 then c else Hstring.compare h1 h2
      | _ , (Plus | Minus | Mult | Div | Modulo
            | Concat | Extract | Get | Set | Fixed | Float | Reach
            | Access _ | Record | Sqrt_real | Abs_int | Abs_real
            | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
            | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
            | Integer_log2 | Pow | Integer_round
            | Constr _ | Destruct _ | Tite) -> assert false
    )
``` 

where `compare_algebraic` is polymorphic comparison function for ADT defined in the module `Util` like this (their are other comparison functions using the same template in `Symbol`)
```ocaml
let [@inline always] compare_algebraic s1 s2 f_same_constrs_with_args =
  let r1 = Obj.repr s1 in
  let r2 = Obj.repr s2 in
  match Obj.is_int r1, Obj.is_int r2 with
  | true, true -> Stdlib.compare s1 s2 (* both constructors without args *)
  | true, false -> -1
  | false, true -> 1
  | false, false ->
    let cmp_tags = Obj.tag r1 - Obj.tag r2 in
    if cmp_tags <> 0 then cmp_tags else f_same_constrs_with_args (s1, s2)
```
The function `compare_algebraic` compares ADT values based on their memory representation and calls `f_same_constrs_with_args` to manage the case where `s1` and `s2` are the same constructor to compare their payload.

This code has many issues:
- It is ugly as hell. The `assert false` to exclude the case of two different contructors or a constructor without payload in `f_same_with_args` is terrible design.
- It depends on the memory representation of values. Even if this stable right now, it could change in the future.
- It is not even an efficient way to write an ADT comparison function. According to Vincent and Nathanaëlle, the function `Obj.tag` costs a lot because it is a C call.

Pros:
- We don't need to maintain these functions anymore.
- `ppx_compare` is stable and does not need memory representation.
- It is more efficient than the current implementation. I don't think this will be a substantial improvement nevertheless.

Cons:
- We depend on a ppx and a change in it could change the behavior of AE.