### PR TITLE
[arith] Add contextual explanation when tightening equalities

### DIFF
--- a/tests/issues/479.expected
+++ b/tests/issues/479.expected
@@ -1,0 +1,2 @@
+
+unknown

--- a/tests/issues/479.smt2
+++ b/tests/issues/479.smt2
@@ -1,0 +1,9 @@
+(set-logic ALL)
+
+(declare-const x Int)
+(declare-const b Bool)
+
+(assert (<= 2 x))
+(assert (<= x (ite b 2 (div 1 x))))
+
+(check-sat)


### PR DESCRIPTION
When asserting an equality [r1 = r2] between two terms, we are tightening the intervals of both terms to the common intersection, and add the explanations of the equality to the new bounds (this is necessary to preserve soundness).

The intersection function tries to be smart, and immediately raises a "not consistent" exception if it finds that the intervals are disjoint, and it does so *before* we added the explanations to the bounds, which may cause us to incorrectly backjump decisions that are actually relevant 💣

Fixes #479