### PR TITLE
Fix js of ocaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ parsers: gen
 	$(DUNE) build $(DUNE_FLAGS) @$(PARSERS_DIR)/all
 
 js: gen
-	$(DUNE) build $(DUNE_FLAGS) -p alt-ergo-js
+	$(DUNE) build $(DUNE_FLAGS) @$(BJS_DIR)/all
 
 fm-simplex: gen
 	$(DUNE) build $(DUNE_FLAGS) @$(PLUGINS_DIR)/fm-simplex/all

--- a/alt-ergo-js.opam
+++ b/alt-ergo-js.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "3.0"}
   "alt-ergo-lib" {= version}
   "alt-ergo-parsers" {= version}
-  "js_of_ocaml" {<= "4.0.0"}
+  "js_of_ocaml" {>= "4.0.1"}
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
   "data-encoding"

--- a/dune-project
+++ b/dune-project
@@ -46,7 +46,7 @@ See more details on https://alt-ergo.ocamlpro.com/")
   dune
   (alt-ergo-lib (= :version))
   (alt-ergo-parsers (= :version))
-  (js_of_ocaml (<= 4.0.0))
+  (js_of_ocaml (>= 4.0.1))
   js_of_ocaml-lwt
   js_of_ocaml-ppx
   data-encoding

--- a/src/bin/common/dune
+++ b/src/bin/common/dune
@@ -11,4 +11,5 @@
 (library
  (name        alt_ergo_common)
  (libraries   alt-ergo-lib alt-ergo-parsers stdlib-shims cmdliner)
- (modules     Parse_command Input_frontend Signals_profiling Solving_loop))
+ (modules     Parse_command Input_frontend Signals_profiling Solving_loop)
+)

--- a/src/bin/js/dune
+++ b/src/bin/js/dune
@@ -33,10 +33,6 @@
  )
  (modules worker_js options_interface)
  (modes byte js)
- (js_of_ocaml
-  (flags --no-source-map)
-  (build_runtime_flags --no-source-map)
- )
 )
 
 ; Rule to build a small js example running the Alt-Ergo web worker

--- a/src/bin/js/dune
+++ b/src/bin/js/dune
@@ -3,40 +3,52 @@
  (name main_text_js)
  (public_name alt-ergo-js)
  (package alt-ergo-js)
- (libraries alt_ergo_common zarith_stubs_js)
+ (libraries
+   alt_ergo_common
+   zarith_stubs_js
+ )
  (modules main_text_js)
  (modes byte js)
- (js_of_ocaml
-  (flags --no-source-map)
- )
 )
 
 (library
  (name worker_interface)
  (package alt-ergo-js)
- (libraries js_of_ocaml data-encoding)
+ (libraries
+   js_of_ocaml
+   data-encoding
+ )
  (modules worker_interface)
 )
 
 ; Rule to build a web worker running Alt-Ergo
 (executable
  (name worker_js)
- (libraries worker_interface alt_ergo_common zarith_stubs_js js_of_ocaml js_of_ocaml-lwt)
+ (libraries
+   worker_interface
+   alt_ergo_common
+   zarith_stubs_js
+   js_of_ocaml
+   js_of_ocaml-lwt
+ )
  (modules worker_js options_interface)
  (modes byte js)
  (js_of_ocaml
   (flags --no-source-map)
+  (build_runtime_flags --no-source-map)
  )
 )
 
 ; Rule to build a small js example running the Alt-Ergo web worker
 (executable
  (name worker_example)
- (libraries worker_interface zarith_stubs_js js_of_ocaml js_of_ocaml-lwt)
+ (libraries
+   worker_interface
+   zarith_stubs_js
+   js_of_ocaml
+   js_of_ocaml-lwt
+ )
  (modules worker_example)
  (modes byte js)
  (preprocess (pps js_of_ocaml-ppx lwt_ppx))
- (js_of_ocaml
-  (flags --no-source-map)
- )
 )

--- a/src/dune
+++ b/src/dune
@@ -11,4 +11,5 @@
   (flags
    (:standard -bin-annot))
   (ocamlopt_flags -O3 -unbox-closures))
+  (js_of_ocaml (flags --no-source-map))
 )

--- a/src/lib/missing_primitives.js
+++ b/src/lib/missing_primitives.js
@@ -2,9 +2,9 @@
 // the missing primitives are replace with dummies
 
 //Provides: unix_times
-//Requires: unix_gettimeofday
+//Requires: caml_unix_gettimeofday
 function unix_times () {
-    var utime = unix_gettimeofday ();
+    var utime = caml_unix_gettimeofday ();
     return BLOCK(0, utime, utime, utime, utime)
 }
 //Provides: unix_setitimer

--- a/src/parsers/dune
+++ b/src/parsers/dune
@@ -12,7 +12,12 @@
 (library
  (name AltErgoParsers)
  (public_name alt-ergo-parsers)
- (libraries camlzip dynlink psmt2-frontend alt-ergo-lib stdlib-shims)
+ (libraries
+   camlzip
+   dynlink
+   psmt2-frontend
+   alt-ergo-lib
+   stdlib-shims)
  (modules
    ; common
    Parsers Parsers_loader MyZip
@@ -21,4 +26,6 @@
    ; AE format
    Native_lexer Native_parser)
  (js_of_ocaml
-  (javascript_files missing_primitives.js)))
+  (javascript_files missing_primitives.js)
+ )
+)


### PR DESCRIPTION
This PR resolves the compilation error about the missing primitive `unix_gettimeoftheday`. Since the release 4.1.0 of `js_of_ocaml`, the function has been renamed as `caml_unix_gettimeoftheday`. See https://github.com/ocsigen/js_of_ocaml/issues/1370.

- I also fixed the command `make js`.
- I set the option `--no-source-map` for the release profile only. Indeed, according to the `js_of_ocaml` documentation, producing a mapping between the OCaml source and the generated Javascript gives a bigger and slower binary. Yet, the option could be useful for debugging purposes.
- I tried to remove the below warning message throwing by `make`:
```
Warning: '--source-map' is enabled but the bytecode program was compiled with no debugging information.
Warning: Consider passing '-g' option to ocamlc.
```
This error is produced during the compilation with `js_of_ocaml` of the `Zarith` library. The warning oddly disappears if we turn off the separation compilation in `js_of_ocaml` but we got a bunch of new warning messages about missing primitives:
```
There are some missing primitives     
Dummy implementations (raising 'Failure' exception) will be used if they are not available at runtime.
You can prevent the generation of dummy implementations with the commandline option '--disable genprim'
Missing primitives provided by +dynlink.js:
  caml_dynlink_add_primitive
  caml_dynlink_get_current_libs
  caml_dynlink_lookup_symbol
  caml_dynlink_open_lib
Missing primitives provided by +toplevel.js:
  caml_get_section_table
  caml_realloc_global
  caml_reify_bytecode
```