### PR TITLE
Use dune-build-info for version number (2.4.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ AB-Why3-plugin.cmxs
 fm-simplex-plugin.cma
 fm-simplex-plugin.cmxs
 rsc/extra/ocpchecker/ocp-checker
+*.exe
 
 # Generated documentation files
 rsc/extra/index.html

--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "2.0"}
   "dune-configurator"
+  "dune-build-info"
   "num"
   "ocplib-simplex" {>= "0.4" & < "0.5"}
   "zarith"

--- a/dune-project
+++ b/dune-project
@@ -106,6 +106,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
   (ocaml (>= 4.05.0))
   (dune (and (>= 2.0)))
   dune-configurator
+  dune-build-info
   num
   (ocplib-simplex (and (>= 0.4) (< 0.5)))
   zarith

--- a/src/bin/text/dune
+++ b/src/bin/text/dune
@@ -4,13 +4,13 @@
 )
 
 (executable
-  (name         Main_text)
-  (public_name  alt-ergo)
-  (package      alt-ergo)
-  (libraries    alt_ergo_common)
-  (link_flags   (:include flags.dune))
-  (modules      Main_text)
-)
+  (name Main_text)
+  (public_name alt-ergo)
+  (package alt-ergo)
+  (libraries alt_ergo_common)
+  (link_flags (:include flags.dune))
+  (modules Main_text)
+  (promote (until-clean)))
 
 ; Rule to generate a man page for alt-ergo
 (rule

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -21,7 +21,16 @@
 
   ; external dependencies
   (libraries
-     seq unix num str zarith dynlink ocplib-simplex stdlib-shims)
+    seq
+    unix
+    num
+    str
+    zarith
+    dynlink
+    ocplib-simplex
+    stdlib-shims
+    dune-build-info
+  )
 
   ; .mli only modules *also* need to be in this field
   (modules_without_implementation matching_types numbersInterface sig sig_rel)

--- a/src/lib/util/version.ml
+++ b/src/lib/util/version.ml
@@ -26,13 +26,11 @@
 (*                                                                            *)
 (******************************************************************************)
 
-(* WARNING: a "cut" is performed on the following file in the Makefile.
-   DO NOT CHANGE its format *)
+let _version =
+  match Build_info.V1.version () with
+  | None -> "%%VERSION_NUM%%"
+  | Some v -> Build_info.V1.Version.to_string v
 
-let _version="dev"
+let _release_commit = "%%VCS_COMMIT_ID%%"
 
-let _release_commit = "(not released)"
-
-let _release_date   = "(not released)"
-
-
+let _release_date   = "%%BUILD_DATE%%"


### PR DESCRIPTION
Currently making alt-ergo releases involves changing the version in version.ml and running a bunch of scripts.

This means that it is rarely done, and that executables built the "regular" way (i.e. not for a release) always report "dev" as their version, which is less than ideal for determining from what source a specific executable was built.

This patch uses the dune-build-info library to get the commit version that was used when building alt-ergo. Because the dune-build-info version is only available when the executable has been either promoted or installed, and we usually don't want to install dev binaries, the alt-ergo binary is now promoted into the source directory (in src/bin/text/Main_text.exe).  This binary has the current git hash embedded as version through dune-build-info.  To facilitate its use, the toplevel `alt-ergo` symlink comes back, and now points to `src/bin/text/Main_text.exe`.

In addition, the public-release Makefile target now replaces the tags %%VERSION_NUM%%, %%VCS_COMMIT_ID%% and %%BUILD_DATE%% (with the same behavior as `dune subst` or `dune-release`, except for the 3rd one that doesn't exist in these tools) with their appropriate values and no longer resort to brittle cuts and the like.  Although I don't know how important this is because `make public-release` is clearly broken right now (e.g. it tries to copy files from the directory licences instead of licenses).