### PR TITLE
WIP: get rid of module rec and functors by moving many types into types.ml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,9 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 	dot -Tpdf archi.dot > archi.pdf
 
 deps:
+	opam install --deps-only .
+
+dune-deps:
 	dune-deps . | dot -Tpng -o docs/deps.png
 
 .PHONY: archi deps

--- a/src/bin/gui/annoted_ast.ml
+++ b/src/bin/gui/annoted_ast.ml
@@ -130,7 +130,7 @@ and at_desc =
   | ATrecord of (Hstring.t * aterm) list
   | ATnamed of Hstring.t * aterm
   | ATmapsTo of Var.t * aterm
-  | ATinInterval of aterm * Symbols.bound * Symbols.bound
+  | ATinInterval of aterm * Types.bound * Types.bound
   (* bool = true <-> interval is_open *)
   | ATite of aform annoted * aterm * aterm
 

--- a/src/bin/gui/annoted_ast.mli
+++ b/src/bin/gui/annoted_ast.mli
@@ -119,7 +119,7 @@ and at_desc =
   | ATrecord of (Hstring.t * aterm) list
   | ATnamed of Hstring.t * aterm
   | ATmapsTo of Var.t * aterm
-  | ATinInterval of aterm * Symbols.bound * Symbols.bound
+  | ATinInterval of aterm * Types.bound * Types.bound
   (* bool = true <-> interval is_open *)
   | ATite of aform annoted * aterm * aterm
 

--- a/src/bin/gui/main_gui.ml
+++ b/src/bin/gui/main_gui.ml
@@ -451,9 +451,9 @@ let add_inst ({ h; _ } as inst_model) orig =
   let id = Expr.id orig in
   let name =
     match Expr.form_view orig with
-    | Expr.Lemma { Expr.name = n ; _ } when Stdlib.(<>) n "" -> n
-    | Expr.Lemma _ | Expr.Unit _ | Expr.Clause _ | Expr.Literal _
-    | Expr.Skolem _ | Expr.Let _ | Expr.Iff _ | Expr.Xor _ ->
+    | Lemma { name = n ; _ } when Stdlib.(<>) n "" -> n
+    | Lemma _ | Types.Unit _ | Types.Clause _ | Types.Literal _
+    | Types.Skolem _ | Types.Let _ | Types.Iff _ | Types.Xor _ ->
       string_of_int id
   in
   let r, n, limit, to_add =

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -56,11 +56,12 @@
     Commands Errors Explanation Fpa_rounding
     Parsed Profiling Satml_types Symbols
     Expr Var Ty Typed Xliteral ModelMap
+    Types
     ; util
     Config Emap Gc_debug Hconsing Hstring Iheap Lists Loc
     MyDynlink MyUnix Numbers NumsNumbers NumbersInterface
     Options Timers Util Vec Version ZarithNumbers Steps Printer Format_shims
-    My_zip
+    My_zip CMap CSet Shostak_pre
   )
 
  (js_of_ocaml

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -96,7 +96,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
         List.fold_left
           (fun env f ->
              SAT.assume env
-               {E.ff=f;
+               {ff=f;
                 origin_name = "";
                 gdist = -1;
                 hdist = -1;
@@ -113,7 +113,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
       in
       ignore (SAT.unsat
                 env
-                {E.ff=E.vrai;
+                {ff=E.vrai;
                  origin_name = "";
                  gdist = -1;
                  hdist = -1;
@@ -163,7 +163,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
           let dep = if is_hyp then Ex.empty else mk_root_dep n f d.st_loc in
           if consistent then
             SAT.assume env
-              {E.ff=f;
+              {ff=f;
                origin_name = n;
                gdist = -1;
                hdist = (if is_hyp then 0 else -1);
@@ -190,7 +190,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
         let dep =
           if consistent then
             let dep' = SAT.unsat env
-                {E.ff=f;
+                {ff=f;
                  origin_name = n;
                  hdist = -1;
                  gdist = 0;
@@ -211,7 +211,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
         print_status (Unsat (d, dep)) (Steps.get_steps ());
         env, false, dep
 
-      | ThAssume ({ Expr.ax_name; Expr.ax_form ; _ } as th_elt) ->
+      | ThAssume ({ ax_name; ax_form ; _ } as th_elt) ->
         if unused_context ax_name used_context then
           acc
         else

--- a/src/lib/frontend/parsed_interface.mli
+++ b/src/lib/frontend/parsed_interface.mli
@@ -32,7 +32,7 @@ val mk_rec_type_decl : Parsed.type_decl list -> decl
 (** Declaration of symbols, functions, predicates, and goals *)
 
 val mk_logic :
-  Loc.t -> Symbols.name_kind -> (string * string) list -> plogic_type -> decl
+  Loc.t -> Types.name_kind -> (string * string) list -> plogic_type -> decl
 
 val mk_function_def :
   Loc.t ->

--- a/src/lib/reasoners/ac.mli
+++ b/src/lib/reasoners/ac.mli
@@ -26,13 +26,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
-module type S = sig
+open Types
 
-  (* the type of amalgamated AC semantic values *)
-  type r
-
-  (* the type of AC semantic values used by the theory *)
-  type t = r Sig.ac
+type t = r ac
 
   (* builds an embeded semantic value from an AC term *)
   val make : Expr.t -> r * Expr.t list
@@ -70,7 +66,3 @@ module type S = sig
   val abstract_selectors : t -> (r * r) list -> r * (r * r) list
 
   val compact : (r * int) list -> (r * int) list
-
-end
-
-module Make (X : Sig.X) : S with type r = X.r

--- a/src/lib/reasoners/adt.mli
+++ b/src/lib/reasoners/adt.mli
@@ -9,20 +9,4 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type 'a abstract =
-  | Constr of
-      { c_name : Hstring.t ; c_ty : Ty.t ; c_args : (Hstring.t * 'a) list }
-  | Select of { d_name : Hstring.t ; d_ty : Ty.t ; d_arg : 'a }
-  | Tester of { t_name : Hstring.t ; t_arg : 'a }
-  (* tester is currently not used to build values *)
-
-  | Alien of 'a
-
-module type ALIEN = sig
-  include Sig.X
-  val embed : r abstract -> r
-  val extract : r -> (r abstract) option
-end
-
-module Shostak
-    (X : ALIEN) : Sig.SHOSTAK with type r = X.r and type t = X.r abstract
+include ( Sig.SHOSTAK with type t = Types.adt )

--- a/src/lib/reasoners/arith.mli
+++ b/src/lib/reasoners/arith.mli
@@ -34,18 +34,4 @@ val calc_power : Numbers.Q.t -> Numbers.Q.t -> Ty.t -> Numbers.Q.t
     Return None if the exception Exit is raised by calc_power *)
 val calc_power_opt : Numbers.Q.t -> Numbers.Q.t -> Ty.t -> Numbers.Q.t option
 
-module Type (X : Sig.X ): Polynome.T with type r = X.r
-
-module Shostak
-    (X : Sig.X)
-    (P : Polynome.EXTENDED_Polynome with type r = X.r) : Sig.SHOSTAK
-  with type r = X.r and type t = P.t
-
-(*
-module Relation
-    (X : Sig.X)
-    (Uf : Uf.S with type r = X.r)
-    (P : Polynome.EXTENDED_Polynome with type r = X.r)
-  : Sig.RELATION
-    with type r = X.r and type uf = Uf.t
-*)
+include ( Sig.SHOSTAK with type t = Types.polynome )

--- a/src/lib/reasoners/arrays.ml
+++ b/src/lib/reasoners/arrays.ml
@@ -26,6 +26,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
+module X = Shostak_pre
+
+(*
 type 'a abstract = unit
 
 module type ALIEN = sig
@@ -38,6 +41,9 @@ module Shostak (X : ALIEN) = struct
 
   type t = X.r abstract
   type r = X.r
+*)
+
+type t = Types.arrays
 
   let name           = "Farrays"
   let is_mine_symb _ _ = false
@@ -80,5 +86,3 @@ module Shostak (X : ALIEN) = struct
       r, Format.asprintf "%a" X.print r (* it's a EUF constant *)
 
     | _ -> assert false
-
-end

--- a/src/lib/reasoners/arrays.mli
+++ b/src/lib/reasoners/arrays.mli
@@ -26,13 +26,4 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type 'a abstract
-
-module type ALIEN = sig
-  include Sig.X
-  val embed : r abstract -> r
-  val extract : r -> (r abstract) option
-end
-
-module Shostak
-    (X : ALIEN) : Sig.SHOSTAK with type r = X.r and type t = X.r abstract
+include ( Sig.SHOSTAK with type t = Types.arrays )

--- a/src/lib/reasoners/arrays_rel.ml
+++ b/src/lib/reasoners/arrays_rel.ml
@@ -26,6 +26,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 module Sy = Symbols
 module E  = Expr
 module A  = Xliteral
@@ -167,7 +169,7 @@ end
 
 (* met a jour gets et tbset en utilisant l'ensemble des termes donne*)
 let rec update_gets_sets acc t =
-  let { E.f; xs; ty; _ } = E.term_view t in
+  let { f; xs; ty; _ } = E.term_view t in
   let gets, tbset = List.fold_left update_gets_sets acc xs in
   match Sy.is_get f, Sy.is_set f, xs with
   | true , false, [a;i]   -> G.add {g=t; gt=a; gi=i; gty=ty} gets, tbset
@@ -232,12 +234,12 @@ let get_of_set are_eq are_dist gtype (env,acc) class_of =
        if Tmap.splited get set env.seen then (env,acc)
        else
          let env = {env with seen = Tmap.update get set env.seen} in
-         let { E.f; xs; _ } = E.term_view set in
+         let { f; xs; _ } = E.term_view set in
          match Sy.is_set f, xs with
          | true , [stab;si;sv] ->
            let xi, _ = X.make gi in
            let xj, _ = X.make si in
-           let get_stab  = E.mk_term (Sy.Op Sy.Get) [stab;gi] gty in
+           let get_stab  = E.mk_term (Types.Op Types.Get) [stab;gi] gty in
            let p       = LR.mk_eq xi xj in
            let p_ded   = E.mk_eq ~iff:false get sv in
            let n     = LR.mk_distinct false [xi;xj] in
@@ -265,7 +267,7 @@ let get_from_set _are_eq _are_dist stype (env,acc) class_of =
 
   S.fold (fun { s = set; si = si; sv = sv; _ } (env,acc) ->
       let ty_si = E.type_info sv in
-      let get = E.mk_term (Sy.Op Sy.Get) [set; si] ty_si in
+      let get = E.mk_term (Types.Op Types.Get) [set; si] ty_si in
       if Tmap.splited get set env.seen then (env,acc)
       else
         let env = {env with
@@ -295,8 +297,8 @@ let get_and_set are_eq are_dist gtype (env,acc) class_of =
            let env = {env with seen = Tmap.update get set env.seen} in
            let xi, _ = X.make gi in
            let xj, _ = X.make si in
-           let get_stab  = E.mk_term (Sy.Op Sy.Get) [stab;gi] gty in
-           let gt_of_st  = E.mk_term (Sy.Op Sy.Get) [set;gi] gty in
+           let get_stab  = E.mk_term (Types.Op Types.Get) [stab;gi] gty in
+           let gt_of_st  = E.mk_term (Types.Op Types.Get) [set;gi] gty in
            let p       = LR.mk_eq xi xj in
            let p_ded   = E.mk_eq ~iff:false gt_of_st sv in
            let n     = LR.mk_distinct false [xi;xj] in
@@ -342,8 +344,8 @@ let extensionality accu la _class_of =
            match X.type_info r, X.term_extract r, X.term_extract s with
            | Ty.Tfarray (ty_k, ty_v), (Some t1, _), (Some t2, _)  ->
              let i  = E.fresh_name ty_k in
-             let g1 = E.mk_term (Sy.Op Sy.Get) [t1;i] ty_v in
-             let g2 = E.mk_term (Sy.Op Sy.Get) [t2;i] ty_v in
+             let g1 = E.mk_term (Types.Op Types.Get) [t1;i] ty_v in
+             let g2 = E.mk_term (Types.Op Types.Get) [t2;i] ty_v in
              let d  = E.mk_distinct ~iff:false [g1;g2] in
              let acc = Conseq.add (d, dep) acc in
              let env =
@@ -444,7 +446,7 @@ let new_terms env = env.new_terms
 let instantiate ~do_syntactic_matching:_ _ env _ _ = env, []
 
 let assume_th_elt t th_elt _ =
-  match th_elt.Expr.extends with
+  match th_elt.extends with
   | Util.Arrays ->
     failwith "This Theory does not support theories extension"
   | _ -> t

--- a/src/lib/reasoners/bitv.mli
+++ b/src/lib/reasoners/bitv.mli
@@ -26,13 +26,4 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type 'a abstract
-
-module type ALIEN = sig
-  include Sig.X
-  val embed : r abstract -> r
-  val extract : r -> (r abstract) option
-end
-
-module Shostak
-    (X : ALIEN) : Sig.SHOSTAK with type r = X.r and type t = X.r abstract
+include ( Sig.SHOSTAK with type t = Types.bitv )

--- a/src/lib/reasoners/bitv_rel.ml
+++ b/src/lib/reasoners/bitv_rel.ml
@@ -26,6 +26,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 type t = unit
 
 let empty _ = ()
@@ -38,7 +40,7 @@ let new_terms _ = Expr.Set.empty
 let instantiate ~do_syntactic_matching:_ _ env _ _ = env, []
 
 let assume_th_elt t th_elt _ =
-  match th_elt.Expr.extends with
+  match th_elt.extends with
   | Util.Bitv ->
     failwith "This Theory does not support theories extension"
   | _ -> t

--- a/src/lib/reasoners/cMap.ml
+++ b/src/lib/reasoners/cMap.ml
@@ -1,0 +1,490 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+type ('a,'b) map =
+    Empty
+  | Node of {l:('a,'b) map; v:'a; d:'b; r:('a,'b) map; h:int}
+
+type 'a compare = 'a -> 'a -> int
+
+let height = function
+    Empty -> 0
+  | Node {h;_} -> h
+
+let create l x d r =
+  let hl = height l and hr = height r in
+  Node{l; v=x; d; r; h=(if hl >= hr then hl + 1 else hr + 1)}
+
+let singleton x d = Node{l=Empty; v=x; d; r=Empty; h=1}
+
+let bal l x d r =
+  let hl = match l with Empty -> 0 | Node {h;_} -> h in
+  let hr = match r with Empty -> 0 | Node {h;_} -> h in
+  if hl > hr + 2 then begin
+    match l with
+      Empty -> invalid_arg "Map.bal"
+    | Node{l=ll; v=lv; d=ld; r=lr; _} ->
+      if height ll >= height lr then
+        create ll lv ld (create lr x d r)
+      else begin
+        match lr with
+          Empty -> invalid_arg "Map.bal"
+        | Node{l=lrl; v=lrv; d=lrd; r=lrr;_}->
+          create (create ll lv ld lrl) lrv lrd (create lrr x d r)
+      end
+  end else if hr > hl + 2 then begin
+    match r with
+      Empty -> invalid_arg "Map.bal"
+    | Node{l=rl; v=rv; d=rd; r=rr;_} ->
+      if height rr >= height rl then
+        create (create l x d rl) rv rd rr
+      else begin
+        match rl with
+          Empty -> invalid_arg "Map.bal"
+        | Node{l=rll; v=rlv; d=rld; r=rlr; _} ->
+          create (create l x d rll) rlv rld (create rlr rv rd rr)
+      end
+  end else
+    Node{l; v=x; d; r; h=(if hl >= hr then hl + 1 else hr + 1)}
+
+let empty = Empty
+
+let is_empty = function Empty -> true | _ -> false
+
+let rec add compare x data = function
+    Empty ->
+    Node{l=Empty; v=x; d=data; r=Empty; h=1}
+  | Node {l; v; d; r; h} as m ->
+    let c = compare x v in
+    if c = 0 then
+      if d == data then m else Node{l; v=x; d=data; r; h}
+    else if c < 0 then
+      let ll = add compare x data l in
+      if l == ll then m else bal ll v d r
+    else
+      let rr = add compare x data r in
+      if r == rr then m else bal l v d rr
+
+let rec find compare x = function
+    Empty ->
+    raise Not_found
+  | Node {l; v; d; r; _} ->
+    let c = compare x v in
+    if c = 0 then d
+    else find compare x (if c < 0 then l else r)
+
+let rec find_first_aux v0 d0 f = function
+    Empty ->
+    (v0, d0)
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_first_aux v d f l
+    else
+      find_first_aux v0 d0 f r
+
+let rec find_first f = function
+    Empty ->
+    raise Not_found
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_first_aux v d f l
+    else
+      find_first f r
+
+let rec find_first_opt_aux v0 d0 f = function
+    Empty ->
+    Some (v0, d0)
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_first_opt_aux v d f l
+    else
+      find_first_opt_aux v0 d0 f r
+
+let rec find_first_opt f = function
+    Empty ->
+    None
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_first_opt_aux v d f l
+    else
+      find_first_opt f r
+
+let rec find_last_aux v0 d0 f = function
+    Empty ->
+    (v0, d0)
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_last_aux v d f r
+    else
+      find_last_aux v0 d0 f l
+
+let rec find_last f = function
+    Empty ->
+    raise Not_found
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_last_aux v d f r
+    else
+      find_last f l
+
+let rec find_last_opt_aux v0 d0 f = function
+    Empty ->
+    Some (v0, d0)
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_last_opt_aux v d f r
+    else
+      find_last_opt_aux v0 d0 f l
+
+let rec find_last_opt f = function
+    Empty ->
+    None
+  | Node {l; v; d; r; _} ->
+    if f v then
+      find_last_opt_aux v d f r
+    else
+      find_last_opt f l
+
+let rec find_opt compare x = function
+    Empty ->
+    None
+  | Node {l; v; d; r; _} ->
+    let c = compare x v in
+    if c = 0 then Some d
+    else find_opt compare x (if c < 0 then l else r)
+
+let rec mem compare x = function
+    Empty ->
+    false
+  | Node {l; v; r; _} ->
+    let c = compare x v in
+    c = 0 || mem compare x (if c < 0 then l else r)
+
+let rec min_binding = function
+    Empty -> raise Not_found
+  | Node {l=Empty; v; d; _} -> (v, d)
+  | Node {l; _} -> min_binding l
+
+let rec min_binding_opt = function
+    Empty -> None
+  | Node {l=Empty; v; d; _} -> Some (v, d)
+  | Node {l; _}-> min_binding_opt l
+
+let rec max_binding = function
+    Empty -> raise Not_found
+  | Node {v; d; r=Empty; _} -> (v, d)
+  | Node {r; _} -> max_binding r
+
+let rec max_binding_opt = function
+    Empty -> None
+  | Node {v; d; r=Empty; _} -> Some (v, d)
+  | Node {r; _} -> max_binding_opt r
+
+let rec remove_min_binding = function
+    Empty -> invalid_arg "Map.remove_min_elt"
+  | Node {l=Empty; r; _} -> r
+  | Node {l; v; d; r; _} -> bal (remove_min_binding l) v d r
+
+let merge t1 t2 =
+  match (t1, t2) with
+    (Empty, t) -> t
+  | (t, Empty) -> t
+  | (_, _) ->
+    let (x, d) = min_binding t2 in
+    bal t1 x d (remove_min_binding t2)
+
+let rec remove compare x = function
+    Empty ->
+    Empty
+  | (Node {l; v; d; r; _} as m) ->
+    let c = compare x v in
+    if c = 0 then merge l r
+    else if c < 0 then
+      let ll = remove compare x l in if l == ll then m else bal ll v d r
+    else
+      let rr = remove compare x r in if r == rr then m else bal l v d rr
+
+let rec update compare x f = function
+    Empty ->
+    begin match f None with
+      | None -> Empty
+      | Some data -> Node{l=Empty; v=x; d=data; r=Empty; h=1}
+    end
+  | Node {l; v; d; r; h} as m ->
+    let c = compare x v in
+    if c = 0 then begin
+      match f (Some d) with
+      | None -> merge l r
+      | Some data ->
+        if d == data then m else Node{l; v=x; d=data; r; h}
+    end else if c < 0 then
+      let ll = update compare x f l in
+      if l == ll then m else bal ll v d r
+    else
+      let rr = update compare x f r in
+      if r == rr then m else bal l v d rr
+
+let add_to_list compare x data m =
+  let add = function None -> Some [data] | Some l -> Some (data :: l) in
+  update compare x add m
+
+let rec iter f = function
+    Empty -> ()
+  | Node {l; v; d; r; _} ->
+    iter f l; f v d; iter f r
+
+let rec map f = function
+    Empty ->
+    Empty
+  | Node {l; v; d; r; h} ->
+    let l' = map f l in
+    let d' = f d in
+    let r' = map f r in
+    Node{l=l'; v; d=d'; r=r'; h}
+
+let rec mapi f = function
+    Empty ->
+    Empty
+  | Node {l; v; d; r; h} ->
+    let l' = mapi f l in
+    let d' = f v d in
+    let r' = mapi f r in
+    Node{l=l'; v; d=d'; r=r'; h}
+
+let rec fold f m accu =
+  match m with
+    Empty -> accu
+  | Node {l; v; d; r; _} ->
+    fold f r (f v d (fold f l accu))
+
+let rec for_all p = function
+    Empty -> true
+  | Node {l; v; d; r; _} -> p v d && for_all p l && for_all p r
+
+let rec exists p = function
+    Empty -> false
+  | Node {l; v; d; r; _} -> p v d || exists p l || exists p r
+
+(* Beware: those two functions assume that the added k is *strictly*
+   smaller (or bigger) than all the present keys in the tree; it
+   does not test for equality with the current min (or max) key.
+
+   Indeed, they are only used during the "join" operation which
+   respects this precondition.
+*)
+
+let rec add_min_binding k x = function
+  | Empty -> singleton k x
+  | Node {l; v; d; r; _} ->
+    bal (add_min_binding k x l) v d r
+
+let rec add_max_binding k x = function
+  | Empty -> singleton k x
+  | Node {l; v; d; r; _} ->
+    bal l v d (add_max_binding k x r)
+
+(* Same as create and bal, but no assumptions are made on the
+   relative heights of l and r. *)
+
+let rec join l v d r =
+  match (l, r) with
+    (Empty, _) -> add_min_binding v d r
+  | (_, Empty) -> add_max_binding v d l
+  | (Node{l=ll; v=lv; d=ld; r=lr; h=lh},
+     Node{l=rl; v=rv; d=rd; r=rr; h=rh}) ->
+    if lh > rh + 2 then bal ll lv ld (join lr v d r) else
+    if rh > lh + 2 then bal (join l v d rl) rv rd rr else
+      create l v d r
+
+(* Merge two trees l and r into one.
+   All elements of l must precede the elements of r.
+   No assumption on the heights of l and r. *)
+
+let concat t1 t2 =
+  match (t1, t2) with
+    (Empty, t) -> t
+  | (t, Empty) -> t
+  | (_, _) ->
+    let (x, d) = min_binding t2 in
+    join t1 x d (remove_min_binding t2)
+
+let concat_or_join t1 v d t2 =
+  match d with
+  | Some d -> join t1 v d t2
+  | None -> concat t1 t2
+
+let rec split compare x = function
+    Empty ->
+    (Empty, None, Empty)
+  | Node {l; v; d; r; _} ->
+    let c = compare x v in
+    if c = 0 then (l, Some d, r)
+    else if c < 0 then
+      let (ll, pres, rl) = split compare x l in (ll, pres, join rl v d r)
+    else
+      let (lr, pres, rr) = split compare x r in (join l v d lr, pres, rr)
+
+let rec merge compare f s1 s2 =
+  match (s1, s2) with
+    (Empty, Empty) -> Empty
+  | (Node {l=l1; v=v1; d=d1; r=r1; h=h1}, _) when h1 >= height s2 ->
+    let (l2, d2, r2) = split compare v1 s2 in
+    concat_or_join (merge compare f l1 l2) v1 (f v1 (Some d1) d2) (merge compare f r1 r2)
+  | (_, Node {l=l2; v=v2; d=d2; r=r2; _}) ->
+    let (l1, d1, r1) = split compare v2 s1 in
+    concat_or_join (merge compare f l1 l2) v2 (f v2 d1 (Some d2)) (merge compare f r1 r2)
+  | _ ->
+    assert false
+
+let rec union compare f s1 s2 =
+  match (s1, s2) with
+  | (Empty, s) | (s, Empty) -> s
+  | (Node {l=l1; v=v1; d=d1; r=r1; h=h1},
+     Node {l=l2; v=v2; d=d2; r=r2; h=h2}) ->
+    if h1 >= h2 then
+      let (l2, d2, r2) = split compare v1 s2 in
+      let l = union compare f l1 l2 and r = union compare f r1 r2 in
+      match d2 with
+      | None -> join l v1 d1 r
+      | Some d2 -> concat_or_join l v1 (f v1 d1 d2) r
+    else
+      let (l1, d1, r1) = split compare v2 s1 in
+      let l = union compare f l1 l2 and r = union compare f r1 r2 in
+      match d1 with
+      | None -> join l v2 d2 r
+      | Some d1 -> concat_or_join l v2 (f v2 d1 d2) r
+
+let rec filter p = function
+    Empty -> Empty
+  | Node {l; v; d; r; _} as m ->
+    (* call [p] in the expected left-to-right order *)
+    let l' = filter p l in
+    let pvd = p v d in
+    let r' = filter p r in
+    if pvd then if l==l' && r==r' then m else join l' v d r'
+    else concat l' r'
+
+let rec filter_map f = function
+    Empty -> Empty
+  | Node {l; v; d; r; _} ->
+    (* call [f] in the expected left-to-right order *)
+    let l' = filter_map f l in
+    let fvd = f v d in
+    let r' = filter_map f r in
+    begin match fvd with
+      | Some d' -> join l' v d' r'
+      | None -> concat l' r'
+    end
+
+let rec partition p = function
+    Empty -> (Empty, Empty)
+  | Node {l; v; d; r; _} ->
+    (* call [p] in the expected left-to-right order *)
+    let (lt, lf) = partition p l in
+    let pvd = p v d in
+    let (rt, rf) = partition p r in
+    if pvd
+    then (join lt v d rt, concat lf rf)
+    else (concat lt rt, join lf v d rf)
+
+type ('key, 'a) enumeration =
+    End
+  | More of 'key * 'a * ('key,'a) map * ('key, 'a) enumeration
+
+let rec cons_enum m e =
+  match m with
+    Empty -> e
+  | Node {l; v; d; r; _} -> cons_enum l (More(v, d, r, e))
+
+let compare compare cmp m1 m2 =
+  let rec compare_aux e1 e2 =
+    match (e1, e2) with
+      (End, End) -> 0
+    | (End, _)  -> -1
+    | (_, End) -> 1
+    | (More(v1, d1, r1, e1), More(v2, d2, r2, e2)) ->
+      let c = compare v1 v2 in
+      if c <> 0 then c else
+        let c = cmp d1 d2 in
+        if c <> 0 then c else
+          compare_aux (cons_enum r1 e1) (cons_enum r2 e2)
+  in compare_aux (cons_enum m1 End) (cons_enum m2 End)
+
+let equal compare cmp m1 m2 =
+  let rec equal_aux e1 e2 =
+    match (e1, e2) with
+      (End, End) -> true
+    | (End, _)  -> false
+    | (_, End) -> false
+    | (More(v1, d1, r1, e1), More(v2, d2, r2, e2)) ->
+      compare v1 v2 = 0 && cmp d1 d2 &&
+      equal_aux (cons_enum r1 e1) (cons_enum r2 e2)
+  in equal_aux (cons_enum m1 End) (cons_enum m2 End)
+
+let rec cardinal = function
+    Empty -> 0
+  | Node {l; r; _} -> cardinal l + 1 + cardinal r
+
+let rec bindings_aux accu = function
+    Empty -> accu
+  | Node {l; v; d; r; _} -> bindings_aux ((v, d) :: bindings_aux accu r) l
+
+let bindings s =
+  bindings_aux [] s
+
+let choose = min_binding
+
+let choose_opt = min_binding_opt
+
+let to_list = bindings
+let of_list compare bs =
+  List.fold_left (fun m (k, v) -> add compare k v m) empty bs
+
+let add_seq compare i m =
+  Seq.fold_left (fun m (k,v) -> add compare k v m) m i
+
+let of_seq compare i = add_seq compare i empty
+
+let rec seq_of_enum_ c () = match c with
+  | End -> Seq.Nil
+  | More (k,v,t,rest) -> Seq.Cons ((k,v), seq_of_enum_ (cons_enum t rest))
+
+let to_seq m =
+  seq_of_enum_ (cons_enum m End)
+
+let rec snoc_enum s e =
+  match s with
+    Empty -> e
+  | Node{l; v; d; r; _} -> snoc_enum r (More(v, d, l, e))
+
+let rec rev_seq_of_enum_ c () = match c with
+  | End -> Seq.Nil
+  | More (k,v,t,rest) ->
+    Seq.Cons ((k,v), rev_seq_of_enum_ (snoc_enum t rest))
+
+let to_rev_seq c =
+  rev_seq_of_enum_ (snoc_enum c End)
+
+let to_seq_from compare low m =
+  let rec aux low m c = match m with
+    | Empty -> c
+    | Node {l; v; d; r; _} ->
+      begin match compare v low with
+        | 0 -> More (v, d, r, c)
+        | n when n<0 -> aux low r c
+        | _ -> aux low l (More (v, d, r, c))
+      end
+  in
+  seq_of_enum_ (aux low m End)

--- a/src/lib/reasoners/cMap.mli
+++ b/src/lib/reasoners/cMap.mli
@@ -1,0 +1,341 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* NOTE: If this file is map.mli, do not edit it directly! Instead,
+   edit templates/map.template.mli and run tools/sync_stdlib_docs *)
+
+(** Association tables over ordered types.
+
+    This module implements applicative association tables, also known as
+    finite maps or dictionaries, given a total ordering function
+    over the keys.
+    All operations over maps are purely applicative (no side-effects).
+    The implementation uses balanced binary trees, and therefore searching
+    and insertion take time logarithmic in the size of the map.
+
+    For instance:
+    {[
+      module IntPairs =
+      struct
+        type t = int * int
+        let compare (x0,y0) (x1,y1) =
+          match Stdlib.compare x0 x1 with
+            0 -> Stdlib.compare y0 y1
+          | c -> c
+      end
+
+      module PairsMap = Map.Make(IntPairs)
+
+      let m = PairsMap.(empty |> add (0,1) "hello" |> add (1,0) "world")
+    ]}
+
+    This creates a new module [PairsMap], with a new type ['a PairsMap.t]
+    of maps from [int * int] to ['a]. In this example, [m] contains [string]
+    values so its type is [string PairsMap.t].
+*)
+
+(** {1:maps Maps} *)
+
+type ('a,'b) map
+(** The type of maps from type ['a] to type ['b]. *)
+
+type 'a compare = 'a -> 'a -> int
+
+val empty: ('a,'b) map
+(** The empty map. *)
+
+val add: 'a compare -> 'a -> 'b -> ('a,'b) map -> ('a,'b) map
+(** [add key data m] returns a map containing the same bindings as
+        [m], plus a binding of [key] to [data]. If [key] was already bound
+        in [m] to a value that is physically equal to [data],
+        [m] is returned unchanged (the result of the function is
+        then physically equal to [m]). Otherwise, the previous binding
+        of [key] in [m] disappears.
+        @before 4.03 Physical equality was not ensured. *)
+
+val add_to_list: 'a compare -> 'a -> 'b -> ('a, 'b list) map -> ('a, 'b list) map
+(** [add_to_list key data m] is [m] with [key] mapped to [l] such
+    that [l] is [data :: Map.find key m] if [key] was bound in
+    [m] and [[v]] otherwise.
+    @since 5.1 *)
+
+val update: 'a compare -> 'a -> ('b option -> 'b option) -> ('a,'b) map -> ('a,'b) map
+(** [update key f m] returns a map containing the same bindings as
+    [m], except for the binding of [key]. Depending on the value of
+    [y] where [y] is [f (find_opt key m)], the binding of [key] is
+    added, removed or updated. If [y] is [None], the binding is
+    removed if it exists; otherwise, if [y] is [Some z] then [key]
+    is associated to [z] in the resulting map.  If [key] was already
+    bound in [m] to a value that is physically equal to [z], [m]
+    is returned unchanged (the result of the function is then
+    physically equal to [m]).
+    @since 4.06 *)
+
+val singleton: 'a -> 'b -> ('a,'b) map
+(** [singleton x y] returns the one-element map that contains a binding
+    [y] for [x].
+    @since 3.12 *)
+
+val remove: 'a compare -> 'a -> ('a,'b) map -> ('a,'b) map
+(** [remove x m] returns a map containing the same bindings as
+    [m], except for [x] which is unbound in the returned map.
+    If [x] was not in [m], [m] is returned unchanged
+    (the result of the function is then physically equal to [m]).
+    @before 4.03 Physical equality was not ensured. *)
+
+val merge: 'a compare ->
+  ('a -> 'b option -> 'b option -> 'c option) ->
+  ('a,'b) map -> ('a,'b) map -> ('a,'c) map
+(** [merge f m1 m2] computes a map whose keys are a subset of the keys of
+    [m1] and of [m2]. The presence of each such binding, and the
+    corresponding value, is determined with the function [f].
+    In terms of the [find_opt] operation, we have
+    [find_opt x (merge f m1 m2) = f x (find_opt x m1) (find_opt x m2)]
+    for any key [x], provided that [f x None None = None].
+    @since 3.12 *)
+
+val union: 'a compare -> ('a -> 'b -> 'b -> 'b option) -> ('a,'b) map -> ('a,'b) map -> ('a,'b) map
+(** [union f m1 m2] computes a map whose keys are a subset of the keys
+    of [m1] and of [m2].  When the same binding is defined in both
+    arguments, the function [f] is used to combine them.
+    This is a special case of [merge]: [union f m1 m2] is equivalent
+    to [merge f' m1 m2], where
+    - [f' _key None None = None]
+    - [f' _key (Some v) None = Some v]
+    - [f' _key None (Some v) = Some v]
+    - [f' key (Some v1) (Some v2) = f key v1 v2]
+
+    @since 4.03 *)
+
+val cardinal: ('a,'b) map -> int
+(** Return the number of bindings of a map.
+    @since 3.12 *)
+
+(** {1:bindings Bindings} *)
+
+val bindings: ('a,'b) map -> ('a * 'b) list
+(** Return the list of all bindings of the given map.
+    The returned list is sorted in increasing order of keys with respect
+    to the ordering [Ord.compare], where [Ord] is the argument
+    given to {!Map.Make}.
+    @since 3.12 *)
+
+val min_binding: ('a,'b) map -> ('a * 'b)
+(** Return the binding with the smallest key in a given map
+    (with respect to the [Ord.compare] ordering), or raise
+    [Not_found] if the map is empty.
+    @since 3.12 *)
+
+val min_binding_opt: ('a,'b) map -> ('a * 'b) option
+(** Return the binding with the smallest key in the given map
+    (with respect to the [Ord.compare] ordering), or [None]
+    if the map is empty.
+    @since 4.05 *)
+
+val max_binding: ('a,'b) map -> ('a * 'b)
+(** Same as {!min_binding}, but returns the binding with
+    the largest key in the given map.
+    @since 3.12 *)
+
+val max_binding_opt: ('a,'b) map -> ('a * 'b) option
+(** Same as {!min_binding_opt}, but returns the binding with
+    the largest key in the given map.
+    @since 4.05 *)
+
+val choose: ('a,'b) map -> ('a * 'b)
+(** Return one binding of the given map, or raise [Not_found] if
+    the map is empty. Which binding is chosen is unspecified,
+    but equal bindings will be chosen for equal maps.
+    @since 3.12 *)
+
+val choose_opt: ('a,'b) map -> ('a * 'b) option
+(** Return one binding of the given map, or [None] if
+    the map is empty. Which binding is chosen is unspecified,
+    but equal bindings will be chosen for equal maps.
+    @since 4.05 *)
+
+(** {1:searching Searching} *)
+
+val find: 'a compare -> 'a -> ('a,'b) map -> 'b
+(** [find x m] returns the current value of [x] in [m],
+    or raises [Not_found] if no binding for [x] exists. *)
+
+val find_opt: 'a compare -> 'a -> ('a,'b) map -> 'b option
+(** [find_opt x m] returns [Some v] if the current value of [x]
+    in [m] is [v], or [None] if no binding for [x] exists.
+    @since 4.05 *)
+
+val find_first: ('a -> bool) -> ('a,'b) map -> 'a * 'b
+(** [find_first f m], where [f] is a monotonically increasing function,
+    returns the binding of [m] with the lowest key [k] such that [f k],
+    or raises [Not_found] if no such key exists.
+
+    For example, [find_first (fun k -> Ord.compare k x >= 0) m] will
+    return the first binding [k, v] of [m] where [Ord.compare k x >= 0]
+    (intuitively: [k >= x]), or raise [Not_found] if [x] is greater than
+    any element of [m].
+
+    @since 4.05 *)
+
+val find_first_opt: ('a -> bool) -> ('a,'b) map -> ('a * 'b) option
+(** [find_first_opt f m], where [f] is a monotonically increasing
+    function, returns an option containing the binding of [m] with the
+    lowest key [k] such that [f k], or [None] if no such key exists.
+    @since 4.05 *)
+
+val find_last: ('a -> bool) -> ('a,'b) map -> 'a * 'b
+(** [find_last f m], where [f] is a monotonically decreasing function,
+    returns the binding of [m] with the highest key [k] such that [f k],
+    or raises [Not_found] if no such key exists.
+    @since 4.05 *)
+
+val find_last_opt: ('a -> bool) -> ('a,'b) map -> ('a * 'b) option
+(** [find_last_opt f m], where [f] is a monotonically decreasing
+    function, returns an option containing the binding of [m] with
+    the highest key [k] such that [f k], or [None] if no such key
+    exists.
+    @since 4.05 *)
+
+(** {1:traversing Traversing} *)
+
+val iter: ('a -> 'b -> unit) -> ('a,'b) map -> unit
+(** [iter f m] applies [f] to all bindings in map [m].
+    [f] receives the key as first argument, and the associated value
+    as second argument.  The bindings are passed to [f] in increasing
+    order with respect to the ordering over the type of the keys. *)
+
+val fold:
+  ('a -> 'b -> 'acc -> 'acc) -> ('a,'b) map -> 'acc -> 'acc
+(** [fold f m init] computes [(f kN dN ... (f k1 d1 init)...)],
+    where [k1 ... kN] are the keys of all bindings in [m]
+    (in increasing order), and [d1 ... dN] are the associated data. *)
+
+(** {1:transforming Transforming} *)
+
+val map: ('b -> 'b) -> ('a,'b) map -> ('a,'b) map
+(** [map f m] returns a map with same domain as [m], where the
+    associated value [a] of all bindings of [m] has been
+    replaced by the result of the application of [f] to [a].
+    The bindings are passed to [f] in increasing order
+    with respect to the ordering over the type of the keys. *)
+
+val mapi: ('a -> 'b -> 'b) -> ('a,'b) map -> ('a,'b) map
+(** Same as {!map}, but the function receives as arguments both the
+    key and the associated value for each binding of the map. *)
+
+val filter: ('a -> 'b -> bool) -> ('a,'b) map -> ('a,'b) map
+(** [filter f m] returns the map with all the bindings in [m]
+    that satisfy predicate [p]. If every binding in [m] satisfies [f],
+    [m] is returned unchanged (the result of the function is then
+    physically equal to [m])
+    @since 3.12
+    @before 4.03 Physical equality was not ensured. *)
+
+val filter_map: ('a -> 'b -> 'b option) -> ('a,'b) map -> ('a,'b) map
+(** [filter_map f m] applies the function [f] to every binding of
+    [m], and builds a map from the results. For each binding
+    [(k, v)] in the input map:
+    - if [f k v] is [None] then [k] is not in the result,
+    - if [f k v] is [Some v'] then the binding [(k, v')]
+      is in the output map.
+
+    For example, the following function on maps whose values are lists
+    {[
+      filter_map
+        (fun _k li -> match li with [] -> None | _::tl -> Some tl)
+        m
+    ]}
+    drops all bindings of [m] whose value is an empty list, and pops
+    the first element of each value that is non-empty.
+
+    @since 4.11 *)
+
+val partition: ('a -> 'b -> bool) -> ('a,'b) map -> ('a,'b) map * ('a,'b) map
+(** [partition f m] returns a pair of maps [(m1, m2)], where
+    [m1] contains all the bindings of [m] that satisfy the
+    predicate [f], and [m2] is the map with all the bindings of
+    [m] that do not satisfy [f].
+    @since 3.12 *)
+
+val split: 'a compare -> 'a -> ('a,'b) map -> ('a,'b) map * 'b option * ('a,'b) map
+(** [split x m] returns a triple [(l, data, r)], where
+      [l] is the map with all the bindings of [m] whose key
+    is strictly less than [x];
+      [r] is the map with all the bindings of [m] whose key
+    is strictly greater than [x];
+      [data] is [None] if [m] contains no binding for [x],
+      or [Some v] if [m] binds [v] to [x].
+    @since 3.12 *)
+
+(** {1:predicates Predicates and comparisons} *)
+
+val is_empty: ('a,'b) map -> bool
+(** Test whether a map is empty or not. *)
+
+val mem: 'a compare -> 'a -> ('a,'b) map -> bool
+(** [mem x m] returns [true] if [m] contains a binding for [x],
+    and [false] otherwise. *)
+
+val equal: 'a compare -> ('b -> 'b -> bool) -> ('a,'b) map -> ('a,'b) map -> bool
+(** [equal cmp m1 m2] tests whether the maps [m1] and [m2] are
+    equal, that is, contain equal keys and associate them with
+    equal data.  [cmp] is the equality predicate used to compare
+    the data associated with the keys. *)
+
+val compare: 'a compare -> ('b -> 'b -> int) -> ('a,'b) map -> ('a,'b) map -> int
+(** Total ordering between maps.  The first argument is a total ordering
+    used to compare data associated with equal keys in the two maps. *)
+
+val for_all: ('a -> 'b -> bool) -> ('a,'b) map -> bool
+(** [for_all f m] checks if all the bindings of the map
+    satisfy the predicate [f].
+    @since 3.12 *)
+
+val exists: ('a -> 'b -> bool) -> ('a,'b) map -> bool
+(** [exists f m] checks if at least one binding of the map satisfies
+    the predicate [f].  @since 3.12 *)
+
+(** {1:converting Converting} *)
+
+val to_list : ('a,'b) map -> ('a * 'b) list
+(** [to_list m] is {!bindings}[ m].
+    @since 5.1 *)
+
+val of_list : 'a compare -> ('a * 'b) list -> ('a,'b) map
+(** [of_list bs] adds the bindings of [bs] to the empty map,
+    in list order (if a key is bound twice in [bs] the last one
+    takes over).
+    @since 5.1 *)
+
+val to_seq : ('a,'b) map -> ('a * 'b) Seq.t
+(** Iterate on the whole map, in ascending order of keys
+    @since 4.07 *)
+
+val to_rev_seq : ('a,'b) map -> ('a * 'b) Seq.t
+(** Iterate on the whole map, in descending order of keys
+    @since 4.12 *)
+
+val to_seq_from : 'a compare -> 'a -> ('a,'b) map -> ('a * 'b) Seq.t
+(** [to_seq_from k m] iterates on a subset of the bindings of [m],
+    in ascending order of keys, from key [k] or above.
+    @since 4.07 *)
+
+val add_seq : 'a compare -> ('a * 'b) Seq.t -> ('a,'b) map -> ('a,'b) map
+(** Add the given bindings to the map, in order.
+        @since 4.07 *)
+
+val of_seq : 'a compare -> ('a * 'b) Seq.t -> ('a,'b) map
+(** Build a map from the given bindings
+    @since 4.07 *)

--- a/src/lib/reasoners/cSet.ml
+++ b/src/lib/reasoners/cSet.ml
@@ -1,0 +1,569 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Sets over ordered types *)
+type 'a set =
+    Empty
+  | Node of {l:'a set; v:'a; r:'a set; h:int}
+
+type 'a setcmp = 'a -> 'a -> int
+
+(* Sets are represented by balanced binary trees (the heights of the
+   children differ by at most 2 *)
+
+let height = function
+    Empty -> 0
+  | Node {h;_} -> h
+
+(* Creates a new node with left son l, value v and right son r.
+   We must have all elements of l < v < all elements of r.
+   l and r must be balanced and | height l - height r | <= 2.
+   Inline expansion of height for better speed. *)
+
+let create l v r =
+  let hl = match l with Empty -> 0 | Node {h;_} -> h in
+  let hr = match r with Empty -> 0 | Node {h;_} -> h in
+  Node{l; v; r; h=(if hl >= hr then hl + 1 else hr + 1)}
+
+(* Same as create, but performs one step of rebalancing if necessary.
+   Assumes l and r balanced and | height l - height r | <= 3.
+   Inline expansion of create for better speed in the most frequent case
+   where no rebalancing is required. *)
+
+let bal l v r =
+  let hl = match l with Empty -> 0 | Node {h;_} -> h in
+  let hr = match r with Empty -> 0 | Node {h;_} -> h in
+  if hl > hr + 2 then begin
+    match l with
+      Empty -> invalid_arg "Set.bal"
+    | Node{l=ll; v=lv; r=lr; _} ->
+      if height ll >= height lr then
+        create ll lv (create lr v r)
+      else begin
+        match lr with
+          Empty -> invalid_arg "Set.bal"
+        | Node{l=lrl; v=lrv; r=lrr; _}->
+          create (create ll lv lrl) lrv (create lrr v r)
+      end
+  end else if hr > hl + 2 then begin
+    match r with
+      Empty -> invalid_arg "Set.bal"
+    | Node{l=rl; v=rv; r=rr; _} ->
+      if height rr >= height rl then
+        create (create l v rl) rv rr
+      else begin
+        match rl with
+          Empty -> invalid_arg "Set.bal"
+        | Node{l=rll; v=rlv; r=rlr; _} ->
+          create (create l v rll) rlv (create rlr rv rr)
+      end
+  end else
+    Node{l; v; r; h=(if hl >= hr then hl + 1 else hr + 1)}
+
+(* Insertion of one element *)
+
+let rec add setcmp x = function
+    Empty -> Node{l=Empty; v=x; r=Empty; h=1}
+  | Node{l; v; r; _} as t ->
+    let c = setcmp x v in
+    if c = 0 then t else
+    if c < 0 then
+      let ll = add setcmp x l in
+      if l == ll then t else bal ll v r
+    else
+      let rr = add setcmp x r in
+      if r == rr then t else bal l v rr
+
+let singleton x = Node{l=Empty; v=x; r=Empty; h=1}
+
+(* Beware: those two functions assume that the added v is *strictly*
+   smaller (or bigger) than all the present elements in the tree; it
+   does not test for equality with the current min (or max) element.
+   Indeed, they are only used during the "join" operation which
+   respects this precondition.
+*)
+
+let rec add_min_element x = function
+  | Empty -> singleton x
+  | Node {l; v; r; _} ->
+    bal (add_min_element x l) v r
+
+let rec add_max_element x = function
+  | Empty -> singleton x
+  | Node {l; v; r; _} ->
+    bal l v (add_max_element x r)
+
+(* Same as create and bal, but no assumptions are made on the
+   relative heights of l and r. *)
+
+let rec join l v r =
+  match (l, r) with
+    (Empty, _) -> add_min_element v r
+  | (_, Empty) -> add_max_element v l
+  | (Node{l=ll; v=lv; r=lr; h=lh}, Node{l=rl; v=rv; r=rr; h=rh}) ->
+    if lh > rh + 2 then bal ll lv (join lr v r) else
+    if rh > lh + 2 then bal (join l v rl) rv rr else
+      create l v r
+
+(* Smallest and greatest element of a set *)
+
+let rec min_elt = function
+    Empty -> raise Not_found
+  | Node{l=Empty; v; _} -> v
+  | Node{l; _} -> min_elt l
+
+let rec min_elt_opt = function
+    Empty -> None
+  | Node{l=Empty; v; _} -> Some v
+  | Node{l; _} -> min_elt_opt l
+
+let rec max_elt = function
+    Empty -> raise Not_found
+  | Node{v; r=Empty; _} -> v
+  | Node{r; _} -> max_elt r
+
+let rec max_elt_opt = function
+    Empty -> None
+  | Node{v; r=Empty; _} -> Some v
+  | Node{r; _} -> max_elt_opt r
+
+(* Remove the smallest element of the given set *)
+
+let rec remove_min_elt = function
+    Empty -> invalid_arg "Set.remove_min_elt"
+  | Node{l=Empty; r; _} -> r
+  | Node{l; v; r; _} -> bal (remove_min_elt l) v r
+
+(* Merge two trees l and r into one.
+   All elements of l must precede the elements of r.
+   Assume | height l - height r | <= 2. *)
+
+let merge t1 t2 =
+  match (t1, t2) with
+    (Empty, t) -> t
+  | (t, Empty) -> t
+  | (_, _) -> bal t1 (min_elt t2) (remove_min_elt t2)
+
+(* Merge two trees l and r into one.
+   All elements of l must precede the elements of r.
+   No assumption on the heights of l and r. *)
+
+let concat t1 t2 =
+  match (t1, t2) with
+    (Empty, t) -> t
+  | (t, Empty) -> t
+  | (_, _) -> join t1 (min_elt t2) (remove_min_elt t2)
+
+(* Splitting.  split x s returns a triple (l, present, r) where
+   - l is the set of elements of s that are < x
+   - r is the set of elements of s that are > x
+   - present is false if s contains no element equal to x,
+      or true if s contains an element equal to x. *)
+
+let rec split setcmp x = function
+    Empty ->
+    (Empty, false, Empty)
+  | Node{l; v; r; _} ->
+    let c = setcmp x v in
+    if c = 0 then (l, true, r)
+    else if c < 0 then
+      let (ll, pres, rl) = split setcmp x l in (ll, pres, join rl v r)
+    else
+      let (lr, pres, rr) = split setcmp x r in (join l v lr, pres, rr)
+
+(* Implementation of the set operations *)
+
+let empty = Empty
+
+let is_empty = function Empty -> true | _ -> false
+
+let rec mem setcmp x = function
+    Empty -> false
+  | Node{l; v; r; _} ->
+    let c = setcmp x v in
+    c = 0 || mem setcmp x (if c < 0 then l else r)
+
+let rec remove setcmp x = function
+    Empty -> Empty
+  | (Node{l; v; r; _} as t) ->
+    let c = setcmp x v in
+    if c = 0 then merge l r
+    else
+    if c < 0 then
+      let ll = remove setcmp x l in
+      if l == ll then t
+      else bal ll v r
+    else
+      let rr = remove setcmp x r in
+      if r == rr then t
+      else bal l v rr
+
+let rec union setcmp s1 s2 =
+  match (s1, s2) with
+    (Empty, t2) -> t2
+  | (t1, Empty) -> t1
+  | (Node{l=l1; v=v1; r=r1; h=h1}, Node{l=l2; v=v2; r=r2; h=h2}) ->
+    if h1 >= h2 then
+      if h2 = 1 then add setcmp v2 s1 else begin
+        let (l2, _, r2) = split setcmp v1 s2 in
+        join (union setcmp l1 l2) v1 (union setcmp r1 r2)
+      end
+    else
+    if h1 = 1 then add setcmp v1 s2 else begin
+      let (l1, _, r1) = split setcmp v2 s1 in
+      join (union setcmp l1 l2) v2 (union setcmp r1 r2)
+    end
+
+let rec inter setcmp s1 s2 =
+  match (s1, s2) with
+    (Empty, _) -> Empty
+  | (_, Empty) -> Empty
+  | (Node{l=l1; v=v1; r=r1; _}, t2) ->
+    match split setcmp v1 t2 with
+      (l2, false, r2) ->
+      concat (inter setcmp l1 l2) (inter setcmp r1 r2)
+    | (l2, true, r2) ->
+      join (inter setcmp l1 l2) v1 (inter setcmp r1 r2)
+
+(* Same as split, but compute the left and right subtrees
+   only if the pivot element is not in the set.  The right subtree
+   is computed on demand. *)
+
+type 'a split_bis =
+  | Found
+  | NotFound of 'a set * (unit -> 'a set)
+
+let rec split_bis setcmp x = function
+    Empty ->
+    NotFound (Empty, (fun () -> Empty))
+  | Node{l; v; r; _} ->
+    let c = setcmp x v in
+    if c = 0 then Found
+    else if c < 0 then
+      match split_bis setcmp x l with
+      | Found -> Found
+      | NotFound (ll, rl) -> NotFound (ll, (fun () -> join (rl ()) v r))
+    else
+      match split_bis setcmp x r with
+      | Found -> Found
+      | NotFound (lr, rr) -> NotFound (join l v lr, rr)
+
+let rec disjoint setcmp s1 s2 =
+  match (s1, s2) with
+    (Empty, _) | (_, Empty) -> true
+  | (Node{l=l1; v=v1; r=r1; _}, t2) ->
+    if s1 == s2 then false
+    else match split_bis setcmp v1 t2 with
+        NotFound(l2, r2) -> disjoint setcmp l1 l2 && disjoint setcmp r1 (r2 ())
+      | Found -> false
+
+let rec diff setcmp s1 s2 =
+  match (s1, s2) with
+    (Empty, _) -> Empty
+  | (t1, Empty) -> t1
+  | (Node{l=l1; v=v1; r=r1; _}, t2) ->
+    match split setcmp v1 t2 with
+      (l2, false, r2) ->
+      join (diff setcmp l1 l2) v1 (diff setcmp r1 r2)
+    | (l2, true, r2) ->
+      concat (diff setcmp l1 l2) (diff setcmp r1 r2)
+
+type 'a enumeration = End | More of 'a * 'a set * 'a enumeration
+
+let rec cons_enum s e =
+  match s with
+    Empty -> e
+  | Node{l; v; r; _} -> cons_enum l (More(v, r, e))
+
+let compare setcmp s1 s2 =
+  let rec compare_aux e1 e2 =
+    match (e1, e2) with
+      (End, End) -> 0
+    | (End, _)  -> -1
+    | (_, End) -> 1
+    | (More(v1, r1, e1), More(v2, r2, e2)) ->
+      let c = setcmp v1 v2 in
+      if c <> 0
+      then c
+      else compare_aux (cons_enum r1 e1) (cons_enum r2 e2)
+  in
+  compare_aux (cons_enum s1 End) (cons_enum s2 End)
+
+let equal setcmp s1 s2 =
+  compare setcmp s1 s2 = 0
+
+let rec subset setcmp s1 s2 =
+  match (s1, s2) with
+    Empty, _ ->
+    true
+  | _, Empty ->
+    false
+  | Node {l=l1; v=v1; r=r1; _}, (Node {l=l2; v=v2; r=r2; _} as t2) ->
+    let c = setcmp v1 v2 in
+    if c = 0 then
+      subset setcmp l1 l2 && subset setcmp r1 r2
+    else if c < 0 then
+      subset setcmp (Node {l=l1; v=v1; r=Empty; h=0}) l2 && subset setcmp r1 t2
+    else
+      subset setcmp (Node {l=Empty; v=v1; r=r1; h=0}) r2 && subset setcmp l1 t2
+
+let rec iter f = function
+    Empty -> ()
+  | Node{l; v; r; _} -> iter f l; f v; iter f r
+
+let rec fold f s accu =
+  match s with
+    Empty -> accu
+  | Node{l; v; r; _} -> fold f r (f v (fold f l accu))
+
+let rec for_all p = function
+    Empty -> true
+  | Node{l; v; r; _} -> p v && for_all p l && for_all p r
+
+let rec exists p = function
+    Empty -> false
+  | Node{l; v; r; _} -> p v || exists p l || exists p r
+
+let rec filter p = function
+    Empty -> Empty
+  | (Node{l; v; r; _}) as t ->
+    (* call [p] in the expected left-to-right order *)
+    let l' = filter p l in
+    let pv = p v in
+    let r' = filter p r in
+    if pv then
+      if l==l' && r==r' then t else join l' v r'
+    else concat l' r'
+
+let rec partition p = function
+    Empty -> (Empty, Empty)
+  | Node{l; v; r; _} ->
+    (* call [p] in the expected left-to-right order *)
+    let (lt, lf) = partition p l in
+    let pv = p v in
+    let (rt, rf) = partition p r in
+    if pv
+    then (join lt v rt, concat lf rf)
+    else (concat lt rt, join lf v rf)
+
+let rec cardinal = function
+    Empty -> 0
+  | Node{l; r; _} -> cardinal l + 1 + cardinal r
+
+let rec elements_aux accu = function
+    Empty -> accu
+  | Node{l; v; r; _} -> elements_aux (v :: elements_aux accu r) l
+
+let elements s =
+  elements_aux [] s
+
+let choose = min_elt
+
+let choose_opt = min_elt_opt
+
+let rec find setcmp x = function
+    Empty -> raise Not_found
+  | Node{l; v; r; _} ->
+    let c = setcmp x v in
+    if c = 0 then v
+    else find setcmp x (if c < 0 then l else r)
+
+let rec find_first_aux v0 f = function
+    Empty ->
+    v0
+  | Node{l; v; r; _} ->
+    if f v then
+      find_first_aux v f l
+    else
+      find_first_aux v0 f r
+
+let rec find_first f = function
+    Empty ->
+    raise Not_found
+  | Node{l; v; r; _} ->
+    if f v then
+      find_first_aux v f l
+    else
+      find_first f r
+
+let rec find_first_opt_aux v0 f = function
+    Empty ->
+    Some v0
+  | Node{l; v; r; _} ->
+    if f v then
+      find_first_opt_aux v f l
+    else
+      find_first_opt_aux v0 f r
+
+let rec find_first_opt f = function
+    Empty ->
+    None
+  | Node{l; v; r; _} ->
+    if f v then
+      find_first_opt_aux v f l
+    else
+      find_first_opt f r
+
+let rec find_last_aux v0 f = function
+    Empty ->
+    v0
+  | Node{l; v; r; _} ->
+    if f v then
+      find_last_aux v f r
+    else
+      find_last_aux v0 f l
+
+let rec find_last f = function
+    Empty ->
+    raise Not_found
+  | Node{l; v; r; _} ->
+    if f v then
+      find_last_aux v f r
+    else
+      find_last f l
+
+let rec find_last_opt_aux v0 f = function
+    Empty ->
+    Some v0
+  | Node{l; v; r; _} ->
+    if f v then
+      find_last_opt_aux v f r
+    else
+      find_last_opt_aux v0 f l
+
+let rec find_last_opt f = function
+    Empty ->
+    None
+  | Node{l; v; r; _} ->
+    if f v then
+      find_last_opt_aux v f r
+    else
+      find_last_opt f l
+
+let rec find_opt setcmp x = function
+    Empty -> None
+  | Node{l; v; r; _} ->
+    let c = setcmp x v in
+    if c = 0 then Some v
+    else find_opt setcmp x (if c < 0 then l else r)
+
+let try_join setcmp l v r =
+  (* [join l v r] can only be called when (elements of l < v <
+     elements of r); use [try_join l v r] when this property may
+     not hold, but you hope it does hold in the common case *)
+  if (l = Empty || setcmp (max_elt l) v < 0)
+  && (r = Empty || setcmp v (min_elt r) < 0)
+  then join l v r
+  else union setcmp l (add setcmp v r)
+
+let rec map setcmp f = function
+  | Empty -> Empty
+  | Node{l; v; r; _} as t ->
+    (* enforce left-to-right evaluation order *)
+    let l' = map setcmp f l in
+    let v' = f v in
+    let r' = map setcmp f r in
+    if l == l' && v == v' && r == r' then t
+    else try_join setcmp l' v' r'
+
+let try_concat setcmp t1 t2 =
+  match (t1, t2) with
+    (Empty, t) -> t
+  | (t, Empty) -> t
+  | (_, _) -> try_join setcmp t1 (min_elt t2) (remove_min_elt t2)
+
+let rec filter_map setcmp f = function
+  | Empty -> Empty
+  | Node{l; v; r; _} as t ->
+    (* enforce left-to-right evaluation order *)
+    let l' = filter_map setcmp f l in
+    let v' = f v in
+    let r' = filter_map setcmp f r in
+    begin match v' with
+      | Some v' ->
+        if l == l' && v == v' && r == r' then t
+        else try_join setcmp l' v' r'
+      | None ->
+        try_concat setcmp l' r'
+    end
+
+let of_sorted_list l =
+  let rec sub n l =
+    match n, l with
+    | 0, l -> Empty, l
+    | 1, x0 :: l -> Node {l=Empty; v=x0; r=Empty; h=1}, l
+    | 2, x0 :: x1 :: l ->
+      Node{l=Node{l=Empty; v=x0; r=Empty; h=1}; v=x1; r=Empty; h=2}, l
+    | 3, x0 :: x1 :: x2 :: l ->
+      Node{l=Node{l=Empty; v=x0; r=Empty; h=1}; v=x1;
+           r=Node{l=Empty; v=x2; r=Empty; h=1}; h=2}, l
+    | n, l ->
+      let nl = n / 2 in
+      let left, l = sub nl l in
+      match l with
+      | [] -> assert false
+      | mid :: l ->
+        let right, l = sub (n - nl - 1) l in
+        create left mid right, l
+  in
+  fst (sub (List.length l) l)
+
+let to_list = elements
+
+let of_list setcmp l =
+  match l with
+  | [] -> empty
+  | [x0] -> singleton x0
+  | [x0; x1] -> add setcmp x1 (singleton x0)
+  | [x0; x1; x2] -> add setcmp x2 (add setcmp x1 (singleton x0))
+  | [x0; x1; x2; x3] ->
+    add setcmp x3 (add setcmp x2 (add setcmp x1 (singleton x0)))
+  | [x0; x1; x2; x3; x4] ->
+    add setcmp x4 (add setcmp x3 (add setcmp x2 (add setcmp x1 (singleton x0))))
+  | _ -> of_sorted_list (List.sort_uniq setcmp l)
+
+let add_seq setcmp i m =
+  Seq.fold_left (fun s x -> add setcmp x s) m i
+
+let of_seq setcmp i = add_seq setcmp i empty
+
+let rec seq_of_enum_ c () = match c with
+  | End -> Seq.Nil
+  | More (x, t, rest) -> Seq.Cons (x, seq_of_enum_ (cons_enum t rest))
+
+let to_seq c = seq_of_enum_ (cons_enum c End)
+
+let rec snoc_enum s e =
+  match s with
+    Empty -> e
+  | Node{l; v; r; _} -> snoc_enum r (More(v, l, e))
+
+let rec rev_seq_of_enum_ c () = match c with
+  | End -> Seq.Nil
+  | More (x, t, rest) -> Seq.Cons (x, rev_seq_of_enum_ (snoc_enum t rest))
+
+let to_rev_seq c = rev_seq_of_enum_ (snoc_enum c End)
+
+let to_seq_from setcmp low s =
+  let rec aux low s c = match s with
+    | Empty -> c
+    | Node {l; r; v; _} ->
+      begin match setcmp v low with
+        | 0 -> More (v, r, c)
+        | n when n<0 -> aux low r c
+        | _ -> aux low l (More (v, r, c))
+      end
+  in
+  seq_of_enum_ (aux low s End)

--- a/src/lib/reasoners/cSet.mli
+++ b/src/lib/reasoners/cSet.mli
@@ -1,0 +1,297 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* NOTE: If this file is set.mli, do not edit it directly! Instead,
+   edit templates/set.template.mli and run tools/sync_stdlib_docs *)
+
+(** Sets over ordered types.
+
+    This module implements the set data structure, given a total ordering
+    function over the set elements. All operations over sets
+    are purely applicative (no side-effects).
+    The implementation uses balanced binary trees, and is therefore
+    reasonably efficient: insertion and membership take time
+    logarithmic in the size of the set, for instance.
+
+    The {!Make} functor constructs implementations for any type, given a
+    [compare] function.
+    For instance:
+    {[
+      module IntPairs =
+      struct
+        type t = int * int
+        let compare (x0,y0) (x1,y1) =
+          match Stdlib.compare x0 x1 with
+            0 -> Stdlib.compare y0 y1
+          | c -> c
+      end
+
+      module PairsSet = Set.Make(IntPairs)
+
+      let m = PairsSet.(empty |> add (2,3) |> add (5,7) |> add (11,13))
+    ]}
+
+    This creates a new module [PairsSet], with a new type [PairsSet.t]
+    of sets of [int * int].
+*)
+
+(** {1:sets Sets} *)
+
+type 'a set
+(** The type of sets. *)
+
+type 'a setcmp = 'a -> 'a -> int
+
+val empty: 'a set
+(** The empty set. *)
+
+val add: 'a setcmp -> 'a -> 'a set -> 'a set
+(** [add x s] returns a set containing all elements of [s],
+    plus [x]. If [x] was already in [s], [s] is returned unchanged
+    (the result of the function is then physically equal to [s]).
+    @before 4.03 Physical equality was not ensured. *)
+
+val singleton: 'a -> 'a set
+(** [singleton x] returns the one-element set containing only [x]. *)
+
+val remove: 'a setcmp -> 'a -> 'a set -> 'a set
+(** [remove x s] returns a set containing all elements of [s],
+    except [x]. If [x] was not in [s], [s] is returned unchanged
+    (the result of the function is then physically equal to [s]).
+    @before 4.03 Physical equality was not ensured. *)
+
+val union: 'a setcmp -> 'a set -> 'a set -> 'a set
+(** Set union. *)
+
+val inter: 'a setcmp -> 'a set -> 'a set -> 'a set
+(** Set intersection. *)
+
+val disjoint: 'a setcmp -> 'a set -> 'a set -> bool
+(** Test if two sets are disjoint.
+    @since 4.08 *)
+
+val diff: 'a setcmp -> 'a set -> 'a set -> 'a set
+(** Set difference: [diff s1 s2] contains the elements of [s1]
+    that are not in [s2]. *)
+
+val cardinal: 'a set -> int
+(** Return the number of elements of a set. *)
+
+(** {1:elements Elements} *)
+
+val elements: 'a set -> 'a list
+(** Return the list of all elements of the given set.
+    The returned list is sorted in increasing order with respect
+    to the ordering [Ord.compare], where [Ord] is the argument
+    given to {!Set.Make}. *)
+
+val min_elt: 'a set -> 'a
+(** Return the smallest element of the given set
+    (with respect to the [Ord.compare] ordering), or raise
+    [Not_found] if the set is empty. *)
+
+val min_elt_opt: 'a set -> 'a option
+(** Return the smallest element of the given set
+    (with respect to the [Ord.compare] ordering), or [None]
+    if the set is empty.
+    @since 4.05 *)
+
+val max_elt: 'a set -> 'a
+(** Same as {!min_elt}, but returns the largest element of the
+    given set. *)
+
+val max_elt_opt: 'a set -> 'a option
+(** Same as {!min_elt_opt}, but returns the largest element of the
+    given set.
+    @since 4.05 *)
+
+val choose: 'a set -> 'a
+(** Return one element of the given set, or raise [Not_found] if
+    the set is empty. Which element is chosen is unspecified,
+    but equal elements will be chosen for equal sets. *)
+
+val choose_opt: 'a set -> 'a option
+(** Return one element of the given set, or [None] if
+    the set is empty. Which element is chosen is unspecified,
+    but equal elements will be chosen for equal sets.
+    @since 4.05 *)
+
+(** {1:searching Searching} *)
+
+val find: 'a setcmp -> 'a -> 'a set -> 'a
+(** [find x s] returns the element of [s] equal to [x] (according
+    to [Ord.compare]), or raise [Not_found] if no such element
+    exists.
+    @since 4.01 *)
+
+val find_opt: 'a setcmp -> 'a -> 'a set -> 'a option
+(** [find_opt x s] returns the element of [s] equal to [x] (according
+    to [Ord.compare]), or [None] if no such element
+    exists.
+    @since 4.05 *)
+
+val find_first: ('a -> bool) -> 'a set -> 'a
+(** [find_first f s], where [f] is a monotonically increasing function,
+    returns the lowest element [e] of [s] such that [f e],
+    or raises [Not_found] if no such element exists.
+
+    For example, [find_first (fun e -> Ord.compare e x >= 0) s] will
+    return the first element [e] of [s] where [Ord.compare e x >= 0]
+    (intuitively: [e >= x]), or raise [Not_found] if [x] is greater than
+    any element of [s].
+
+    @since 4.05 *)
+
+val find_first_opt: ('a -> bool) -> 'a set -> 'a option
+(** [find_first_opt f s], where [f] is a monotonically increasing
+    function, returns an option containing the lowest element [e] of [s]
+    such that [f e], or [None] if no such element exists.
+    @since 4.05
+*)
+
+val find_last: ('a -> bool) -> 'a set -> 'a
+(** [find_last f s], where [f] is a monotonically decreasing function,
+    returns the highest element [e] of [s] such that [f e],
+    or raises [Not_found] if no such element exists.
+    @since 4.05 *)
+
+val find_last_opt: ('a -> bool) -> 'a set -> 'a option
+(** [find_last_opt f s], where [f] is a monotonically decreasing
+    function, returns an option containing the highest element [e] of [s]
+    such that [f e], or [None] if no such element exists.
+    @since 4.05 *)
+
+(** {1:traversing Traversing} *)
+
+val iter: ('a -> unit) -> 'a set -> unit
+(** [iter f s] applies [f] in turn to all elements of [s].
+    The elements of [s] are presented to [f] in increasing order
+    with respect to the ordering over the type of the elements. *)
+
+val fold: ('a -> 'acc -> 'acc) -> 'a set -> 'acc -> 'acc
+(** [fold f s init] computes [(f xN ... (f x2 (f x1 init))...)],
+    where [x1 ... xN] are the elements of [s], in increasing order. *)
+
+(** {1:transforming Transforming} *)
+
+val map: 'a setcmp -> ('a -> 'a) -> 'a set -> 'a set
+(** [map f s] is the set whose elements are [f a0],[f a1]... [f
+    aN], where [a0],[a1]...[aN] are the elements of [s].
+
+    The elements are passed to [f] in increasing order
+    with respect to the ordering over the type of the elements.
+
+    If no element of [s] is changed by [f], [s] is returned
+    unchanged. (If each output of [f] is physically equal to its
+    input, the returned set is physically equal to [s].)
+    @since 4.04 *)
+
+val filter: ('a -> bool) -> 'a set -> 'a set
+(** [filter f s] returns the set of all elements in [s]
+    that satisfy predicate [f]. If [f] satisfies every element in [s],
+    [s] is returned unchanged (the result of the function is then
+    physically equal to [s]).
+    @before 4.03 Physical equality was not ensured.*)
+
+val filter_map: 'a setcmp -> ('a -> 'a option) -> 'a set -> 'a set
+(** [filter_map f s] returns the set of all [v] such that
+    [f x = Some v] for some element [x] of [s].
+
+    For example,
+    {[filter_map (fun n -> if n mod 2 = 0 then Some (n / 2) else None) s]}
+    is the set of halves of the even elements of [s].
+
+    If no element of [s] is changed or dropped by [f] (if
+    [f x = Some x] for each element [x]), then
+    [s] is returned unchanged: the result of the function
+    is then physically equal to [s].
+
+    @since 4.11 *)
+
+val partition: ('a -> bool) -> 'a set -> 'a set * 'a set
+(** [partition f s] returns a pair of sets [(s1, s2)], where
+    [s1] is the set of all the elements of [s] that satisfy the
+    predicate [f], and [s2] is the set of all the elements of
+    [s] that do not satisfy [f]. *)
+
+val split: 'a setcmp -> 'a -> 'a set -> 'a set * bool * 'a set
+(** [split x s] returns a triple [(l, present, r)], where
+    [l] is the set of elements of [s] that are
+    strictly less than [x];
+    [r] is the set of elements of [s] that are
+    strictly greater than [x];
+    [present] is [false] if [s] contains no element equal to [x],
+    or [true] if [s] contains an element equal to [x]. *)
+
+(** {1:predicates Predicates and comparisons} *)
+
+val is_empty: 'a set -> bool
+(** Test whether a set is empty or not. *)
+
+val mem: 'a setcmp -> 'a -> 'a set -> bool
+(** [mem x s] tests whether [x] belongs to the set [s]. *)
+
+val equal: 'a setcmp -> 'a set -> 'a set -> bool
+(** [equal s1 s2] tests whether the sets [s1] and [s2] are
+    equal, that is, contain equal elements. *)
+
+val compare: 'a setcmp -> 'a set -> 'a set -> int
+(** Total ordering between sets. Can be used as the ordering function
+    for doing sets of sets. *)
+
+val subset: 'a setcmp -> 'a set -> 'a set -> bool
+(** [subset s1 s2] tests whether the set [s1] is a subset of
+    the set [s2]. *)
+
+val for_all: ('a -> bool) -> 'a set -> bool
+(** [for_all f s] checks if all elements of the set
+    satisfy the predicate [f]. *)
+
+val exists: ('a -> bool) -> 'a set -> bool
+(** [exists f s] checks if at least one element of
+    the set satisfies the predicate [f]. *)
+
+(** {1:converting Converting} *)
+
+val to_list : 'a set -> 'a list
+(** [to_list s] is {!elements}[ s].
+    @since 5.1 *)
+
+val of_list: 'a setcmp -> 'a list -> 'a set
+(** [of_list l] creates a set from a list of elements.
+    This is usually more efficient than folding [add] over the list,
+    except perhaps for lists with many duplicated elements.
+    @since 4.02 *)
+
+val to_seq_from : 'a setcmp -> 'a -> 'a set -> 'a Seq.t
+(** [to_seq_from x s] iterates on a subset of the elements of [s]
+    in ascending order, from [x] or above.
+    @since 4.07 *)
+
+val to_seq : 'a set -> 'a Seq.t
+(** Iterate on the whole set, in ascending order
+    @since 4.07 *)
+
+val to_rev_seq : 'a set -> 'a Seq.t
+(** Iterate on the whole set, in descending order
+    @since 4.12 *)
+
+val add_seq : 'a setcmp -> 'a Seq.t -> 'a set -> 'a set
+(** Add the given elements to the set, in order.
+    @since 4.07 *)
+
+val of_seq : 'a setcmp -> 'a Seq.t -> 'a set
+(** Build a set from the given bindings
+    @since 4.07 *)

--- a/src/lib/reasoners/ccx.mli
+++ b/src/lib/reasoners/ccx.mli
@@ -29,7 +29,7 @@
 module type S = sig
 
   type t
-  type r = Shostak.Combine.r
+  type r = Types.r
 
   val empty : unit -> t
 
@@ -68,7 +68,7 @@ module type S = sig
   val term_repr : t -> Expr.t -> init_term:bool -> Expr.t
   val get_union_find : t -> Uf.t
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Types.th_elt -> Explanation.t -> t
   val theories_instances :
     do_syntactic_matching:bool ->
     Matching_types.info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t ->

--- a/src/lib/reasoners/enum.mli
+++ b/src/lib/reasoners/enum.mli
@@ -26,7 +26,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-(*type 'a abstract*)
+(*type 'a abstract
 type 'a abstract = Cons of Hstring.t * Ty.t |  Alien of 'a
 
 module type ALIEN = sig
@@ -37,3 +37,7 @@ end
 
 module Shostak
     (X : ALIEN) : Sig.SHOSTAK with type r = X.r and type t = X.r abstract
+
+*)
+
+include ( Sig.SHOSTAK with type t = Types.enum )

--- a/src/lib/reasoners/inequalities.ml
+++ b/src/lib/reasoners/inequalities.ml
@@ -26,20 +26,22 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 module Z = Numbers.Z
 module Q = Numbers.Q
 
 module type S = sig
 
-  module P : Polynome.T with type r = Shostak.Combine.r
-  module MP : Map.S with type key = P.t
+  module P : Polynome.T
+  module MP : Map.S with type key = polynome
 
   type t = {
-    ple0 : P.t;
+    ple0 : polynome;
     is_le : bool;
     (* int instead of Term.t as a key to prevent us
        from using it in deductions *)
-    dep : (Q.t * P.t * bool) Util.MI.t;
+    dep : (Q.t * polynome * bool) Util.MI.t;
     expl : Explanation.t;
     age : Z.t;
   }
@@ -52,28 +54,28 @@ module type S = sig
     val insert : t -> mp -> mp
     val ineqs_of : mp -> t list
     val add_to_map : mp -> t list -> mp
-    val iter : (P.t -> (t * Q.t) -> unit) -> mp -> unit
-    val fold : (P.t -> (t * Q.t) -> 'a -> 'a) -> mp -> 'a -> 'a
+    val iter : (polynome -> (t * Q.t) -> unit) -> mp -> unit
+    val fold : (polynome -> (t * Q.t) -> 'a -> 'a) -> mp -> 'a -> 'a
   end
 
   val current_age : unit -> Numbers.Z.t
   val incr_age : unit -> unit
 
   val create_ineq :
-    P.t -> P.t -> bool -> Expr.t option -> Explanation.t -> t
+    polynome -> polynome -> bool -> Expr.t option -> Explanation.t -> t
 
   val print_inequation : Format.formatter -> t -> unit
 
   val fourierMotzkin :
-    ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
+    ('are_eq -> 'acc -> r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
   val fmSimplex :
-    ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
+    ('are_eq -> 'acc -> r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
   val available :
-    ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
+    ('are_eq -> 'acc -> r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
   val reset_age_cpt : unit -> unit
@@ -82,14 +84,14 @@ end
 
 module type Container_SIG = sig
   module Make
-      (P : Polynome.T with type r = Shostak.Combine.r)
+      (P : Polynome.T)
     : S with module P = P
 
 end
 
 module Container : Container_SIG = struct
   module Make
-      (P : Polynome.T with type r = Shostak.Combine.r)
+      (P : Polynome.T)
     : S with module P = P = struct
 
     module X = Shostak.Combine
@@ -104,9 +106,9 @@ module Container : Container_SIG = struct
     let incr_age () =  age_cpt := Z.add !age_cpt Z.one;
 
     type t = {
-      ple0 : P.t;
+      ple0 : polynome;
       is_le : bool;
-      dep : (Q.t * P.t * bool) Util.MI.t;
+      dep : (Q.t * polynome * bool) Util.MI.t;
       expl : Explanation.t;
       age : Z.t;
     }

--- a/src/lib/reasoners/inequalities.mli
+++ b/src/lib/reasoners/inequalities.mli
@@ -26,15 +26,17 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 module type S = sig
 
-  module P : Polynome.T with type r = Shostak.Combine.r
-  module MP : Map.S with type key = P.t
+  module P : Polynome.T
+  module MP : Map.S with type key = polynome
 
   type t = {
-    ple0 : P.t;
+    ple0 : polynome;
     is_le : bool;
-    dep : (Numbers.Q.t * P.t * bool) Util.MI.t;
+    dep : (Numbers.Q.t * polynome * bool) Util.MI.t;
     expl : Explanation.t;
     age : Numbers.Z.t;
   }
@@ -47,28 +49,28 @@ module type S = sig
     val insert : t -> mp -> mp
     val ineqs_of : mp -> t list
     val add_to_map : mp -> t list -> mp
-    val iter : (P.t -> (t * Numbers.Q.t) -> unit) -> mp -> unit
-    val fold : (P.t -> (t * Numbers.Q.t) -> 'a -> 'a) -> mp -> 'a -> 'a
+    val iter : (polynome -> (t * Numbers.Q.t) -> unit) -> mp -> unit
+    val fold : (polynome -> (t * Numbers.Q.t) -> 'a -> 'a) -> mp -> 'a -> 'a
   end
 
   val current_age : unit -> Numbers.Z.t
   val incr_age : unit -> unit
 
   val create_ineq :
-    P.t -> P.t -> bool -> Expr.t option -> Explanation.t -> t
+    polynome -> polynome -> bool -> Expr.t option -> Explanation.t -> t
 
   val print_inequation : Format.formatter -> t -> unit
 
   val fourierMotzkin :
-    ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
+    ('are_eq -> 'acc -> r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
   val fmSimplex :
-    ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
+    ('are_eq -> 'acc -> r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
   val available :
-    ('are_eq -> 'acc -> P.r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
+    ('are_eq -> 'acc -> r option -> t list -> 'acc) -> 'are_eq -> 'acc ->
     MINEQS.mp -> 'acc
 
   val reset_age_cpt : unit -> unit
@@ -78,12 +80,12 @@ end
 
 
 module FM
-    (P : Polynome.T with type r = Shostak.Combine.r)
+    (P : Polynome.T)
   : S with module P = P
 
 module type Container_SIG = sig
   module Make
-      (P : Polynome.T with type r = Shostak.Combine.r)
+      (P : Polynome.T)
     : S with module P = P
 end
 

--- a/src/lib/reasoners/instances.mli
+++ b/src/lib/reasoners/instances.mli
@@ -29,16 +29,16 @@
 module type S = sig
   type t
   type tbox
-  type instances = (Expr.gformula * Explanation.t) list
+  type instances = (Types.gformula * Explanation.t) list
 
   val empty : t
-  val add_terms : t -> Expr.Set.t -> Expr.gformula -> t
-  val add_lemma : t -> Expr.gformula -> Explanation.t -> t
+  val add_terms : t -> Expr.Set.t -> Types.gformula -> t
+  val add_lemma : t -> Types.gformula -> Explanation.t -> t
   val add_predicate :
     t ->
     guard:Expr.t ->
     name:string ->
-    Expr.gformula ->
+    Types.gformula ->
     Explanation.t ->
     t
 

--- a/src/lib/reasoners/intervals.ml
+++ b/src/lib/reasoners/intervals.ml
@@ -26,6 +26,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 module Q = Numbers.Q
 
 module Ex = Explanation
@@ -1119,45 +1121,45 @@ let new_var idoms s ty =
   if MV.mem s idoms then idoms
   else MV.add s (None, None, ty) idoms
 
-let match_interval_upper {Sy.sort; is_open; kind; is_lower} i imatch =
+let match_interval_upper {sort; is_open; bkind; is_lower} i imatch =
   assert (not is_lower);
-  match kind, max_bound i with
-  | Sy.VarBnd s, _ when is_question_mark s -> imatch (* ? var *)
-  | Sy.VarBnd _, Minfty -> assert false
-  | Sy.VarBnd s, Pinfty -> new_var imatch s sort
-  | Sy.VarBnd s, Strict (v, _) -> new_low_bound imatch s sort v false
-  | Sy.VarBnd s, Large  (v, _) -> new_low_bound imatch s sort v is_open
+  match bkind, max_bound i with
+  | Types.VarBnd s, _ when is_question_mark s -> imatch (* ? var *)
+  | Types.VarBnd _, Minfty -> assert false
+  | Types.VarBnd s, Pinfty -> new_var imatch s sort
+  | Types.VarBnd s, Strict (v, _) -> new_low_bound imatch s sort v false
+  | Types.VarBnd s, Large  (v, _) -> new_low_bound imatch s sort v is_open
 
-  | Sy.ValBnd _, Minfty -> assert false
-  | Sy.ValBnd _, Pinfty -> raise Exit
-  | Sy.ValBnd vl, Strict (v, _) ->
+  | Types.ValBnd _, Minfty -> assert false
+  | Types.ValBnd _, Pinfty -> raise Exit
+  | Types.ValBnd vl, Strict (v, _) ->
     let c = Q.compare v vl in
     if c > 0 then raise Exit;
     imatch
 
-  | Sy.ValBnd vl, Large  (v, _) ->
+  | Types.ValBnd vl, Large  (v, _) ->
     let c = Q.compare v vl in
     if c > 0 || c = 0 && is_open then raise Exit;
     imatch
 
 
-let match_interval_lower {Sy.sort; is_open; kind; is_lower} i imatch =
+let match_interval_lower {Types.sort; is_open; bkind; is_lower} i imatch =
   assert (is_lower);
-  match kind, min_bound i with
-  | Sy.VarBnd s, _ when is_question_mark s -> imatch (* ? var *)
-  | Sy.VarBnd _, Pinfty -> assert false
-  | Sy.VarBnd s,  Minfty -> new_var imatch s sort
-  | Sy.VarBnd s, Strict (v, _) -> new_up_bound imatch s sort v false
-  | Sy.VarBnd s, Large  (v, _) -> new_up_bound imatch s sort v is_open
+  match bkind, min_bound i with
+  | Types.VarBnd s, _ when is_question_mark s -> imatch (* ? var *)
+  | Types.VarBnd _, Pinfty -> assert false
+  | Types.VarBnd s,  Minfty -> new_var imatch s sort
+  | Types.VarBnd s, Strict (v, _) -> new_up_bound imatch s sort v false
+  | Types.VarBnd s, Large  (v, _) -> new_up_bound imatch s sort v is_open
 
-  | Sy.ValBnd _, Minfty -> raise Exit
-  | Sy.ValBnd _, Pinfty -> assert false
-  | Sy.ValBnd vl, Strict (v, _) ->
+  | Types.ValBnd _, Minfty -> raise Exit
+  | Types.ValBnd _, Pinfty -> assert false
+  | Types.ValBnd vl, Strict (v, _) ->
     let c = Q.compare v vl in
     if c < 0 then raise Exit;
     imatch
 
-  | Sy.ValBnd vl, Large  (v, _) ->
+  | Types.ValBnd vl, Large  (v, _) ->
     let c = Q.compare v vl in
     if c < 0 || c = 0 && is_open then raise Exit;
     imatch

--- a/src/lib/reasoners/intervals.mli
+++ b/src/lib/reasoners/intervals.mli
@@ -148,5 +148,5 @@ type interval_matching =
     the matching problem is inconsistent
 *)
 val match_interval:
-  Symbols.bound -> Symbols.bound -> t -> interval_matching ->
+  Types.bound -> Types.bound -> t -> interval_matching ->
   interval_matching option

--- a/src/lib/reasoners/ite.ml
+++ b/src/lib/reasoners/ite.ml
@@ -9,6 +9,10 @@
 (*                                                                            *)
 (******************************************************************************)
 
+
+module X = Shostak_pre
+
+(*
 type 'a abstract = unit
 
 module type ALIEN = sig
@@ -21,6 +25,9 @@ module Shostak (X : ALIEN) = struct
 
   type t = X.r abstract
   type r = X.r
+*)
+
+type t = Types.ite
 
   let name           = "Ite"
   let is_mine_symb _ _ = false
@@ -41,5 +48,3 @@ module Shostak (X : ALIEN) = struct
   let solve _ _ = assert false
   let assign_value _ _ _ = assert false
   let choose_adequate_model _ _ _ = assert false
-end
-

--- a/src/lib/reasoners/ite.mli
+++ b/src/lib/reasoners/ite.mli
@@ -26,13 +26,4 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type 'a abstract
-
-module type ALIEN = sig
-  include Sig.X
-  val embed : r abstract -> r
-  val extract : r -> (r abstract) option
-end
-
-module Shostak
-    (X : ALIEN) : Sig.SHOSTAK with type r = X.r and type t = X.r abstract
+include ( Sig.SHOSTAK with type t = Types.ite )

--- a/src/lib/reasoners/ite_rel.ml
+++ b/src/lib/reasoners/ite_rel.ml
@@ -52,10 +52,10 @@ let empty _ =
   }
 
 let is_ite =
-  let ite = Symbols.Op Symbols.Tite in
+  let ite = Types.Op Types.Tite in
   fun t ->
     match E.term_view t with
-    | { E.f ; xs = [p;t1;t2]; _ } when Symbols.equal f ite -> Some (p, t1, t2)
+    | { f ; xs = [p;t1;t2]; _ } when Symbols.equal f ite -> Some (p, t1, t2)
     | _ -> None
 
 let add_to_guarded p s t mp =
@@ -96,7 +96,7 @@ let extract_preds env la =
        | None -> acc
        | Some a ->
          match E.lit_view a with
-         | E.Pred (t, is_neg)
+         | Pred (t, is_neg)
            when not (ME.mem t env.assumed_pos_preds) &&
                 not (ME.mem t env.assumed_neg_preds) ->
            if get_debug_ite () then

--- a/src/lib/reasoners/matching_types.mli
+++ b/src/lib/reasoners/matching_types.mli
@@ -38,7 +38,7 @@ type gsubst = {
 }
 
 type trigger_info = {
-  trigger : Expr.trigger;
+  trigger : Types.trigger;
   trigger_age : int ;  (* age d'un trigger *)
   trigger_orig : Expr.t ; (* lemme d'origine *)
   trigger_formula : Expr.t ; (* formule associee au trigger *)

--- a/src/lib/reasoners/polynome.ml
+++ b/src/lib/reasoners/polynome.ml
@@ -26,21 +26,33 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+module X = struct
+  include Shostak_pre
+      let mult v1 v2 =
+        ac_embed
+          {
+            distribute = true;
+            h = Types.Op Types.Mult;
+            t = type_info v1;
+            l = let l2 = match ac_extract v1 with
+                | Some { h; l; _ } when Symbols.equal h (Types.Op Types.Mult) -> l
+                | _ -> [v1, 1]
+              in Ac.add (Types.Op Types.Mult) (v2,1) l2
+          }
+
+end
+
+
 module Z = Numbers.Z
 module Q = Numbers.Q
 
 exception Not_a_num
 exception Maybe_zero
 
-module type S = sig
-  include Sig.X
-  val mult : r -> r -> r
-end
-
 module type T = sig
 
-  type r
-  type t
+  type t = Types.polynome
 
   val compare : t -> t -> int
   val equal : t -> t -> bool
@@ -76,6 +88,10 @@ module type T = sig
   val separate_constant : t -> t * Numbers.Q.t
 end
 
+
+type t = Types.polynome
+
+(*
 module type EXTENDED_Polynome = sig
   include T
   val extract : r -> t option
@@ -86,18 +102,21 @@ module Make (X : S) = struct
 
   type r = X.r
 
-  module M : Map.S with type key = r =
+  type t = Types.POLYNOME.polynom
+
+  module M : Map.S with type key = SHOSTAK.r =
     Map.Make(
     struct
-      type t = r
+      type t = SHOSTAK.r
 
-      (*sorted in decreasing order to comply with AC(X) order requirements*)
-      let compare x y = X.str_cmp y x
     end)
+*)
 
-  type t = { m : Q.t M.t; c : Q.t; ty : Ty.t }
+(*sorted in decreasing order to comply with AC(X) order requirements*)
+  let mapcmp x y = X.str_cmp y x
 
-  let map_to_list m = List.rev (M.fold (fun x a aliens -> (a, x)::aliens) m [])
+let map_to_list m = List.rev (
+    CMap.fold (fun x a aliens -> (a, x)::aliens) m [])
 
   exception Out of int
 
@@ -115,9 +134,9 @@ module Make (X : S) = struct
       List.length l1 - List.length l2
 
   let compare p1 p2 =
-    let c = Ty.compare p1.ty p2.ty in
+    let c = Ty.compare p1.pty p2.pty in
     if c <> 0 then c
-    else match M.is_empty p1.m, M.is_empty p2.m with
+    else match CMap.is_empty p1.m, CMap.is_empty p2.m with
       | true , false -> -1
       | false, true  -> 1
       | true , true  -> Q.compare p1.c p2.c
@@ -126,14 +145,14 @@ module Make (X : S) = struct
         if c = 0 then Q.compare p1.c p2.c else c
 
   let equal { m = m1; c = c1; _ } { m = m2; c = c2; _ } =
-    Q.equal c1 c2 && M.equal Q.equal m1 m2
+    Q.equal c1 c2 && CMap.equal mapcmp Q.equal m1 m2
 
   let hash p =
     let h =
-      M.fold
+      CMap.fold
         (fun k v acc ->
            23 * acc + (X.hash k) * Q.hash v
-        )p.m (19 * Q.hash p.c + 17 * Ty.hash p.ty)
+        )p.m (19 * Q.hash p.c + 17 * Ty.hash p.pty)
     in
     abs h
 
@@ -141,7 +160,7 @@ module Make (X : S) = struct
   module Debug = struct
     let pprint fmt p =
       let zero = ref true in
-      M.iter
+      CMap.iter
         (fun x n ->
            let s, n, op =
              if Q.equal n Q.one then (if !zero then "" else "+"), "", ""
@@ -163,73 +182,76 @@ module Make (X : S) = struct
     let print fmt p =
       if Options.get_term_like_pp () then pprint fmt p
       else begin
-        M.iter (fun t n ->
+        CMap.iter (fun t n ->
             Format.fprintf fmt "%s*%a " (Q.to_string n) X.print t
           ) p.m;
         Format.fprintf fmt "%s%s"
           (if Q.compare_to_0 p.c >= 0 then "+ " else "")
           (Q.to_string p.c);
-        Format.fprintf fmt " [%a]" Ty.print p.ty
+        Format.fprintf fmt " [%a]" Ty.print p.pty
       end
   end
   (*BISECT-IGNORE-END*)
 
   let print = Debug.print
 
-  let is_const p = if M.is_empty p.m then Some p.c else None
+  let is_const p = if CMap.is_empty p.m then Some p.c else None
 
-  let find x m = try M.find x m with Not_found -> Q.zero
+  let find x m = try CMap.find mapcmp x m with Not_found -> Q.zero
 
   let create l c ty =
     let m =
       List.fold_left
         (fun m (n, x) ->
            let n' = Q.add n (find x m) in
-           if Q.sign n' = 0 then M.remove x m else M.add x n' m) M.empty l
+           if Q.sign n' = 0 then CMap.remove mapcmp x m
+           else CMap.add mapcmp x n' m) CMap.empty l
     in
-    { m = m; c = c; ty = ty }
+    { m = m; c = c; pty = ty }
 
   let add p1 p2 =
     Options.tool_req 4 "TR-Arith-Poly plus";
     let m =
-      M.fold
+      CMap.fold
         (fun x a m ->
            let a' = Q.add (find x m) a in
-           if Q.sign a' = 0 then M.remove x m  else M.add x a' m)
+           if Q.sign a' = 0 then CMap.remove mapcmp x m
+           else CMap.add mapcmp x a' m)
         p2.m p1.m
     in
-    { m = m; c = Q.add p1.c p2.c; ty = p1.ty }
+    { m = m; c = Q.add p1.c p2.c; pty = p1.pty }
 
   let mult_const n p =
-    if Q.sign n = 0 then { m = M.empty; c = Q.zero; ty = p.ty }
-    else { p with m = M.map (Q.mult n) p.m; c =  Q.mult n p.c }
+    if Q.sign n = 0 then { m = CMap.empty; c = Q.zero; pty = p.pty }
+    else { p with m = CMap.map (Q.mult n) p.m; c =  Q.mult n p.c }
 
   let add_const n p = {p with c = Q.add p.c n}
 
   let mult_monome a x p  =
-    let ax = { m = M.add x a M.empty; c = Q.zero; ty = p.ty} in
+    let ax = { m = CMap.add mapcmp x a CMap.empty; c = Q.zero; pty = p.pty} in
     let acx = mult_const p.c ax in
     let m =
-      M.fold
-        (fun xi ai m -> M.add (X.mult x xi) (Q.mult a ai) m) p.m acx.m
+      CMap.fold
+        (fun xi ai m -> CMap.add mapcmp (X.mult x xi) (Q.mult a ai) m) p.m acx.m
     in
     { acx with m = m}
 
   let mult p1 p2 =
     Options.tool_req 4 "TR-Arith-Poly mult";
     let p = mult_const p1.c p2 in
-    M.fold (fun x a p -> add (mult_monome a x p2) p) p1.m p
+    CMap.fold (fun x a p -> add (mult_monome a x p2) p) p1.m p
 
   let sub p1 p2 =
     Options.tool_req 4 "TR-Arith-Poly moins";
     let m =
-      M.fold
+      CMap.fold
         (fun x a m ->
            let a' = Q.sub (find x m) a in
-           if Q.sign a' = 0 then M.remove x m  else M.add x a' m)
+           if Q.sign a' = 0 then CMap.remove mapcmp x m
+           else CMap.add mapcmp x a' m)
         p2.m p1.m
     in
-    { m = m; c = Q.sub p1.c p2.c; ty = p1.ty }
+    { m = m; c = Q.sub p1.c p2.c; pty = p1.pty }
 
 
   let euc_mod_num c1 c2 =
@@ -240,10 +262,10 @@ module Make (X : S) = struct
 
   let div p1 p2 =
     Options.tool_req 4 "TR-Arith-Poly div";
-    if not (M.is_empty p2.m) then raise Maybe_zero;
+    if not (CMap.is_empty p2.m) then raise Maybe_zero;
     if Q.sign p2.c = 0 then raise Division_by_zero;
     let p = mult_const (Q.div Q.one p2.c) p1 in
-    match M.is_empty p.m, p.ty with
+    match CMap.is_empty p.m, p.pty with
     | _ , Ty.Treal  ->  p, false
     | true, Ty.Tint  -> {p with c = euc_div_num p1.c p2.c}, false
     | false, Ty.Tint ->  p, true (* XXX *)
@@ -251,31 +273,31 @@ module Make (X : S) = struct
 
   let modulo p1 p2 =
     Options.tool_req 4 "TR-Arith-Poly mod";
-    if not (M.is_empty p2.m) then raise Maybe_zero;
+    if not (CMap.is_empty p2.m) then raise Maybe_zero;
     if Q.sign p2.c = 0 then raise Division_by_zero;
-    if not (M.is_empty p1.m) then raise Not_a_num;
+    if not (CMap.is_empty p1.m) then raise Not_a_num;
     { p1 with c = euc_mod_num p1.c p2.c }
 
-  let find x p = M.find x p.m
+  let find x p = CMap.find mapcmp x p.m
 
-  let is_empty p = M.is_empty p.m
+  let is_empty p = CMap.is_empty p.m
 
   let choose p =
     let tn= ref None in
     (*version I : prend le premier element de la table*)
-    (try M.iter
+    (try CMap.iter
            (fun x a -> tn := Some (a, x); raise Exit) p.m with Exit -> ());
     (*version II : prend le dernier element de la table i.e. le plus grand
-      M.iter (fun x a -> tn := Some (a, x)) p.m;*)
+      CMap.iter (fun x a -> tn := Some (a, x)) p.m;*)
     match !tn with Some p -> p | _ -> raise Not_found
 
   let subst x p1 p2 =
     try
-      let a = M.find x p2.m in
-      add (mult_const a p1) { p2 with m = M.remove x p2.m}
+      let a = CMap.find mapcmp x p2.m in
+      add (mult_const a p1) { p2 with m = CMap.remove mapcmp x p2.m}
     with Not_found -> p2
 
-  let remove x p = { p with m = M.remove x p.m }
+  let remove x p = { p with m = CMap.remove mapcmp x p.m }
 
   let to_list p = map_to_list p.m , p.c
 
@@ -285,15 +307,15 @@ module Make (X : S) = struct
 
   let leaves p =
     let s =
-      M.fold (fun a _ s -> xs_of_list s (X.leaves a)) p.m SX.empty
+      CMap.fold (fun a _ s -> xs_of_list s (X.leaves a)) p.m SX.empty
     in
     SX.elements s
 
-  let type_info p = p.ty
+  let type_info p = p.pty
 
   let is_monomial p  =
     try
-      M.fold
+      CMap.fold
         (fun x a r ->
            match r with
            | None -> Some (a, x, p.c)
@@ -303,21 +325,21 @@ module Make (X : S) = struct
 
   let ppmc_denominators { m; _ } =
     let res =
-      M.fold
+      CMap.fold
         (fun _ c acc -> Z.my_lcm (Q.den c) acc)
         m Z.one in
     Q.abs (Q.from_z res)
 
   let pgcd_numerators { m; _ } =
     let res =
-      M.fold
+      CMap.fold
         (fun _ c acc -> Z.my_gcd (Q.num c) acc)
         m Z.zero
     in
     Q.abs (Q.from_z res)
 
   let normal_form ({ m; _ } as p) =
-    if M.is_empty m then
+    if CMap.is_empty m then
       { p with c = Q.zero }, p.c, Q.one
     else
       let ppcm = ppmc_denominators p in
@@ -335,21 +357,24 @@ module Make (X : S) = struct
 
   let abstract_selectors p acc =
     let mp, acc =
-      M.fold
+      CMap.fold
         (fun r i (mp, acc) ->
            let r, acc = X.abstract_selectors r acc in
            let mp =
              try
-               let j = M.find r mp in
+               let j = CMap.find mapcmp r mp in
                let k = Q.add i j in
-               if Q.sign k = 0 then M.remove r mp else M.add r k mp
-             with Not_found -> M.add r i mp
+               if Q.sign k = 0 then CMap.remove mapcmp r mp
+               else CMap.add mapcmp r k mp
+             with Not_found -> CMap.add mapcmp r i mp
            in
            mp, acc
-        )p.m (M.empty, acc)
+        )p.m (CMap.empty, acc)
     in
     {p with m=mp}, acc
 
   let separate_constant t = { t with c = Q.zero}, t.c
 
+(*
 end
+*)

--- a/src/lib/reasoners/polynome.mli
+++ b/src/lib/reasoners/polynome.mli
@@ -29,6 +29,7 @@
 exception Not_a_num
 exception Maybe_zero
 
+(*
 module type S = sig
   include Sig.X
   val mult : r -> r -> r
@@ -38,6 +39,11 @@ module type T = sig
 
   type r
   type t
+*)
+open Types
+
+module type T = sig
+  type t = Types.polynome
 
   val compare : t -> t -> int
   val equal : t -> t -> bool
@@ -81,6 +87,11 @@ module type T = sig
   val separate_constant : t -> t * Numbers.Q.t
 end
 
+include T
+
+(*
+end
+
 module type EXTENDED_Polynome = sig
   include T
   val extract : r -> t option
@@ -89,3 +100,4 @@ end
 
 module Make (X : S) : T with type r = X.r
 
+*)

--- a/src/lib/reasoners/records.mli
+++ b/src/lib/reasoners/records.mli
@@ -26,13 +26,4 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type 'a abstract
-
-module type ALIEN = sig
-  include Sig.X
-  val embed : r abstract -> r
-  val extract : r -> (r abstract) option
-end
-
-module Shostak
-    (X : ALIEN) : Sig.SHOSTAK with type r = X.r and type t = X.r abstract
+include ( Sig.SHOSTAK with type t = Types.records )

--- a/src/lib/reasoners/records_rel.ml
+++ b/src/lib/reasoners/records_rel.ml
@@ -26,6 +26,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 type t = unit
 
 let empty _ = ()
@@ -38,7 +40,7 @@ let new_terms _ = Expr.Set.empty
 let instantiate ~do_syntactic_matching:_ _ env _ _ = env, []
 
 let assume_th_elt t th_elt _ =
-  match th_elt.Expr.extends with
+  match th_elt.extends with
   | Util.Records ->
     failwith "This Theory does not support theories extension"
   | _ -> t

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -54,9 +54,9 @@ module type S = sig
 
   (* [assume env f] assume a new formula [f] in [env]. Raises Unsat if
      [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> t
+  val assume : t -> Types.gformula -> Explanation.t -> t
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Types.th_elt -> Explanation.t -> t
 
   (* [pred_def env f] assume a new predicate definition [f] in [env]. *)
   val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
@@ -64,7 +64,7 @@ module type S = sig
   (* [unsat env f size] checks the unsatisfiability of [f] in
      [env]. Raises I_dont_know when the proof tree's height reaches
      [size]. Raises Sat if [f] is satisfiable in [env] *)
-  val unsat : t -> Expr.gformula -> Explanation.t
+  val unsat : t -> Types.gformula -> Explanation.t
 
   val reset_refs : unit -> unit
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -51,11 +51,11 @@ module type S = sig
 
   (** [assume env f] assume a new formula [f] in [env]. Raises Unsat if
       [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> t
+  val assume : t -> Types.gformula -> Explanation.t -> t
 
   (** [assume env f exp] assume a new formula [f] with the explanation [exp]
       in the theories environment of [env]. *)
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Types.th_elt -> Explanation.t -> t
 
   (** [pred_def env f] assume a new predicate definition [f] in [env]. *)
   val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
@@ -63,7 +63,7 @@ module type S = sig
   (** [unsat env f size] checks the unsatisfiability of [f] in
       [env]. Raises I_dont_know when the proof tree's height reaches
       [size]. Raises Sat if [f] is satisfiable in [env] *)
-  val unsat : t -> Expr.gformula -> Explanation.t
+  val unsat : t -> Types.gformula -> Explanation.t
 
   (** [print_model header fmt env] print propositional model and theory model
       on the corresponding fmt. *)

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -60,7 +60,7 @@ module type SAT_ML = sig
   val set_current_tbox : t -> th -> unit
   val empty : unit -> t
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> unit
+  val assume_th_elt : t -> Types.th_elt -> Explanation.t -> unit
   val decision_level : t -> int
   val cancel_until : t -> int -> unit
 

--- a/src/lib/reasoners/satml.mli
+++ b/src/lib/reasoners/satml.mli
@@ -56,7 +56,7 @@ module type SAT_ML = sig
   val set_current_tbox : t -> th -> unit
   val empty : unit -> t
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> unit
+  val assume_th_elt : t -> Types.th_elt -> Explanation.t -> unit
   val decision_level : t -> int
   val cancel_until : t -> int -> unit
 
@@ -80,4 +80,3 @@ module type SAT_ML = sig
 end
 
 module Make (Th : Theory.S) : SAT_ML with type th = Th.t
-

--- a/src/lib/reasoners/satml_frontend_hybrid.ml
+++ b/src/lib/reasoners/satml_frontend_hybrid.ml
@@ -9,6 +9,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
 
 module Make (Th : Theory.S) = struct
 
@@ -30,7 +31,7 @@ module Make (Th : Theory.S) = struct
      inv_proxies : E.t MA.t;
      hcons_env : Atom.hcons_env;
      decisions : (int * E.t) list;
-     pending : (E.gformula * Ex.t) list list;
+     pending : (gformula * Ex.t) list list;
     }
 
   exception Bottom of Explanation.t * E.Set.t list * t
@@ -119,7 +120,7 @@ module Make (Th : Theory.S) = struct
       let env, pfl, cnf, new_vars =
         List.fold_left (fun acc l ->
             List.fold_left
-              (fun ((env, pfl, cnf, vars) as acc) ({ E.ff = f; _ }, ex) ->
+              (fun ((env, pfl, cnf, vars) as acc) ({ ff = f; _ }, ex) ->
                  if SE.mem f env.assumed then acc
                  else
                  if Ex.has_no_bj ex then begin

--- a/src/lib/reasoners/satml_frontend_hybrid.mli
+++ b/src/lib/reasoners/satml_frontend_hybrid.mli
@@ -19,7 +19,7 @@ module Make (Th : Theory.S) : sig
 
   val is_true : t -> Expr.t -> (Explanation.t Lazy.t * int) option
 
-  val assume : bool -> t -> (Expr.gformula * Explanation.t) list -> t
+  val assume : bool -> t -> (Types.gformula * Explanation.t) list -> t
 
   val decide : t -> Expr.t -> int -> t
 

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -34,26 +34,26 @@ module H = Hashtbl.Make(Expr)
 module rec CX : sig
   include Sig.X
 
-  val extract1 : r -> X1.t option
-  val embed1 : X1.t -> r
+  val extract1 : r -> ARITH.t option
+  val embed1 : ARITH.t -> r
 
-  val extract2 : r -> X2.t option
-  val embed2 : X2.t -> r
+  val extract2 : r -> RECORDS.t option
+  val embed2 : RECORDS.t -> r
 
-  val extract3 : r -> X3.t option
-  val embed3 : X3.t -> r
+  val extract3 : r -> BITV.t option
+  val embed3 : BITV.t -> r
 
-  val extract4 : r -> X4.t option
-  val embed4 : X4.t -> r
+  val extract4 : r -> ARRAYS.t option
+  val embed4 : ARRAYS.t -> r
 
-  val extract5 : r -> X5.t option
-  val embed5 : X5.t -> r
+  val extract5 : r -> ENUM.t option
+  val embed5 : ENUM.t -> r
 
-  val extract6 : r -> X6.t option
-  val embed6 : X6.t -> r
+  val extract6 : r -> ADT.t option
+  val embed6 : ADT.t -> r
 
-  val extract7 : r -> X7.t option
-  val embed7 : X7.t -> r
+  val extract7 : r -> ITE.t option
+  val embed7 : ITE.t -> r
 
 end =
 struct
@@ -61,13 +61,13 @@ struct
   type rview =
     | Term  of Expr.t
     | Ac    of AC.t
-    | X1    of X1.t
-    | X2    of X2.t
-    | X3    of X3.t
-    | X4    of X4.t
-    | X5    of X5.t
-    | X6    of X6.t
-    | X7    of X7.t
+    | ARITH    of ARITH.t
+    | RECORDS    of RECORDS.t
+    | BITV    of BITV.t
+    | ARRAYS    of ARRAYS.t
+    | ENUM    of ENUM.t
+    | ADT    of ADT.t
+    | ITE    of ITE.t
 
   type r = {v : rview ; id : int}
 
@@ -81,13 +81,13 @@ struct
 
     let hash r =
       let res = match r.v with
-        | X1 x   -> 1 + 10 * X1.hash x
-        | X2 x   -> 2 + 10 * X2.hash x
-        | X3 x   -> 3 + 10 * X3.hash x
-        | X4 x   -> 4 + 10 * X4.hash x
-        | X5 x   -> 5 + 10 * X5.hash x
-        | X6 x   -> 6 + 10 * X6.hash x
-        | X7 x   -> 7 + 10 * X7.hash x
+        | ARITH x   -> 1 + 10 * ARITH.hash x
+        | RECORDS x   -> 2 + 10 * RECORDS.hash x
+        | BITV x   -> 3 + 10 * BITV.hash x
+        | ARRAYS x   -> 4 + 10 * ARRAYS.hash x
+        | ENUM x   -> 5 + 10 * ENUM.hash x
+        | ADT x   -> 6 + 10 * ADT.hash x
+        | ITE x   -> 7 + 10 * ITE.hash x
         | Ac ac  -> 9 + 10 * AC.hash ac
         | Term t -> 8 + 10 * Expr.hash t
       in
@@ -95,13 +95,13 @@ struct
 
     let eq  r1 r2 =
       match r1.v, r2.v with
-      | X1 x, X1 y -> X1.equal x y
-      | X2 x, X2 y -> X2.equal x y
-      | X3 x, X3 y -> X3.equal x y
-      | X4 x, X4 y -> X4.equal x y
-      | X5 x, X5 y -> X5.equal x y
-      | X6 x, X6 y -> X6.equal x y
-      | X7 x, X7 y -> X7.equal x y
+      | ARITH x, ARITH y -> ARITH.equal x y
+      | RECORDS x, RECORDS y -> RECORDS.equal x y
+      | BITV x, BITV y -> BITV.equal x y
+      | ARRAYS x, ARRAYS y -> ARRAYS.equal x y
+      | ENUM x, ENUM y -> ENUM.equal x y
+      | ADT x, ADT y -> ADT.equal x y
+      | ITE x, ITE y -> ITE.equal x y
       | Term x  , Term y  -> Expr.equal x y
       | Ac x    , Ac    y -> AC.equal x y
       | _ -> false
@@ -124,13 +124,13 @@ struct
 
   (* end: Hconsing modules and functions *)
 
-  let embed1 x = hcons {v = X1 x; id = -1000 (* dummy *)}
-  let embed2 x = hcons {v = X2 x; id = -1000 (* dummy *)}
-  let embed3 x = hcons {v = X3 x; id = -1000 (* dummy *)}
-  let embed4 x = hcons {v = X4 x; id = -1000 (* dummy *)}
-  let embed5 x = hcons {v = X5 x; id = -1000 (* dummy *)}
-  let embed6 x = hcons {v = X6 x; id = -1000 (* dummy *)}
-  let embed7 x = hcons {v = X7 x; id = -1000 (* dummy *)}
+  let embed1 x = hcons {v = ARITH x; id = -1000 (* dummy *)}
+  let embed2 x = hcons {v = RECORDS x; id = -1000 (* dummy *)}
+  let embed3 x = hcons {v = BITV x; id = -1000 (* dummy *)}
+  let embed4 x = hcons {v = ARRAYS x; id = -1000 (* dummy *)}
+  let embed5 x = hcons {v = ENUM x; id = -1000 (* dummy *)}
+  let embed6 x = hcons {v = ADT x; id = -1000 (* dummy *)}
+  let embed7 x = hcons {v = ITE x; id = -1000 (* dummy *)}
 
   let ac_embed ({ Sig.l; _ } as t) =
     match l with
@@ -144,13 +144,13 @@ struct
 
   let term_embed t = hcons {v = Term t; id = -1000 (* dummy *)}
 
-  let extract1 = function { v=X1 r; _ } -> Some r | _ -> None
-  let extract2 = function { v=X2 r; _ } -> Some r | _ -> None
-  let extract3 = function { v=X3 r; _ } -> Some r | _ -> None
-  let extract4 = function { v=X4 r; _ } -> Some r | _ -> None
-  let extract5 = function { v=X5 r; _ } -> Some r | _ -> None
-  let extract6 = function { v=X6 r; _ } -> Some r | _ -> None
-  let extract7 = function { v=X7 r; _ } -> Some r | _ -> None
+  let extract1 = function { v=ARITH r; _ } -> Some r | _ -> None
+  let extract2 = function { v=RECORDS r; _ } -> Some r | _ -> None
+  let extract3 = function { v=BITV r; _ } -> Some r | _ -> None
+  let extract4 = function { v=ARRAYS r; _ } -> Some r | _ -> None
+  let extract5 = function { v=ENUM r; _ } -> Some r | _ -> None
+  let extract6 = function { v=ADT r; _ } -> Some r | _ -> None
+  let extract7 = function { v=ITE r; _ } -> Some r | _ -> None
 
   let ac_extract = function
     | { v = Ac t; _ }   -> Some t
@@ -158,13 +158,13 @@ struct
 
   let term_extract r =
     match r.v with
-    | X1 _ -> X1.term_extract r
-    | X2 _ -> X2.term_extract r
-    | X3 _ -> X3.term_extract r
-    | X4 _ -> X4.term_extract r
-    | X5 _ -> X5.term_extract r
-    | X6 _ -> X6.term_extract r
-    | X7 _ -> X7.term_extract r
+    | ARITH _ -> ARITH.term_extract r
+    | RECORDS _ -> RECORDS.term_extract r
+    | BITV _ -> BITV.term_extract r
+    | ARRAYS _ -> ARRAYS.term_extract r
+    | ENUM _ -> ENUM.term_extract r
+    | ADT _ -> ADT.term_extract r
+    | ITE _ -> ITE.term_extract r
     | Ac _ -> None, false (* SYLVAIN : TODO *)
     | Term t -> Some t, true
 
@@ -172,27 +172,27 @@ struct
   let bot () = term_embed Expr.faux
 
   let type_info = function
-    | { v = X1 t; _ }   -> X1.type_info t
-    | { v = X2 t; _ }   -> X2.type_info t
-    | { v = X3 t; _ }   -> X3.type_info t
-    | { v = X4 t; _ }   -> X4.type_info t
-    | { v = X5 t; _ }   -> X5.type_info t
-    | { v = X6 t; _ }   -> X6.type_info t
-    | { v = X7 t; _ }   -> X7.type_info t
+    | { v = ARITH t; _ }   -> ARITH.type_info t
+    | { v = RECORDS t; _ }   -> RECORDS.type_info t
+    | { v = BITV t; _ }   -> BITV.type_info t
+    | { v = ARRAYS t; _ }   -> ARRAYS.type_info t
+    | { v = ENUM t; _ }   -> ENUM.type_info t
+    | { v = ADT t; _ }   -> ADT.type_info t
+    | { v = ITE t; _ }   -> ITE.type_info t
     | { v = Ac x; _ }   -> AC.type_info x
     | { v = Term t; _ } -> Expr.type_info t
 
-  (* Xi < Term < Ac *)
+  (* Constraint that must be maintained: all theories should have Xi < Term < Ac *)
   let theory_num x = match x with
     | Ac _    -> -1
     | Term  _ -> -2
-    | X1 _    -> -3
-    | X2 _    -> -4
-    | X3 _    -> -5
-    | X4 _    -> -6
-    | X5 _    -> -7
-    | X6 _    -> -8
-    | X7 _    -> -9
+    | ARITH _    -> -3
+    | RECORDS _    -> -4
+    | BITV _    -> -5
+    | ARRAYS _    -> -6
+    | ENUM _    -> -7
+    | ADT _    -> -8
+    | ITE _    -> -9
 
   let compare_tag a b = theory_num a - theory_num b
 
@@ -200,13 +200,13 @@ struct
     if CX.equal a b then 0
     else
       match a.v, b.v with
-      | X1 _, X1 _ -> X1.compare a b
-      | X2 _, X2 _ -> X2.compare a b
-      | X3 _, X3 _ -> X3.compare a b
-      | X4 _, X4 _ -> X4.compare a b
-      | X5 _, X5 _ -> X5.compare a b
-      | X6 _, X6 _ -> X6.compare a b
-      | X7 _, X7 _ -> X7.compare a b
+      | ARITH _, ARITH _ -> ARITH.compare a b
+      | RECORDS _, RECORDS _ -> RECORDS.compare a b
+      | BITV _, BITV _ -> BITV.compare a b
+      | ARRAYS _, ARRAYS _ -> ARRAYS.compare a b
+      | ENUM _, ENUM _ -> ENUM.compare a b
+      | ADT _, ADT _ -> ADT.compare a b
+      | ITE _, ITE _ -> ITE.compare a b
       | Term x  , Term y  -> Expr.compare x y
       | Ac x    , Ac y    -> AC.compare x y
       | va, vb            -> compare_tag va vb
@@ -218,11 +218,11 @@ struct
        let hash r = match r.v with
        | Term  t -> Expr.hash t
        | Ac x -> AC.hash x
-       | X1 x -> X1.hash x
-       | X2 x -> X2.hash x
-       | X3 x -> X3.hash x
-       | X4 x -> X4.hash x
-       | X5 x -> X5.hash x
+       | ARITH x -> ARITH.hash x
+       | RECORDS x -> RECORDS.hash x
+       | BITV x -> BITV.hash x
+       | ARRAYS x -> ARRAYS.hash x
+       | ENUM x -> ENUM.hash x
 
    ***)
 
@@ -247,26 +247,26 @@ struct
 
   let leaves r =
     match r.v with
-    | X1 t -> X1.leaves t
-    | X2 t -> X2.leaves t
-    | X3 t -> X3.leaves t
-    | X4 t -> X4.leaves t
-    | X5 t -> X5.leaves t
-    | X6 t -> X6.leaves t
-    | X7 t -> X7.leaves t
+    | ARITH t -> ARITH.leaves t
+    | RECORDS t -> RECORDS.leaves t
+    | BITV t -> BITV.leaves t
+    | ARRAYS t -> ARRAYS.leaves t
+    | ENUM t -> ENUM.leaves t
+    | ADT t -> ADT.leaves t
+    | ITE t -> ITE.leaves t
     | Ac t -> r :: (AC.leaves t)
     | Term _ -> [r]
 
   let subst p v r =
     if equal p v then r
     else match r.v with
-      | X1 t   -> X1.subst p v t
-      | X2 t   -> X2.subst p v t
-      | X3 t   -> X3.subst p v t
-      | X4 t   -> X4.subst p v t
-      | X5 t   -> X5.subst p v t
-      | X6 t   -> X6.subst p v t
-      | X7 t   -> X7.subst p v t
+      | ARITH t   -> ARITH.subst p v t
+      | RECORDS t   -> RECORDS.subst p v t
+      | BITV t   -> BITV.subst p v t
+      | ARRAYS t   -> ARRAYS.subst p v t
+      | ENUM t   -> ENUM.subst p v t
+      | ADT t   -> ADT.subst p v t
+      | ITE t   -> ITE.subst p v t
       | Ac t   -> if equal p r then v else AC.subst p v t
       | Term _ -> if equal p r then v else r
 
@@ -274,22 +274,22 @@ struct
     let { Expr.f = sb; ty; _ } = Expr.term_view t in
     let not_restricted = not @@ Options.get_restricted () in
     match
-      X1.is_mine_symb sb ty,
-      not_restricted && X2.is_mine_symb sb ty,
-      not_restricted && X3.is_mine_symb sb ty,
-      not_restricted && X4.is_mine_symb sb ty,
-      not_restricted && X5.is_mine_symb sb ty,
-      not_restricted && X6.is_mine_symb sb ty,
-      not_restricted && X7.is_mine_symb sb ty,
+      ARITH.is_mine_symb sb ty,
+      not_restricted && RECORDS.is_mine_symb sb ty,
+      not_restricted && BITV.is_mine_symb sb ty,
+      not_restricted && ARRAYS.is_mine_symb sb ty,
+      not_restricted && ENUM.is_mine_symb sb ty,
+      not_restricted && ADT.is_mine_symb sb ty,
+      not_restricted && ITE.is_mine_symb sb ty,
       AC.is_mine_symb sb ty
     with
-    | true  , false , false , false, false, false, false, false -> X1.make t
-    | false , true  , false , false, false, false, false, false -> X2.make t
-    | false , false , true  , false, false, false, false, false -> X3.make t
-    | false , false , false , true , false, false, false, false -> X4.make t
-    | false , false , false , false, true , false, false, false -> X5.make t
-    | false , false , false , false, false, true , false, false -> X6.make t
-    | false , false , false , false, false, false, true , false -> X7.make t
+    | true  , false , false , false, false, false, false, false -> ARITH.make t
+    | false , true  , false , false, false, false, false, false -> RECORDS.make t
+    | false , false , true  , false, false, false, false, false -> BITV.make t
+    | false , false , false , true , false, false, false, false -> ARRAYS.make t
+    | false , false , false , false, true , false, false, false -> ENUM.make t
+    | false , false , false , false, false, true , false, false -> ADT.make t
+    | false , false , false , false, false, false, true , false -> ITE.make t
     | false , false , false , false, false, false, false, true  -> AC.make t
     | false , false , false , false, false, false, false, false ->
       term_embed t, []
@@ -298,29 +298,29 @@ struct
   let fully_interpreted sb ty =
     let not_restricted = not @@ Options.get_restricted () in
     match
-      X1.is_mine_symb sb ty,
-      not_restricted && X2.is_mine_symb sb ty,
-      not_restricted && X3.is_mine_symb sb ty,
-      not_restricted && X4.is_mine_symb sb ty,
-      not_restricted && X5.is_mine_symb sb ty,
-      not_restricted && X6.is_mine_symb sb ty,
-      not_restricted && X7.is_mine_symb sb ty,
+      ARITH.is_mine_symb sb ty,
+      not_restricted && RECORDS.is_mine_symb sb ty,
+      not_restricted && BITV.is_mine_symb sb ty,
+      not_restricted && ARRAYS.is_mine_symb sb ty,
+      not_restricted && ENUM.is_mine_symb sb ty,
+      not_restricted && ADT.is_mine_symb sb ty,
+      not_restricted && ITE.is_mine_symb sb ty,
       AC.is_mine_symb sb ty
     with
     | true  , false , false , false, false, false, false, false ->
-      X1.fully_interpreted sb
+      ARITH.fully_interpreted sb
     | false , true  , false , false, false, false, false, false ->
-      X2.fully_interpreted sb
+      RECORDS.fully_interpreted sb
     | false , false , true  , false, false, false, false, false ->
-      X3.fully_interpreted sb
+      BITV.fully_interpreted sb
     | false , false , false , true , false, false, false, false ->
-      X4.fully_interpreted sb
+      ARRAYS.fully_interpreted sb
     | false , false , false , false, true , false, false, false ->
-      X5.fully_interpreted sb
+      ENUM.fully_interpreted sb
     | false , false , false , false, false, true , false, false ->
-      X6.fully_interpreted sb
+      ADT.fully_interpreted sb
     | false , false , false , false, false, false, true , false ->
-      X7.fully_interpreted sb
+      ITE.fully_interpreted sb
     | false , false , false , false, false, false, false, true  ->
       AC.fully_interpreted sb
     | false , false , false , false, false, false, false, false ->
@@ -328,12 +328,12 @@ struct
     | _ -> assert false
 
   let is_solvable_theory_symbol sb ty =
-    X1.is_mine_symb sb ty ||
+    ARITH.is_mine_symb sb ty ||
     not (Options.get_restricted ()) &&
-    (X2.is_mine_symb sb ty ||
-     X3.is_mine_symb sb ty ||
-     X4.is_mine_symb sb ty ||
-     X5.is_mine_symb sb ty)
+    (RECORDS.is_mine_symb sb ty ||
+     BITV.is_mine_symb sb ty ||
+     ARRAYS.is_mine_symb sb ty ||
+     ENUM.is_mine_symb sb ty)
 
 
   let is_a_leaf r = match r.v with
@@ -347,22 +347,22 @@ struct
     | _ ->
       let ty = ac.Sig.t in
       match
-        X1.is_mine_symb ac.Sig.h ty,
-        X2.is_mine_symb ac.Sig.h ty,
-        X3.is_mine_symb ac.Sig.h ty,
-        X4.is_mine_symb ac.Sig.h ty,
-        X5.is_mine_symb ac.Sig.h ty,
-        X6.is_mine_symb ac.Sig.h ty,
-        X7.is_mine_symb ac.Sig.h ty,
+        ARITH.is_mine_symb ac.Sig.h ty,
+        RECORDS.is_mine_symb ac.Sig.h ty,
+        BITV.is_mine_symb ac.Sig.h ty,
+        ARRAYS.is_mine_symb ac.Sig.h ty,
+        ENUM.is_mine_symb ac.Sig.h ty,
+        ADT.is_mine_symb ac.Sig.h ty,
+        ITE.is_mine_symb ac.Sig.h ty,
         AC.is_mine_symb ac.Sig.h ty with
       (*AC.is_mine may say F if Options.get_no_ac is set to F dynamically *)
-      | true  , false , false , false, false, false, false, false -> X1.color ac
-      | false , true  , false , false, false, false, false, false -> X2.color ac
-      | false , false , true  , false, false, false, false, false -> X3.color ac
-      | false , false , false , true , false, false, false, false -> X4.color ac
-      | false , false , false , false, true , false, false, false -> X5.color ac
-      | false , false , false , false, false, true , false, false -> X6.color ac
-      | false , false , false , false, false, false, true , false -> X7.color ac
+      | true  , false , false , false, false, false, false, false -> ARITH.color ac
+      | false , true  , false , false, false, false, false, false -> RECORDS.color ac
+      | false , false , true  , false, false, false, false, false -> BITV.color ac
+      | false , false , false , true , false, false, false, false -> ARRAYS.color ac
+      | false , false , false , false, true , false, false, false -> ENUM.color ac
+      | false , false , false , false, false, true , false, false -> ADT.color ac
+      | false , false , false , false, false, false, true , false -> ITE.color ac
       | _  -> ac_embed ac
 
 
@@ -374,25 +374,25 @@ struct
       let open Format in
       if Options.get_term_like_pp () then begin
         match r.v with
-        | X1 t    -> fprintf fmt "%a" X1.print t
-        | X2 t    -> fprintf fmt "%a" X2.print t
-        | X3 t    -> fprintf fmt "%a" X3.print t
-        | X4 t    -> fprintf fmt "%a" X4.print t
-        | X5 t    -> fprintf fmt "%a" X5.print t
-        | X6 t    -> fprintf fmt "%a" X6.print t
-        | X7 t    -> fprintf fmt "%a" X7.print t
+        | ARITH t    -> fprintf fmt "%a" ARITH.print t
+        | RECORDS t    -> fprintf fmt "%a" RECORDS.print t
+        | BITV t    -> fprintf fmt "%a" BITV.print t
+        | ARRAYS t    -> fprintf fmt "%a" ARRAYS.print t
+        | ENUM t    -> fprintf fmt "%a" ENUM.print t
+        | ADT t    -> fprintf fmt "%a" ADT.print t
+        | ITE t    -> fprintf fmt "%a" ITE.print t
         | Term t  -> fprintf fmt "%a" Expr.print t
         | Ac t    -> fprintf fmt "%a" AC.print t
       end
       else begin
         match r.v with
-        | X1 t    -> fprintf fmt "X1(%s):[%a]" X1.name X1.print t
-        | X2 t    -> fprintf fmt "X2(%s):[%a]" X2.name X2.print t
-        | X3 t    -> fprintf fmt "X3(%s):[%a]" X3.name X3.print t
-        | X4 t    -> fprintf fmt "X4(%s):[%a]" X4.name X4.print t
-        | X5 t    -> fprintf fmt "X5(%s):[%a]" X5.name X5.print t
-        | X6 t    -> fprintf fmt "X6(%s):[%a]" X6.name X6.print t
-        | X7 t    -> fprintf fmt "X7(%s):[%a]" X7.name X7.print t
+        | ARITH t    -> fprintf fmt "ARITH(%s):[%a]" ARITH.name ARITH.print t
+        | RECORDS t    -> fprintf fmt "RECORDS(%s):[%a]" RECORDS.name RECORDS.print t
+        | BITV t    -> fprintf fmt "BITV(%s):[%a]" BITV.name BITV.print t
+        | ARRAYS t    -> fprintf fmt "ARRAYS(%s):[%a]" ARRAYS.name ARRAYS.print t
+        | ENUM t    -> fprintf fmt "ENUM(%s):[%a]" ENUM.name ENUM.print t
+        | ADT t    -> fprintf fmt "ADT(%s):[%a]" ADT.name ADT.print t
+        | ITE t    -> fprintf fmt "ITE(%s):[%a]" ITE.name ITE.print t
         | Term t  -> fprintf fmt "FT:[%a]" Expr.print t
         | Ac t    -> fprintf fmt "Ac:[%a]" AC.print t
       end
@@ -458,13 +458,13 @@ struct
   let abstract_selectors a acc =
     Debug.debug_abstract_selectors a;
     match a.v with
-    | X1 a   -> X1.abstract_selectors a acc
-    | X2 a   -> X2.abstract_selectors a acc
-    | X3 a   -> X3.abstract_selectors a acc
-    | X4 a   -> X4.abstract_selectors a acc
-    | X5 a   -> X5.abstract_selectors a acc
-    | X6 a   -> X6.abstract_selectors a acc
-    | X7 a   -> X7.abstract_selectors a acc
+    | ARITH a   -> ARITH.abstract_selectors a acc
+    | RECORDS a   -> RECORDS.abstract_selectors a acc
+    | BITV a   -> BITV.abstract_selectors a acc
+    | ARRAYS a   -> ARRAYS.abstract_selectors a acc
+    | ENUM a   -> ENUM.abstract_selectors a acc
+    | ADT a   -> ADT.abstract_selectors a acc
+    | ITE a   -> ITE.abstract_selectors a acc
     | Term _ -> a, acc
     | Ac a   -> AC.abstract_selectors a acc
 
@@ -540,12 +540,12 @@ struct
         let tyb = CX.type_info rb in
         Debug.assert_have_mem_types tya tyb;
         let pb = match tya with
-          | Ty.Tint | Ty.Treal -> X1.solve ra rb pb
-          | Ty.Trecord _       -> X2.solve ra rb pb
-          | Ty.Tbitv _         -> X3.solve ra rb pb
-          | Ty.Tsum _          -> X5.solve ra rb pb
+          | Ty.Tint | Ty.Treal -> ARITH.solve ra rb pb
+          | Ty.Trecord _       -> RECORDS.solve ra rb pb
+          | Ty.Tbitv _         -> BITV.solve ra rb pb
+          | Ty.Tsum _          -> ENUM.solve ra rb pb
           (*| Ty.Tunit           -> pb *)
-          | Ty.Tadt _ when not (Options.get_disable_adts()) -> X6.solve ra rb pb
+          | Ty.Tadt _ when not (Options.get_disable_adts()) -> ADT.solve ra rb pb
           | _                  -> solve_uninterpreted ra rb pb
         in
         solve_list pb
@@ -579,13 +579,13 @@ struct
   let assign_value r distincts eq =
     let opt = match r.v, type_info r with
       | _, Ty.Tint
-      | _, Ty.Treal     -> X1.assign_value r distincts eq
-      | _, Ty.Trecord _ -> X2.assign_value r distincts eq
-      | _, Ty.Tbitv _   -> X3.assign_value r distincts eq
-      | _, Ty.Tfarray _ -> X4.assign_value r distincts eq
-      | _, Ty.Tsum _    -> X5.assign_value r distincts eq
+      | _, Ty.Treal     -> ARITH.assign_value r distincts eq
+      | _, Ty.Trecord _ -> RECORDS.assign_value r distincts eq
+      | _, Ty.Tbitv _   -> BITV.assign_value r distincts eq
+      | _, Ty.Tfarray _ -> ARRAYS.assign_value r distincts eq
+      | _, Ty.Tsum _    -> ENUM.assign_value r distincts eq
       | _, Ty.Tadt _    when not (Options.get_disable_adts()) ->
-        X6.assign_value r distincts eq
+        ADT.assign_value r distincts eq
 
       | Term _t, Ty.Tbool ->
         if is_bool_const r then None
@@ -625,13 +625,13 @@ struct
     let r, pprint =
       match Expr.type_info t with
       | Ty.Tint
-      | Ty.Treal     -> X1.choose_adequate_model t rep l
-      | Ty.Tbitv _   -> X3.choose_adequate_model t rep l
-      | Ty.Tsum _    -> X5.choose_adequate_model t rep l
+      | Ty.Treal     -> ARITH.choose_adequate_model t rep l
+      | Ty.Tbitv _   -> BITV.choose_adequate_model t rep l
+      | Ty.Tsum _    -> ENUM.choose_adequate_model t rep l
       | Ty.Tadt _    when not (Options.get_disable_adts()) ->
-        X6.choose_adequate_model t rep l
-      | Ty.Trecord _ -> X2.choose_adequate_model t rep l
-      | Ty.Tfarray _ -> X4.choose_adequate_model t rep l
+        ADT.choose_adequate_model t rep l
+      | Ty.Trecord _ -> RECORDS.choose_adequate_model t rep l
+      | Ty.Tfarray _ -> ARRAYS.choose_adequate_model t rep l
       | Ty.Tbool ->
         (* case split is now supposed to be done for internal bools if
            needed as well *)
@@ -682,22 +682,22 @@ struct
 
 end
 
-and TX1 : Polynome.T
+and TARITH : Polynome.T
   with type r = CX.r =
   Arith.Type(CX)
 
-and X1 : Sig.SHOSTAK
-  with type t = TX1.t
+and ARITH : Sig.SHOSTAK
+  with type t = TARITH.t
    and type r = CX.r =
   Arith.Shostak
     (CX)
     (struct
-      include TX1
+      include TARITH
       let extract = CX.extract1
       let embed =  CX.embed1
     end)
 
-and X2 : Sig.SHOSTAK
+and RECORDS : Sig.SHOSTAK
   with type r = CX.r
    and type t = CX.r Records.abstract =
   Records.Shostak
@@ -707,7 +707,7 @@ and X2 : Sig.SHOSTAK
       let embed = embed2
     end)
 
-and X3 : Sig.SHOSTAK
+and BITV : Sig.SHOSTAK
   with type r = CX.r
    and type t = CX.r Bitv.abstract =
   Bitv.Shostak
@@ -717,7 +717,7 @@ and X3 : Sig.SHOSTAK
       let embed = embed3
     end)
 
-and X4 : Sig.SHOSTAK
+and ARRAYS : Sig.SHOSTAK
   with type r = CX.r
    and type t = CX.r Arrays.abstract =
   Arrays.Shostak
@@ -727,7 +727,7 @@ and X4 : Sig.SHOSTAK
       let embed = embed4
     end)
 
-and X5 : Sig.SHOSTAK
+and ENUM : Sig.SHOSTAK
   with type r = CX.r
    and type t = CX.r Enum.abstract =
   Enum.Shostak
@@ -737,7 +737,7 @@ and X5 : Sig.SHOSTAK
       let embed = embed5
     end)
 
-and X6 : Sig.SHOSTAK
+and ADT : Sig.SHOSTAK
   with type r = CX.r
    and type t = CX.r Adt.abstract =
   Adt.Shostak
@@ -747,7 +747,7 @@ and X6 : Sig.SHOSTAK
       let embed = embed6
     end)
 
-and X7 : Sig.SHOSTAK
+and ITE : Sig.SHOSTAK
   with type r = CX.r
    and type t = CX.r Ite.abstract =
   Ite.Shostak
@@ -786,14 +786,14 @@ module Combine = struct
 
 end
 
-module Arith = X1
-module Records = X2
-module Bitv = X3
-module Arrays = X4
-module Enum = X5
-module Adt = X6
-module Ite = X7
-module Polynome = TX1
+module Arith = ARITH
+module Records = RECORDS
+module Bitv = BITV
+module Arrays = ARRAYS
+module Enum = ENUM
+module Adt = ADT
+module Ite = ITE
+module Polynome = TARITH
 module Ac = AC
 
 (** map of semantic values using Combine.hash_cmp *)

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -1,5 +1,16 @@
 (******************************************************************************)
 (*                                                                            *)
+(*  Alt-Ergo: The SMT Solver For Software Verification                        *)
+(*  Copyright (C) 2013-2023 --- OCamlPro SAS                                  *)
+(*                                                                            *)
+(*  This file is distributed under the terms of the OCamlPro Non-Commercial   *)
+(*  License version 2.0                                                       *)
+(*                                                                            *)
+(*  AS AN EXCEPTION, Gold members of the Alt-Ergo's Club can distribute this  *)
+(*  file under the terms of the Apache Software License version 2             *)
+(*                                                                            *)
+(*  ------------------------------------------------------------------------  *)
+(*                                                                            *)
 (*     The Alt-Ergo theorem prover                                            *)
 (*     Copyright (C) 2006-2013                                                *)
 (*                                                                            *)
@@ -13,97 +24,55 @@
 (*                                                                            *)
 (*     CNRS - INRIA - Universite Paris Sud                                    *)
 (*                                                                            *)
-(*     This file is distributed under the terms of the Apache Software        *)
-(*     License version 2.0                                                    *)
-(*                                                                            *)
-(*  ------------------------------------------------------------------------  *)
-(*                                                                            *)
-(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
-(*     Copyright (C) 2013-2018 --- OCamlPro SAS                               *)
-(*                                                                            *)
-(*     This file is distributed under the terms of the Apache Software        *)
-(*     License version 2.0                                                    *)
-(*                                                                            *)
 (******************************************************************************)
+
+open Types
 
 module H = Hashtbl.Make(Expr)
 
 (*** Combination module of Shostak theories ***)
 
 [@@@ocaml.warning "-60"]
-module rec CX : sig
+module CX : sig
   include Sig.X
+  val init : unit -> unit
+end = struct
 
-  val extract1 : r -> ARITH.t option
-  val embed1 : ARITH.t -> r
-
-  val extract2 : r -> RECORDS.t option
-  val embed2 : RECORDS.t -> r
-
-  val extract3 : r -> BITV.t option
-  val embed3 : BITV.t -> r
-
-  val extract4 : r -> ARRAYS.t option
-  val embed4 : ARRAYS.t -> r
-
-  val extract5 : r -> ENUM.t option
-  val embed5 : ENUM.t -> r
-
-  val extract6 : r -> ADT.t option
-  val embed6 : ADT.t -> r
-
-  val extract7 : r -> ITE.t option
-  val embed7 : ITE.t -> r
-
-end =
-struct
-
-  type rview =
-    | Term  of Expr.t
-    | Ac    of AC.t
-    | ARITH    of ARITH.t
-    | RECORDS    of RECORDS.t
-    | BITV    of BITV.t
-    | ARRAYS    of ARRAYS.t
-    | ENUM    of ENUM.t
-    | ADT    of ADT.t
-    | ITE    of ITE.t
-
-  type r = {v : rview ; id : int}
+  module CX = Shostak_pre
 
   (* begin: Hashconsing modules and functions *)
 
   module View = struct
 
-    type elt = r
+    type elt = Types.r
 
     let set_id tag r = { r with id=tag }
 
     let hash r =
       let res = match r.v with
-        | ARITH x   -> 1 + 10 * ARITH.hash x
-        | RECORDS x   -> 2 + 10 * RECORDS.hash x
-        | BITV x   -> 3 + 10 * BITV.hash x
-        | ARRAYS x   -> 4 + 10 * ARRAYS.hash x
-        | ENUM x   -> 5 + 10 * ENUM.hash x
-        | ADT x   -> 6 + 10 * ADT.hash x
-        | ITE x   -> 7 + 10 * ITE.hash x
-        | Ac ac  -> 9 + 10 * AC.hash ac
-        | Term t -> 8 + 10 * Expr.hash t
+        | ARITH x   -> 1 + 10 * Arith.hash x
+        | RECORDS x   -> 2 + 10 * Records.hash x
+        | BITV x   -> 3 + 10 * Bitv.hash x
+        | ARRAYS x   -> 4 + 10 * Arrays.hash x
+        | ENUM x   -> 5 + 10 * Enum.hash x
+        | ADT x   -> 6 + 10 * Adt.hash x
+        | ITE x   -> 7 + 10 * Ite.hash x
+        | AC ac  -> 9 + 10 * Ac.hash ac
+        | TERM t -> 8 + 10 * Expr.hash t
       in
       abs res
 
     let eq  r1 r2 =
       match r1.v, r2.v with
-      | ARITH x, ARITH y -> ARITH.equal x y
-      | RECORDS x, RECORDS y -> RECORDS.equal x y
-      | BITV x, BITV y -> BITV.equal x y
-      | ARRAYS x, ARRAYS y -> ARRAYS.equal x y
-      | ENUM x, ENUM y -> ENUM.equal x y
-      | ADT x, ADT y -> ADT.equal x y
-      | ITE x, ITE y -> ITE.equal x y
-      | Term x  , Term y  -> Expr.equal x y
-      | Ac x    , Ac    y -> AC.equal x y
+      | ARITH x, ARITH y -> Arith.equal x y
+      | RECORDS x, RECORDS y -> Records.equal x y
+      | BITV x, BITV y -> Bitv.equal x y
+      | ARRAYS x, ARRAYS y -> Arrays.equal x y
+      | ENUM x, ENUM y -> Enum.equal x y
+      | ADT x, ADT y -> Adt.equal x y
+      | ITE x, ITE y -> Ite.equal x y
+      | TERM x  , TERM y  -> Expr.equal x y
+      | AC x    , AC    y -> Ac.equal x y
       | _ -> false
 
     let initial_size = 9001
@@ -121,71 +90,16 @@ struct
     HC.reinit_cache ()
 
   let hcons v = HC.make v
+  let () = Shostak_pre.REFS.hcons_ref := hcons
 
   (* end: Hconsing modules and functions *)
 
-  let embed1 x = hcons {v = ARITH x; id = -1000 (* dummy *)}
-  let embed2 x = hcons {v = RECORDS x; id = -1000 (* dummy *)}
-  let embed3 x = hcons {v = BITV x; id = -1000 (* dummy *)}
-  let embed4 x = hcons {v = ARRAYS x; id = -1000 (* dummy *)}
-  let embed5 x = hcons {v = ENUM x; id = -1000 (* dummy *)}
-  let embed6 x = hcons {v = ADT x; id = -1000 (* dummy *)}
-  let embed7 x = hcons {v = ITE x; id = -1000 (* dummy *)}
+  let equal a b = a.id = b.id
 
-  let ac_embed ({ Sig.l; _ } as t) =
-    match l with
-    | []    ->
-      assert false
-    | [x, 1] -> x
-    | l     ->
-      let sort = List.fast_sort (fun (x,_) (y,_) -> CX.str_cmp x y) in
-      let ac = { t with Sig.l = List.rev (sort l) } in
-      hcons {v = Ac ac; id = -1000 (* dummy *)}
-
-  let term_embed t = hcons {v = Term t; id = -1000 (* dummy *)}
-
-  let extract1 = function { v=ARITH r; _ } -> Some r | _ -> None
-  let extract2 = function { v=RECORDS r; _ } -> Some r | _ -> None
-  let extract3 = function { v=BITV r; _ } -> Some r | _ -> None
-  let extract4 = function { v=ARRAYS r; _ } -> Some r | _ -> None
-  let extract5 = function { v=ENUM r; _ } -> Some r | _ -> None
-  let extract6 = function { v=ADT r; _ } -> Some r | _ -> None
-  let extract7 = function { v=ITE r; _ } -> Some r | _ -> None
-
-  let ac_extract = function
-    | { v = Ac t; _ }   -> Some t
-    | _ -> None
-
-  let term_extract r =
-    match r.v with
-    | ARITH _ -> ARITH.term_extract r
-    | RECORDS _ -> RECORDS.term_extract r
-    | BITV _ -> BITV.term_extract r
-    | ARRAYS _ -> ARRAYS.term_extract r
-    | ENUM _ -> ENUM.term_extract r
-    | ADT _ -> ADT.term_extract r
-    | ITE _ -> ITE.term_extract r
-    | Ac _ -> None, false (* SYLVAIN : TODO *)
-    | Term t -> Some t, true
-
-  let top () = term_embed Expr.vrai
-  let bot () = term_embed Expr.faux
-
-  let type_info = function
-    | { v = ARITH t; _ }   -> ARITH.type_info t
-    | { v = RECORDS t; _ }   -> RECORDS.type_info t
-    | { v = BITV t; _ }   -> BITV.type_info t
-    | { v = ARRAYS t; _ }   -> ARRAYS.type_info t
-    | { v = ENUM t; _ }   -> ENUM.type_info t
-    | { v = ADT t; _ }   -> ADT.type_info t
-    | { v = ITE t; _ }   -> ITE.type_info t
-    | { v = Ac x; _ }   -> AC.type_info x
-    | { v = Term t; _ } -> Expr.type_info t
-
-  (* Constraint that must be maintained: all theories should have Xi < Term < Ac *)
+  (* Constraint that must be maintained: all theories should have Xi < TERM < AC *)
   let theory_num x = match x with
-    | Ac _    -> -1
-    | Term  _ -> -2
+    | AC _    -> -1
+    | TERM  _ -> -2
     | ARITH _    -> -3
     | RECORDS _    -> -4
     | BITV _    -> -5
@@ -197,27 +111,69 @@ struct
   let compare_tag a b = theory_num a - theory_num b
 
   let str_cmp a b =
-    if CX.equal a b then 0
+    if equal a b then 0
     else
       match a.v, b.v with
-      | ARITH _, ARITH _ -> ARITH.compare a b
-      | RECORDS _, RECORDS _ -> RECORDS.compare a b
-      | BITV _, BITV _ -> BITV.compare a b
-      | ARRAYS _, ARRAYS _ -> ARRAYS.compare a b
-      | ENUM _, ENUM _ -> ENUM.compare a b
-      | ADT _, ADT _ -> ADT.compare a b
-      | ITE _, ITE _ -> ITE.compare a b
-      | Term x  , Term y  -> Expr.compare x y
-      | Ac x    , Ac y    -> AC.compare x y
+      | ARITH _, ARITH _ -> Arith.compare a b
+      | RECORDS _, RECORDS _ -> Records.compare a b
+      | BITV _, BITV _ -> Bitv.compare a b
+      | ARRAYS _, ARRAYS _ -> Arrays.compare a b
+      | ENUM _, ENUM _ -> Enum.compare a b
+      | ADT _, ADT _ -> Adt.compare a b
+      | ITE _, ITE _ -> Ite.compare a b
+      | TERM x  , TERM y  -> Expr.compare x y
+      | AC x    , AC y    -> Ac.compare x y
       | va, vb            -> compare_tag va vb
+
+  let ac_embed ({ Sig.l; _ } as t) =
+    match l with
+    | []    ->
+      assert false
+    | [x, 1] -> x
+    | l     ->
+      let sort = List.fast_sort (fun (x,_) (y,_) -> str_cmp x y) in
+      let ac = { t with Sig.l = List.rev (sort l) } in
+      hcons {v = AC ac; id = -1000 (* dummy *)}
+
+  let term_embed t = hcons {v = TERM t; id = -1000 (* dummy *)}
+
+  let ac_extract = function
+    | { v = AC t; _ }   -> Some t
+    | _ -> None
+
+  let term_extract r =
+    match r.v with
+    | ARITH _ -> Arith.term_extract r
+    | RECORDS _ -> Records.term_extract r
+    | BITV _ -> Bitv.term_extract r
+    | ARRAYS _ -> Arrays.term_extract r
+    | ENUM _ -> Enum.term_extract r
+    | ADT _ -> Adt.term_extract r
+    | ITE _ -> Ite.term_extract r
+    | AC _ -> None, false (* SYLVAIN : TODO *)
+    | TERM t -> Some t, true
+
+  let top () = term_embed Expr.vrai
+  let bot () = term_embed Expr.faux
+
+  let type_info = function
+    | { v = ARITH t; _ }   -> Arith.type_info t
+    | { v = RECORDS t; _ }   -> Records.type_info t
+    | { v = BITV t; _ }   -> Bitv.type_info t
+    | { v = ARRAYS t; _ }   -> Arrays.type_info t
+    | { v = ENUM t; _ }   -> Enum.type_info t
+    | { v = ADT t; _ }   -> Adt.type_info t
+    | { v = ITE t; _ }   -> Ite.type_info t
+    | { v = AC x; _ }   -> Ac.type_info x
+    | { v = TERM t; _ } -> Expr.type_info t
 
   (*** implementations before hash-consing semantic values
 
        let equal a b = CX.compare a b = 0
 
        let hash r = match r.v with
-       | Term  t -> Expr.hash t
-       | Ac x -> AC.hash x
+       | TERM  t -> Expr.hash t
+       | AC x -> AC.hash x
        | ARITH x -> ARITH.hash x
        | RECORDS x -> RECORDS.hash x
        | BITV x -> BITV.hash x
@@ -225,8 +181,6 @@ struct
        | ENUM x -> ENUM.hash x
 
    ***)
-
-  let equal a b = a.id = b.id
 
   let hash v = v.id
 
@@ -243,54 +197,54 @@ struct
     c
   *)
 
-  module SX = Set.Make(struct type t = r let compare = CX.hash_cmp end)
+  module SX = Set.Make(struct type t = r let compare = hash_cmp end)
 
   let leaves r =
     match r.v with
-    | ARITH t -> ARITH.leaves t
-    | RECORDS t -> RECORDS.leaves t
-    | BITV t -> BITV.leaves t
-    | ARRAYS t -> ARRAYS.leaves t
-    | ENUM t -> ENUM.leaves t
-    | ADT t -> ADT.leaves t
-    | ITE t -> ITE.leaves t
-    | Ac t -> r :: (AC.leaves t)
-    | Term _ -> [r]
+    | ARITH t -> Arith.leaves t
+    | RECORDS t -> Records.leaves t
+    | BITV t -> Bitv.leaves t
+    | ARRAYS t -> Arrays.leaves t
+    | ENUM t -> Enum.leaves t
+    | ADT t -> Adt.leaves t
+    | ITE t -> Ite.leaves t
+    | AC t -> r :: (Ac.leaves t)
+    | TERM _ -> [r]
 
   let subst p v r =
     if equal p v then r
     else match r.v with
-      | ARITH t   -> ARITH.subst p v t
-      | RECORDS t   -> RECORDS.subst p v t
-      | BITV t   -> BITV.subst p v t
-      | ARRAYS t   -> ARRAYS.subst p v t
-      | ENUM t   -> ENUM.subst p v t
-      | ADT t   -> ADT.subst p v t
-      | ITE t   -> ITE.subst p v t
-      | Ac t   -> if equal p r then v else AC.subst p v t
-      | Term _ -> if equal p r then v else r
+      | ARITH t   -> Arith.subst p v t
+      | RECORDS t   -> Records.subst p v t
+      | BITV t   -> Bitv.subst p v t
+      | ARRAYS t   -> Arrays.subst p v t
+      | ENUM t   -> Enum.subst p v t
+      | ADT t   -> Adt.subst p v t
+      | ITE t   -> Ite.subst p v t
+      | AC t   -> if equal p r then v else Ac.subst p v t
+      | TERM _ -> if equal p r then v else r
 
   let make t =
-    let { Expr.f = sb; ty; _ } = Expr.term_view t in
+    let { f = sb; ty; _ } = Expr.term_view t in
     let not_restricted = not @@ Options.get_restricted () in
     match
-      ARITH.is_mine_symb sb ty,
-      not_restricted && RECORDS.is_mine_symb sb ty,
-      not_restricted && BITV.is_mine_symb sb ty,
-      not_restricted && ARRAYS.is_mine_symb sb ty,
-      not_restricted && ENUM.is_mine_symb sb ty,
-      not_restricted && ADT.is_mine_symb sb ty,
-      not_restricted && ITE.is_mine_symb sb ty,
-      AC.is_mine_symb sb ty
+      Arith.is_mine_symb sb ty,
+      not_restricted && Records.is_mine_symb sb ty,
+      not_restricted && Bitv.is_mine_symb sb ty,
+      not_restricted && Arrays.is_mine_symb sb ty,
+      not_restricted && Enum.is_mine_symb sb ty,
+      not_restricted && Adt.is_mine_symb sb ty,
+      not_restricted && Ite.is_mine_symb sb ty,
+      Ac.is_mine_symb sb ty
     with
-    | true  , false , false , false, false, false, false, false -> ARITH.make t
-    | false , true  , false , false, false, false, false, false -> RECORDS.make t
-    | false , false , true  , false, false, false, false, false -> BITV.make t
-    | false , false , false , true , false, false, false, false -> ARRAYS.make t
-    | false , false , false , false, true , false, false, false -> ENUM.make t
-    | false , false , false , false, false, true , false, false -> ADT.make t
-    | false , false , false , false, false, false, true , false -> ITE.make t
-    | false , false , false , false, false, false, false, true  -> AC.make t
+    | true  , false , false , false, false, false, false, false -> Arith.make t
+    | false , true  , false , false, false, false, false, false -> Records.make t
+    | false , false , true  , false, false, false, false, false -> Bitv.make t
+    | false , false , false , true , false, false, false, false -> Arrays.make t
+    | false , false , false , false, true , false, false, false -> Enum.make t
+    | false , false , false , false, false, true , false, false -> Adt.make t
+    | false , false , false , false, false, false, true , false -> Ite.make t
+    | false , false , false , false, false, false, false, true  -> Ac.make t
     | false , false , false , false, false, false, false, false ->
       term_embed t, []
     | _ -> assert false
@@ -298,46 +252,46 @@ struct
   let fully_interpreted sb ty =
     let not_restricted = not @@ Options.get_restricted () in
     match
-      ARITH.is_mine_symb sb ty,
-      not_restricted && RECORDS.is_mine_symb sb ty,
-      not_restricted && BITV.is_mine_symb sb ty,
-      not_restricted && ARRAYS.is_mine_symb sb ty,
-      not_restricted && ENUM.is_mine_symb sb ty,
-      not_restricted && ADT.is_mine_symb sb ty,
-      not_restricted && ITE.is_mine_symb sb ty,
-      AC.is_mine_symb sb ty
+      Arith.is_mine_symb sb ty,
+      not_restricted && Records.is_mine_symb sb ty,
+      not_restricted && Bitv.is_mine_symb sb ty,
+      not_restricted && Arrays.is_mine_symb sb ty,
+      not_restricted && Enum.is_mine_symb sb ty,
+      not_restricted && Adt.is_mine_symb sb ty,
+      not_restricted && Ite.is_mine_symb sb ty,
+      Ac.is_mine_symb sb ty
     with
     | true  , false , false , false, false, false, false, false ->
-      ARITH.fully_interpreted sb
+      Arith.fully_interpreted sb
     | false , true  , false , false, false, false, false, false ->
-      RECORDS.fully_interpreted sb
+      Records.fully_interpreted sb
     | false , false , true  , false, false, false, false, false ->
-      BITV.fully_interpreted sb
+      Bitv.fully_interpreted sb
     | false , false , false , true , false, false, false, false ->
-      ARRAYS.fully_interpreted sb
+      Arrays.fully_interpreted sb
     | false , false , false , false, true , false, false, false ->
-      ENUM.fully_interpreted sb
+      Enum.fully_interpreted sb
     | false , false , false , false, false, true , false, false ->
-      ADT.fully_interpreted sb
+      Adt.fully_interpreted sb
     | false , false , false , false, false, false, true , false ->
-      ITE.fully_interpreted sb
+      Ite.fully_interpreted sb
     | false , false , false , false, false, false, false, true  ->
-      AC.fully_interpreted sb
+      Ac.fully_interpreted sb
     | false , false , false , false, false, false, false, false ->
       false
     | _ -> assert false
 
   let is_solvable_theory_symbol sb ty =
-    ARITH.is_mine_symb sb ty ||
+    Arith.is_mine_symb sb ty ||
     not (Options.get_restricted ()) &&
-    (RECORDS.is_mine_symb sb ty ||
-     BITV.is_mine_symb sb ty ||
-     ARRAYS.is_mine_symb sb ty ||
-     ENUM.is_mine_symb sb ty)
+    (Records.is_mine_symb sb ty ||
+     Bitv.is_mine_symb sb ty ||
+     Arrays.is_mine_symb sb ty ||
+     Enum.is_mine_symb sb ty)
 
 
   let is_a_leaf r = match r.v with
-    | Term _ | Ac _ -> true
+    | TERM _ | AC _ -> true
     | _ -> false
 
   let color ac =
@@ -347,22 +301,22 @@ struct
     | _ ->
       let ty = ac.Sig.t in
       match
-        ARITH.is_mine_symb ac.Sig.h ty,
-        RECORDS.is_mine_symb ac.Sig.h ty,
-        BITV.is_mine_symb ac.Sig.h ty,
-        ARRAYS.is_mine_symb ac.Sig.h ty,
-        ENUM.is_mine_symb ac.Sig.h ty,
-        ADT.is_mine_symb ac.Sig.h ty,
-        ITE.is_mine_symb ac.Sig.h ty,
-        AC.is_mine_symb ac.Sig.h ty with
+        Arith.is_mine_symb ac.Sig.h ty,
+        Records.is_mine_symb ac.Sig.h ty,
+        Bitv.is_mine_symb ac.Sig.h ty,
+        Arrays.is_mine_symb ac.Sig.h ty,
+        Enum.is_mine_symb ac.Sig.h ty,
+        Adt.is_mine_symb ac.Sig.h ty,
+        Ite.is_mine_symb ac.Sig.h ty,
+        Ac.is_mine_symb ac.Sig.h ty with
       (*AC.is_mine may say F if Options.get_no_ac is set to F dynamically *)
-      | true  , false , false , false, false, false, false, false -> ARITH.color ac
-      | false , true  , false , false, false, false, false, false -> RECORDS.color ac
-      | false , false , true  , false, false, false, false, false -> BITV.color ac
-      | false , false , false , true , false, false, false, false -> ARRAYS.color ac
-      | false , false , false , false, true , false, false, false -> ENUM.color ac
-      | false , false , false , false, false, true , false, false -> ADT.color ac
-      | false , false , false , false, false, false, true , false -> ITE.color ac
+      | true  , false , false , false, false, false, false, false -> Arith.color ac
+      | false , true  , false , false, false, false, false, false -> Records.color ac
+      | false , false , true  , false, false, false, false, false -> Bitv.color ac
+      | false , false , false , true , false, false, false, false -> Arrays.color ac
+      | false , false , false , false, true , false, false, false -> Enum.color ac
+      | false , false , false , false, false, true , false, false -> Adt.color ac
+      | false , false , false , false, false, false, true , false -> Ite.color ac
       | _  -> ac_embed ac
 
 
@@ -370,31 +324,31 @@ struct
   module Debug = struct
     open Printer
 
-    let print fmt r =
+    let print fmt (r : r) =
       let open Format in
       if Options.get_term_like_pp () then begin
         match r.v with
-        | ARITH t    -> fprintf fmt "%a" ARITH.print t
-        | RECORDS t    -> fprintf fmt "%a" RECORDS.print t
-        | BITV t    -> fprintf fmt "%a" BITV.print t
-        | ARRAYS t    -> fprintf fmt "%a" ARRAYS.print t
-        | ENUM t    -> fprintf fmt "%a" ENUM.print t
-        | ADT t    -> fprintf fmt "%a" ADT.print t
-        | ITE t    -> fprintf fmt "%a" ITE.print t
-        | Term t  -> fprintf fmt "%a" Expr.print t
-        | Ac t    -> fprintf fmt "%a" AC.print t
+        | ARITH t    -> fprintf fmt "%a" Arith.print t
+        | RECORDS t    -> fprintf fmt "%a" Records.print t
+        | BITV t    -> fprintf fmt "%a" Bitv.print t
+        | ARRAYS t    -> fprintf fmt "%a" Arrays.print t
+        | ENUM t    -> fprintf fmt "%a" Enum.print t
+        | ADT t    -> fprintf fmt "%a" Adt.print t
+        | ITE t    -> fprintf fmt "%a" Ite.print t
+        | TERM t  -> fprintf fmt "%a" Expr.print t
+        | AC t    -> fprintf fmt "%a" Ac.print t
       end
       else begin
         match r.v with
-        | ARITH t    -> fprintf fmt "ARITH(%s):[%a]" ARITH.name ARITH.print t
-        | RECORDS t    -> fprintf fmt "RECORDS(%s):[%a]" RECORDS.name RECORDS.print t
-        | BITV t    -> fprintf fmt "BITV(%s):[%a]" BITV.name BITV.print t
-        | ARRAYS t    -> fprintf fmt "ARRAYS(%s):[%a]" ARRAYS.name ARRAYS.print t
-        | ENUM t    -> fprintf fmt "ENUM(%s):[%a]" ENUM.name ENUM.print t
-        | ADT t    -> fprintf fmt "ADT(%s):[%a]" ADT.name ADT.print t
-        | ITE t    -> fprintf fmt "ITE(%s):[%a]" ITE.name ITE.print t
-        | Term t  -> fprintf fmt "FT:[%a]" Expr.print t
-        | Ac t    -> fprintf fmt "Ac:[%a]" AC.print t
+        | ARITH t    -> fprintf fmt "ARITH(%s):[%a]" Arith.name Arith.print t
+        | RECORDS t    -> fprintf fmt "RECORDS(%s):[%a]" Records.name Records.print t
+        | BITV t    -> fprintf fmt "BITV(%s):[%a]" Bitv.name Bitv.print t
+        | ARRAYS t    -> fprintf fmt "ARRAYS(%s):[%a]" Arrays.name Arrays.print t
+        | ENUM t    -> fprintf fmt "ENUM(%s):[%a]" Enum.name Enum.print t
+        | ADT t    -> fprintf fmt "ADT(%s):[%a]" Adt.name Adt.print t
+        | ITE t    -> fprintf fmt "ITE(%s):[%a]" Ite.name Ite.print t
+        | TERM t  -> fprintf fmt "FT:[%a]" Expr.print t
+        | AC t    -> fprintf fmt "Ac:[%a]" Ac.print t
       end
 
     let print_sbt msg sbs =
@@ -411,12 +365,12 @@ struct
           msg
           (pp_list_no_space print) sbs
 
-    let debug_abstraction_result oa ob a b acc =
+    let debug_abstraction_result oa ob (a : r) b acc =
       let c = ref 0 in
-      let print fmt (p,v) =
+      let print_pair fmt (p,v) =
         incr c;
         Format.fprintf fmt "(%d) %a |-> %a@ "
-          !c CX.print p CX.print v
+          !c print p print v
       in
       if Options.get_debug_combine () then
         print_dbg
@@ -426,20 +380,20 @@ struct
            abstracted equality: %a = %a@ \
            @[<v 2>selectors elimination result:@ \
            %a@]@]"
-          CX.print oa CX.print ob CX.print a CX.print b
-          (pp_list_no_space print) acc
+          print oa print ob print a print b
+          (pp_list_no_space print_pair) acc
 
     let solve_one a b =
       if Options.get_debug_combine () then
         print_dbg
           ~module_name:"Shostak" ~function_name:"solve_one"
-          "solve one %a = %a" CX.print a CX.print b
+          "solve one %a = %a" print a print b
 
     let debug_abstract_selectors a =
       if Options.get_debug_combine () then
         print_dbg
           ~module_name:"Shostak" ~function_name:"abstract_selectors"
-          "abstract selectors of %a" CX.print a
+          "abstract selectors of %a" print a
 
     let assert_have_mem_types tya tyb =
       assert (
@@ -458,20 +412,20 @@ struct
   let abstract_selectors a acc =
     Debug.debug_abstract_selectors a;
     match a.v with
-    | ARITH a   -> ARITH.abstract_selectors a acc
-    | RECORDS a   -> RECORDS.abstract_selectors a acc
-    | BITV a   -> BITV.abstract_selectors a acc
-    | ARRAYS a   -> ARRAYS.abstract_selectors a acc
-    | ENUM a   -> ENUM.abstract_selectors a acc
-    | ADT a   -> ADT.abstract_selectors a acc
-    | ITE a   -> ITE.abstract_selectors a acc
-    | Term _ -> a, acc
-    | Ac a   -> AC.abstract_selectors a acc
+    | ARITH a   -> Arith.abstract_selectors a acc
+    | RECORDS a   -> Records.abstract_selectors a acc
+    | BITV a   -> Bitv.abstract_selectors a acc
+    | ARRAYS a   -> Arrays.abstract_selectors a acc
+    | ENUM a   -> Enum.abstract_selectors a acc
+    | ADT a   -> Adt.abstract_selectors a acc
+    | ITE a   -> Ite.abstract_selectors a acc
+    | TERM _ -> a, acc
+    | AC a   -> Ac.abstract_selectors a acc
 
   let abstract_equality a b =
     let aux r acc =
       match r.v with
-      | Ac ({ l = args; _ } as ac) ->
+      | AC ({ l = args; _ } as ac) ->
         let args, acc =
           List.fold_left
             (fun (args, acc) (r, i) ->
@@ -479,7 +433,7 @@ struct
                (r, i) :: args, acc
             )([],acc) args
         in
-        ac_embed {ac with l = AC.compact args}, acc
+        ac_embed {ac with l = Ac.compact args}, acc
       | _     -> abstract_selectors r acc
     in
     let a', acc = aux a [] in
@@ -495,14 +449,14 @@ struct
     Debug.print_sbt "Non triangular" sbs;
     let sbs = triangular_down sbs in
     let sbs = triangular_down (List.rev sbs) in (* triangular up *)
-    let original = List.fold_right SX.add (CX.leaves a) SX.empty in
-    let original = List.fold_right SX.add (CX.leaves b) original in
+    let original = List.fold_right SX.add (leaves a) SX.empty in
+    let original = List.fold_right SX.add (leaves b) original in
     let sbs =
       List.filter (fun (p,_) ->
           match p.v with
-          | Ac _ -> true | Term _ -> SX.mem p original
+          | AC _ -> true | TERM _ -> SX.mem p original
           | _ ->
-            Printer.print_err "%a" CX.print p;
+            Printer.print_err "%a" print p;
             assert false
         )sbs
     in
@@ -515,13 +469,13 @@ struct
     sbs
 
   let apply_subst_right r sbt =
-    List.fold_right (fun (p,v)r  -> CX.subst p v r) sbt r
+    List.fold_right (fun (p,v)r  -> subst p v r) sbt r
 
   let solve_uninterpreted r1 r2 (pb : r Sig.solve_pb) = (* r1 != r2*)
     if Options.get_debug_combine () then
       Printer.print_dbg
         "solve uninterpreted %a = %a" print r1 print r2;
-    if CX.str_cmp r1 r2 > 0 then { pb with sbt = (r1,r2)::pb.sbt }
+    if str_cmp r1 r2 > 0 then { pb with sbt = (r1,r2)::pb.sbt }
     else { pb with sbt = (r2,r1)::pb.sbt }
 
   let rec solve_list (pb : r Sig.solve_pb) =
@@ -534,18 +488,18 @@ struct
       Debug.solve_one a b;
       let ra = apply_subst_right a pb.sbt in
       let rb = apply_subst_right b pb.sbt in
-      if CX.equal ra rb then solve_list pb
+      if equal ra rb then solve_list pb
       else
-        let tya = CX.type_info ra in
-        let tyb = CX.type_info rb in
+        let tya = type_info ra in
+        let tyb = type_info rb in
         Debug.assert_have_mem_types tya tyb;
         let pb = match tya with
-          | Ty.Tint | Ty.Treal -> ARITH.solve ra rb pb
-          | Ty.Trecord _       -> RECORDS.solve ra rb pb
-          | Ty.Tbitv _         -> BITV.solve ra rb pb
-          | Ty.Tsum _          -> ENUM.solve ra rb pb
+          | Ty.Tint | Ty.Treal -> Arith.solve ra rb pb
+          | Ty.Trecord _       -> Records.solve ra rb pb
+          | Ty.Tbitv _         -> Bitv.solve ra rb pb
+          | Ty.Tsum _          -> Enum.solve ra rb pb
           (*| Ty.Tunit           -> pb *)
-          | Ty.Tadt _ when not (Options.get_disable_adts()) -> ADT.solve ra rb pb
+          | Ty.Tadt _ when not (Options.get_disable_adts()) -> Adt.solve ra rb pb
           | _                  -> solve_uninterpreted ra rb pb
         in
         solve_list pb
@@ -579,15 +533,15 @@ struct
   let assign_value r distincts eq =
     let opt = match r.v, type_info r with
       | _, Ty.Tint
-      | _, Ty.Treal     -> ARITH.assign_value r distincts eq
-      | _, Ty.Trecord _ -> RECORDS.assign_value r distincts eq
-      | _, Ty.Tbitv _   -> BITV.assign_value r distincts eq
-      | _, Ty.Tfarray _ -> ARRAYS.assign_value r distincts eq
-      | _, Ty.Tsum _    -> ENUM.assign_value r distincts eq
+      | _, Ty.Treal     -> Arith.assign_value r distincts eq
+      | _, Ty.Trecord _ -> Records.assign_value r distincts eq
+      | _, Ty.Tbitv _   -> Bitv.assign_value r distincts eq
+      | _, Ty.Tfarray _ -> Arrays.assign_value r distincts eq
+      | _, Ty.Tsum _    -> Enum.assign_value r distincts eq
       | _, Ty.Tadt _    when not (Options.get_disable_adts()) ->
-        ADT.assign_value r distincts eq
+        Adt.assign_value r distincts eq
 
-      | Term _t, Ty.Tbool ->
+      | TERM _t, Ty.Tbool ->
         if is_bool_const r then None
         else
           begin
@@ -597,7 +551,7 @@ struct
             | [] ->
               let dist = List.filter (fun r -> is_bool_const r) distincts in
               match dist with
-              | {v = Term e; _}::_ ->
+              | {v = TERM e; _}::_ ->
                 Some (Expr.neg e, true) (* safety: consider it as case-split *)
               | _::_ ->
                 assert false
@@ -605,7 +559,7 @@ struct
                 Some (Expr.faux, true) (* true <-> make a case split *)
           end
 
-      | Term t, ty      -> (* case disable_adts() handled here *)
+      | TERM t, ty      -> (* case disable_adts() handled here *)
         if Expr.const_term t ||
            List.exists (fun (t,_) -> Expr.const_term t) eq then None
         else Some (Expr.fresh_name ty, false) (* false <-> not a case-split *)
@@ -625,13 +579,13 @@ struct
     let r, pprint =
       match Expr.type_info t with
       | Ty.Tint
-      | Ty.Treal     -> ARITH.choose_adequate_model t rep l
-      | Ty.Tbitv _   -> BITV.choose_adequate_model t rep l
-      | Ty.Tsum _    -> ENUM.choose_adequate_model t rep l
+      | Ty.Treal     -> Arith.choose_adequate_model t rep l
+      | Ty.Tbitv _   -> Bitv.choose_adequate_model t rep l
+      | Ty.Tsum _    -> Enum.choose_adequate_model t rep l
       | Ty.Tadt _    when not (Options.get_disable_adts()) ->
-        ADT.choose_adequate_model t rep l
-      | Ty.Trecord _ -> RECORDS.choose_adequate_model t rep l
-      | Ty.Tfarray _ -> ARRAYS.choose_adequate_model t rep l
+        Adt.choose_adequate_model t rep l
+      | Ty.Trecord _ -> Records.choose_adequate_model t rep l
+      | Ty.Tfarray _ -> Arrays.choose_adequate_model t rep l
       | Ty.Tbool ->
         (* case split is now supposed to be done for internal bools if
            needed as well *)
@@ -680,87 +634,36 @@ struct
         print r Expr.print t;
     r, pprint
 
+  let init () =
+    let open Shostak_pre.REFS in
+    leaves_ref := leaves ;
+    equal_ref := equal ;
+    term_extract_ref := term_extract ;
+    save_cache_ref := save_cache ;
+    reinit_cache_ref := reinit_cache ;
+    make_ref := make ;
+    type_info_ref := type_info ;
+    str_cmp_ref := str_cmp ;
+    hash_cmp_ref := hash_cmp ;
+    hash_ref := hash ;
+    subst_ref := subst ;
+    solve_ref := solve ;
+    term_embed_ref := term_embed ;
+    ac_embed_ref := ac_embed ;
+    ac_extract_ref := ac_extract ;
+    color_ref := color ;
+    fully_interpreted_ref := fully_interpreted ;
+    is_a_leaf_ref := is_a_leaf ;
+    print_ref := print ;
+    abstract_selectors_ref := abstract_selectors ;
+    top_ref := top ;
+    bot_ref := bot ;
+    is_solvable_theory_symbol_ref := is_solvable_theory_symbol ;
+    assign_value_ref := assign_value ;
+    choose_adequate_model_ref := choose_adequate_model ;
+    ()
+
 end
-
-and TARITH : Polynome.T
-  with type r = CX.r =
-  Arith.Type(CX)
-
-and ARITH : Sig.SHOSTAK
-  with type t = TARITH.t
-   and type r = CX.r =
-  Arith.Shostak
-    (CX)
-    (struct
-      include TARITH
-      let extract = CX.extract1
-      let embed =  CX.embed1
-    end)
-
-and RECORDS : Sig.SHOSTAK
-  with type r = CX.r
-   and type t = CX.r Records.abstract =
-  Records.Shostak
-    (struct
-      include CX
-      let extract = extract2
-      let embed = embed2
-    end)
-
-and BITV : Sig.SHOSTAK
-  with type r = CX.r
-   and type t = CX.r Bitv.abstract =
-  Bitv.Shostak
-    (struct
-      include CX
-      let extract = extract3
-      let embed = embed3
-    end)
-
-and ARRAYS : Sig.SHOSTAK
-  with type r = CX.r
-   and type t = CX.r Arrays.abstract =
-  Arrays.Shostak
-    (struct
-      include CX
-      let extract = extract4
-      let embed = embed4
-    end)
-
-and ENUM : Sig.SHOSTAK
-  with type r = CX.r
-   and type t = CX.r Enum.abstract =
-  Enum.Shostak
-    (struct
-      include CX
-      let extract = extract5
-      let embed = embed5
-    end)
-
-and ADT : Sig.SHOSTAK
-  with type r = CX.r
-   and type t = CX.r Adt.abstract =
-  Adt.Shostak
-    (struct
-      include CX
-      let extract = extract6
-      let embed = embed6
-    end)
-
-and ITE : Sig.SHOSTAK
-  with type r = CX.r
-   and type t = CX.r Ite.abstract =
-  Ite.Shostak
-    (struct
-      include CX
-      let extract = extract7
-      let embed = embed7
-    end)
-
-(* Its signature is not Sig.SHOSTAK because it does not provide a solver *)
-and AC : Ac.S
-  with type r = CX.r =
-  Ac.Make(CX)
 
 module Combine = struct
   include CX
@@ -786,28 +689,31 @@ module Combine = struct
 
 end
 
-module Arith = ARITH
-module Records = RECORDS
-module Bitv = BITV
-module Arrays = ARRAYS
-module Enum = ENUM
-module Adt = ADT
-module Ite = ITE
-module Polynome = TARITH
-module Ac = AC
+module Arith = Arith
+module Records = Records
+module Bitv = Bitv
+module Arrays = Arrays
+module Enum = Enum
+module Adt = Adt
+module Ite = Ite
+module Polynome = Polynome
+module Ac = Ac
 
 (** map of semantic values using Combine.hash_cmp *)
 module MXH =
-  Map.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)
+  Map.Make(struct type t = Types.r let compare = Combine.hash_cmp end)
 
 (** set of semantic values using Combine.hash_cmp *)
 module SXH =
-  Set.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)
+  Set.Make(struct type t = Types.r let compare = Combine.hash_cmp end)
 
 (** map of semantic values using structural compare Combine.str_cmp *)
 module MXS =
-  Map.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)
+  Map.Make(struct type t = Types.r let compare = Combine.hash_cmp end)
 
 (** set of semantic values using structural compare Combine.str_cmp *)
 module SXS =
-  Set.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)
+  Set.Make(struct type t = Types.r let compare = Combine.hash_cmp end)
+
+let init () =
+  CX.init ()

--- a/src/lib/reasoners/shostak.mli
+++ b/src/lib/reasoners/shostak.mli
@@ -26,42 +26,37 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 module Combine : Sig.X
 
-module Polynome : Polynome.T
-  with type r = Combine.r
+module Polynome : (module type of Polynome)
+module Arith : Sig.SHOSTAK with type t = polynome
 
-module Arith : Sig.SHOSTAK
-  with type r = Combine.r and type t = Polynome.t
+module Records : Sig.SHOSTAK with type t = Types.records
 
-module Records : Sig.SHOSTAK
-  with type r = Combine.r and type t = Combine.r Records.abstract
+module Bitv : Sig.SHOSTAK with type t = Types.bitv
 
-module Bitv : Sig.SHOSTAK
-  with type r = Combine.r and type t = Combine.r Bitv.abstract
+module Arrays : Sig.SHOSTAK with type t = Types.arrays
 
-module Arrays : Sig.SHOSTAK
-  with type r = Combine.r and type t = Combine.r Arrays.abstract
+module Enum : Sig.SHOSTAK with type t = Types.enum
 
-module Enum : Sig.SHOSTAK
-  with type r = Combine.r and type t = Combine.r Enum.abstract
+module Adt : Sig.SHOSTAK with type t = Types.adt
 
-module Adt : Sig.SHOSTAK
-  with type r = Combine.r and type t = Combine.r Adt.abstract
+module Ite : Sig.SHOSTAK with type t = Types.ite
 
-module Ite : Sig.SHOSTAK
-  with type r = Combine.r and type t = Combine.r Ite.abstract
-
-module Ac : Ac.S with type r = Combine.r and type t = Combine.r Sig.ac
+module Ac : (module type of Ac)
 
 (** map of semantic values using Combine.hash_cmp *)
-module MXH : Map.S with type key = Combine.r
+module MXH : Map.S with type key = Types.r
 
 (** set of semantic values using Combine.hash_cmp *)
-module SXH : Set.S with type elt = Combine.r
+module SXH : Set.S with type elt = Types.r
 
 (** map of semantic values using structural compare Combine.str_cmp *)
-module MXS : Map.S with type key = Combine.r
+module MXS : Map.S with type key = Types.r
 
 (** set of semantic values using structural compare Combine.str_cmp *)
-module SXS : Set.S with type elt = Combine.r
+module SXS : Set.S with type elt = Types.r
+
+val init : unit -> unit

--- a/src/lib/reasoners/shostak_pre.ml
+++ b/src/lib/reasoners/shostak_pre.ml
@@ -1,0 +1,93 @@
+(******************************************************************************)
+(*                                                                            *)
+(*  Alt-Ergo: The SMT Solver For Software Verification                        *)
+(*  Copyright (C) 2013-2023 --- OCamlPro SAS                                  *)
+(*                                                                            *)
+(*  This file is distributed under the terms of the OCamlPro Non-Commercial   *)
+(*  License version 2.0                                                       *)
+(*                                                                            *)
+(*  AS AN EXCEPTION, Gold members of the Alt-Ergo's Club can distribute this  *)
+(*  file under the terms of the Apache Software License version 2             *)
+(*                                                                            *)
+(*  ------------------------------------------------------------------------  *)
+(*                                                                            *)
+(*     The Alt-Ergo theorem prover                                            *)
+(*     Copyright (C) 2006-2013                                                *)
+(*                                                                            *)
+(*     Sylvain Conchon                                                        *)
+(*     Evelyne Contejean                                                      *)
+(*                                                                            *)
+(*     Francois Bobot                                                         *)
+(*     Mohamed Iguernelala                                                    *)
+(*     Stephane Lescuyer                                                      *)
+(*     Alain Mebsout                                                          *)
+(*                                                                            *)
+(*     CNRS - INRIA - Universite Paris Sud                                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+module REFS = struct
+
+  let leaves_ref = ref (fun _ -> assert false)
+  let equal_ref = ref (fun _ -> assert false)
+  let term_extract_ref = ref (fun _ -> assert false)
+  let save_cache_ref = ref (fun _ -> assert false)
+  let reinit_cache_ref = ref (fun _ -> assert false)
+  let make_ref = ref (fun _ -> assert false)
+  let type_info_ref = ref (fun _ -> assert false)
+  let str_cmp_ref = ref (fun _ -> assert false)
+  let hash_cmp_ref = ref (fun _ -> assert false)
+  let hash_ref = ref (fun _ -> assert false)
+  let subst_ref = ref (fun _ -> assert false)
+  let solve_ref = ref (fun _ -> assert false)
+  let term_embed_ref = ref (fun _ -> assert false)
+  let ac_embed_ref = ref (fun _ -> assert false)
+  let ac_extract_ref = ref (fun _ -> assert false)
+  let color_ref = ref (fun _ -> assert false)
+  let fully_interpreted_ref = ref (fun _ -> assert false)
+  let is_a_leaf_ref = ref (fun _ -> assert false)
+  let print_ref = ref (fun _ -> assert false)
+  let abstract_selectors_ref = ref (fun _ -> assert false)
+  let top_ref = ref (fun _ -> assert false)
+  let bot_ref = ref (fun _ -> assert false)
+  let is_solvable_theory_symbol_ref = ref (fun _ -> assert false)
+  let assign_value_ref = ref (fun _ -> assert false)
+  let choose_adequate_model_ref = ref (fun _ -> assert false)
+
+  let hcons_ref = ref (fun _ -> assert false)
+
+end
+
+open REFS
+
+module FUNS : Sig.X = struct
+  let leaves x = !leaves_ref x
+  let equal x y = !equal_ref x y
+  let term_extract x = !term_extract_ref x
+  let save_cache x = !save_cache_ref x
+  let reinit_cache x = !reinit_cache_ref x
+  let make x = !make_ref x
+  let type_info x = !type_info_ref x
+  let str_cmp x y = !str_cmp_ref x y
+  let hash_cmp x y = !hash_cmp_ref x y
+  let hash x = !hash_ref x
+  let subst x y z = !subst_ref x y z
+  let solve x y = !solve_ref x y
+  let term_embed x = !term_embed_ref x
+  let ac_embed x = !ac_embed_ref x
+  let ac_extract x = !ac_extract_ref x
+  let color x = !color_ref x
+  let fully_interpreted x y = !fully_interpreted_ref x y
+  let is_a_leaf x = !is_a_leaf_ref x
+  let print x y = !print_ref x y
+  let abstract_selectors x y = !abstract_selectors_ref x y
+  let top x = !top_ref x
+  let bot x = !bot_ref x
+  let is_solvable_theory_symbol x = !is_solvable_theory_symbol_ref x
+  let assign_value x y z = !assign_value_ref x y z
+  let choose_adequate_model x y z = !choose_adequate_model_ref x y z
+end
+
+include FUNS
+
+let hcons v = !hcons_ref v

--- a/src/lib/reasoners/shostak_pre.mli
+++ b/src/lib/reasoners/shostak_pre.mli
@@ -1,0 +1,73 @@
+(******************************************************************************)
+(*                                                                            *)
+(*  Alt-Ergo: The SMT Solver For Software Verification                        *)
+(*  Copyright (C) 2013-2023 --- OCamlPro SAS                                  *)
+(*                                                                            *)
+(*  This file is distributed under the terms of the OCamlPro Non-Commercial   *)
+(*  License version 2.0                                                       *)
+(*                                                                            *)
+(*  AS AN EXCEPTION, Gold members of the Alt-Ergo's Club can distribute this  *)
+(*  file under the terms of the Apache Software License version 2             *)
+(*                                                                            *)
+(*  ------------------------------------------------------------------------  *)
+(*                                                                            *)
+(*     The Alt-Ergo theorem prover                                            *)
+(*     Copyright (C) 2006-2013                                                *)
+(*                                                                            *)
+(*     Sylvain Conchon                                                        *)
+(*     Evelyne Contejean                                                      *)
+(*                                                                            *)
+(*     Francois Bobot                                                         *)
+(*     Mohamed Iguernelala                                                    *)
+(*     Stephane Lescuyer                                                      *)
+(*     Alain Mebsout                                                          *)
+(*                                                                            *)
+(*     CNRS - INRIA - Universite Paris Sud                                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+include Sig.X
+
+val hcons : Types.r -> Types.r
+
+
+module REFS : sig
+
+  val leaves_ref : ( Types.r -> Types.r list ) ref
+  val equal_ref : ( Types.r -> Types.r -> bool ) ref
+  val term_extract_ref : ( Types.r -> Types.expr option * bool ) ref
+  val save_cache_ref : ( unit -> unit ) ref
+  val reinit_cache_ref : ( unit -> unit ) ref
+  val make_ref : ( Types.expr -> Types.r * Types.expr list ) ref
+  val type_info_ref : ( Types.r -> Ty.t ) ref
+  val str_cmp_ref : ( Types.r -> Types.r -> int ) ref
+  val hash_cmp_ref : ( Types.r -> Types.r -> int ) ref
+  val hash_ref : ( Types.r -> int ) ref
+  val subst_ref : ( Types.r -> Types.r -> Types.r -> Types.r ) ref
+  val solve_ref : ( Types.r -> Types.r -> (Types.r * Types.r) list ) ref
+  val term_embed_ref : ( Types.expr -> Types.r ) ref
+  val ac_embed_ref : ( Types.r Types.ac -> Types.r ) ref
+  val ac_extract_ref : ( Types.r -> Types.r Types.ac option ) ref
+  val color_ref : ( Types.r Types.ac -> Types.r ) ref
+  val fully_interpreted_ref : ( Types.symbol -> Ty.t -> bool ) ref
+  val is_a_leaf_ref : ( Types.r -> bool ) ref
+  val print_ref : ( Format.formatter -> Types.r -> unit ) ref
+  val abstract_selectors_ref :
+    ( Types.r ->
+      (Types.r * Types.r) list -> Types.r * (Types.r * Types.r) list) ref
+  val top_ref : ( unit -> Types.r ) ref
+  val bot_ref : ( unit -> Types.r ) ref
+  val is_solvable_theory_symbol_ref : ( Types.symbol -> Ty.t -> bool ) ref
+  val assign_value_ref :
+    ( Types.r ->
+      Types.r list ->
+      (Types.expr * Types.r) list -> (Types.expr * bool) option
+    ) ref
+  val choose_adequate_model_ref :
+    ( Types.expr ->
+      Types.r -> (Types.expr * Types.r) list -> Types.r * string
+    ) ref
+
+  val hcons_ref : ( Types.r -> Types.r ) ref
+
+end

--- a/src/lib/reasoners/sig.mli
+++ b/src/lib/reasoners/sig.mli
@@ -26,8 +26,10 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type 'a ac =
-  {h: Symbols.t ; t: Ty.t ; l: ('a * int) list; distribute: bool}
+open Types
+
+type 'a ac = 'a Types.ac =
+  {h: symbol ; t: Ty.t ; l: ('a * int) list; distribute: bool}
 
 type 'a solve_pb = { sbt : ('a * 'a) list; eqs : ('a * 'a) list }
 
@@ -35,9 +37,6 @@ module type SHOSTAK = sig
 
   (**Type of terms of the theory*)
   type t
-
-  (**Type of representants of terms of the theory*)
-  type r
 
   (** Name of the theory*)
   val name : string
@@ -92,8 +91,6 @@ module type SHOSTAK = sig
 end
 
 module type X = sig
-  type r
-
   val save_cache : unit -> unit
   (** saves the module's current cache *)
 

--- a/src/lib/reasoners/sig_rel.mli
+++ b/src/lib/reasoners/sig_rel.mli
@@ -28,7 +28,7 @@
 
 type 'a literal = LTerm of Expr.t | LSem of 'a Xliteral.view
 
-type instances = (Expr.t list * Expr.gformula * Explanation.t) list
+type instances = (Expr.t list * Types.gformula * Explanation.t) list
 
 type 'a input =
   'a Xliteral.view * Expr.t option * Explanation.t * Th_util.lit_origin
@@ -53,17 +53,17 @@ module type RELATION = sig
   val empty : Expr.Set.t list -> t
 
   val assume : t ->
-    Uf.t -> (Shostak.Combine.r input) list -> t * Shostak.Combine.r result
-  val query  : t -> Uf.t -> Shostak.Combine.r input -> Th_util.answer
+    Uf.t -> (Types.r input) list -> t * Types.r result
+  val query  : t -> Uf.t -> Types.r input -> Th_util.answer
 
   val case_split :
     t -> Uf.t ->
     for_model:bool ->
-    (Shostak.Combine.r Xliteral.view * bool * Th_util.lit_origin) list
+    (Types.r Xliteral.view * bool * Th_util.lit_origin) list
   (** case_split env returns a list of equalities *)
 
-  val add : t -> Uf.t -> Shostak.Combine.r -> Expr.t ->
-    t * (Shostak.Combine.r Xliteral.view * Explanation.t) list
+  val add : t -> Uf.t -> Types.r -> Expr.t ->
+    t * (Types.r Xliteral.view * Explanation.t) list
   (** add a representant to take into account *)
 
   val instantiate :
@@ -74,6 +74,6 @@ module type RELATION = sig
 
   val new_terms : t -> Expr.Set.t
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Types.th_elt -> Explanation.t -> t
 
 end

--- a/src/lib/reasoners/theory.mli
+++ b/src/lib/reasoners/theory.mli
@@ -49,7 +49,7 @@ module type S = sig
 
   val compute_concrete_model : t -> t
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Types.th_elt -> Explanation.t -> t
   val theories_instances :
     do_syntactic_matching:bool ->
     Matching_types.info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t ->

--- a/src/lib/reasoners/types.ml
+++ b/src/lib/reasoners/types.ml
@@ -1,0 +1,396 @@
+(******************************************************************************)
+(*                                                                            *)
+(*  Alt-Ergo: The SMT Solver For Software Verification                        *)
+(*  Copyright (C) 2013-2023 --- OCamlPro SAS                                  *)
+(*                                                                            *)
+(*  This file is distributed under the terms of the OCamlPro Non-Commercial   *)
+(*  License version 2.0                                                       *)
+(*                                                                            *)
+(*  AS AN EXCEPTION, Gold members of the Alt-Ergo's Club can distribute this  *)
+(*  file under the terms of the Apache Software License version 2             *)
+(*                                                                            *)
+(*  ------------------------------------------------------------------------  *)
+(*                                                                            *)
+(*     The Alt-Ergo theorem prover                                            *)
+(*     Copyright (C) 2006-2013                                                *)
+(*                                                                            *)
+(*     Sylvain Conchon                                                        *)
+(*     Evelyne Contejean                                                      *)
+(*                                                                            *)
+(*     Francois Bobot                                                         *)
+(*     Mohamed Iguernelala                                                    *)
+(*     Stephane Lescuyer                                                      *)
+(*     Alain Mebsout                                                          *)
+(*                                                                            *)
+(*     CNRS - INRIA - Universite Paris Sud                                    *)
+(*                                                                            *)
+(******************************************************************************)
+
+
+(* Symbols *)
+
+
+type builtin =
+    LE | LT (* arithmetic *)
+  | IsConstr of Hstring.t (* ADT tester *)
+
+type operator =
+    Plus | Minus | Mult | Div | Modulo
+  | Concat | Extract | Get | Set | Fixed | Float
+  | Reach | Access of Hstring.t | Record
+  | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
+  | Sqrt_real_default | Sqrt_real_excess
+  | Min_real | Min_int | Max_real | Max_int | Integer_log2
+  | Pow | Integer_round
+  | Constr of Hstring.t (* enums, adts *)
+  | Destruct of Hstring.t * bool
+  | Tite
+
+type lit =
+  (* literals *)
+  | L_eq
+  | L_built of builtin
+  | L_neg_eq
+  | L_neg_built of builtin
+  | L_neg_pred
+
+type form =
+  (* formulas *)
+  | F_Unit of bool
+  | F_Clause of bool
+  | F_Iff
+  | F_Xor
+  | F_Lemma
+  | F_Skolem
+
+type name_kind = Ac | Other
+
+type bound_kind =
+    VarBnd of Var.t
+  | ValBnd of Numbers.Q.t
+
+type bound = (* private *)
+  { bkind : bound_kind; (* was kind *)
+    sort : Ty.t; is_open : bool; is_lower : bool }
+
+type symbol =
+  | True
+  | False
+  | Void
+  | Name of Hstring.t * name_kind
+  | Int of Hstring.t
+  | Real of Hstring.t
+  | Bitv of string
+  | Op of operator
+  | Lit of lit
+  | Form of form
+  | Var of Var.t
+  | In of bound * bound
+  | MapsTo of Var.t (* beware: semantic_trigger.MapsTo renamed to SemMapsTo *)
+  | Let
+
+module SYMBOL = struct
+
+  let compare_kinds k1 k2 =
+    Util.compare_algebraic k1 k2
+      (function
+        | _, (Ac | Other) -> assert false
+      )
+
+  let compare_operators op1 op2 =
+    Util.compare_algebraic op1 op2
+      (function
+        | Access h1, Access h2 | Constr h1, Constr h2 -> Hstring.compare h1 h2
+        | Destruct (h1, b1), Destruct(h2, b2) ->
+          let c = Stdlib.compare b1 b2 in
+          if c <> 0 then c else Hstring.compare h1 h2
+        | _ , (Plus | Minus | Mult | Div | Modulo
+              | Concat | Extract | Get | Set | Fixed | Float | Reach
+              | Access _ | Record | Sqrt_real | Abs_int | Abs_real
+              | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
+              | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
+              | Integer_log2 | Pow | Integer_round
+              | Constr _ | Destruct _ | Tite) -> assert false
+      )
+
+  let compare_builtin b1 b2 =
+    Util.compare_algebraic b1 b2
+      (function
+        | IsConstr h1, IsConstr h2 -> Hstring.compare h1 h2
+        | _, (LT | LE | IsConstr _) -> assert false
+      )
+
+  let compare_lits lit1 lit2 =
+    Util.compare_algebraic lit1 lit2
+      (function
+        | L_built b1, L_built b2 -> compare_builtin b1 b2
+        | L_neg_built b1, L_neg_built b2 -> compare_builtin b1 b2
+        | _, (L_eq | L_built _ | L_neg_eq | L_neg_built _ | L_neg_pred) ->
+          assert false
+      )
+
+  let compare_forms f1 f2 =
+    Util.compare_algebraic f1 f2
+      (function
+        | F_Unit b1, F_Unit b2
+        | F_Clause b1, F_Clause b2 -> Stdlib.compare b1 b2
+        | _, (F_Unit _ | F_Clause _ | F_Lemma | F_Skolem
+             | F_Iff | F_Xor) ->
+          assert false
+      )
+
+  let compare_bounds_kind a b =
+    Util.compare_algebraic a b
+      (function
+        | VarBnd h1, VarBnd h2 -> Var.compare h1 h2
+        | ValBnd q1, ValBnd q2 -> Numbers.Q.compare q1 q2
+        | _, (VarBnd _ | ValBnd _) -> assert false
+      )
+
+  let compare_bounds a b =
+    let c = Ty.compare a.sort b.sort in
+    if c <> 0 then c
+    else
+      let c = Stdlib.compare a.is_open b.is_open in
+      if c <> 0 then c
+      else
+        let c = Stdlib.compare a.is_lower b.is_lower in
+        if c <> 0 then c
+        else compare_bounds_kind a.bkind b.bkind
+
+  let compare s1 s2 =
+    Util.compare_algebraic s1 s2
+      (function
+        | Int h1, Int h2
+        | Real h1, Real h2 -> Hstring.compare h1 h2
+        | Var v1, Var v2 | MapsTo v1, MapsTo v2 -> Var.compare v1 v2
+        | Name (h1, k1), Name (h2, k2) ->
+          let c = Hstring.compare h1 h2 in
+          if c <> 0 then c else compare_kinds k1 k2
+        | Bitv s1, Bitv s2 -> String.compare s1 s2
+        | Op op1, Op op2 -> compare_operators op1 op2
+        | Lit lit1, Lit lit2 -> compare_lits lit1 lit2
+        | Form f1, Form f2 -> compare_forms f1 f2
+        | In (b1, b2), In (b1', b2') ->
+          let c = compare_bounds b1 b1' in
+          if c <> 0 then c else compare_bounds b2 b2'
+        | _ ,
+          (True | False | Void | Name _ | Int _ | Real _ | Bitv _
+          | Op _ | Lit _ | Form _ | Var _ | In _ | MapsTo _ | Let) ->
+          assert false
+      )
+
+  module Set : Set.S with type elt = symbol =
+    Set.Make (struct type t=symbol let compare=compare end)
+
+  module Map : sig
+    include Map.S with type key = symbol
+  end = struct
+    include Map.Make (struct type t = symbol let compare = compare end)
+  end
+
+end
+
+(** Data structures from Expr *)
+
+type binders = (Ty.t * int) SYMBOL.Map.t (*int tag in globally unique *)
+
+type expr = (* term_view *)
+  {
+    f: symbol;
+    xs: expr list;
+    ty: Ty.t;
+    bind : bind_kind;
+    tag: int;
+    vars : (Ty.t * int) SYMBOL.Map.t; (* vars to types and nb of occurences *)
+    vty : Ty.Svty.t;
+    depth: int;
+    nb_nodes : int;
+    pure : bool;
+    mutable neg : expr option
+  }
+
+and decl_kind =
+  | Dtheory
+  | Daxiom
+  | Dgoal
+  | Dpredicate of expr
+  | Dfunction of expr
+
+and bind_kind =
+  | B_none
+  | B_lemma of quantified
+  | B_skolem of quantified
+  | B_let of letin
+
+and quantified = {
+  name : string;
+  main : expr;
+  toplevel : bool;
+  user_trs : trigger list;
+  binders : binders;
+  (* These fields should be (ordered) lists ! important for skolemization *)
+  sko_v : expr list;
+  sko_vty : Ty.t list;
+  loc : Loc.t; (* location of the "GLOBAL" axiom containing this quantified
+                  formula. It forms with name a unique id *)
+  kind : decl_kind; (* beware: bound.kind was renamed to bkind *)
+}
+
+and letin = {
+  let_v: symbol;
+  let_e : expr;
+  in_e : expr;
+  let_sko : expr; (* fresh symb. with free vars *)
+  is_bool : bool;
+}
+
+and semantic_trigger =
+  | Interval of expr * bound * bound
+  | SemMapsTo of Var.t * expr (* was MapsTo *)
+  | NotTheoryConst of expr
+  | IsTheoryConst of expr
+  | LinearDependency of expr * expr
+
+and trigger = {
+  content : expr list;
+  (* this field is filled (with a part of 'content' field) by theories
+     when assume_th_elt is called *)
+  semantic : semantic_trigger list;
+  hyp : expr list;
+  t_depth : int;
+  from_user : bool;
+  guard : expr option
+}
+
+
+type subst = expr SYMBOL.Map.t * Ty.subst
+
+type lit_view =
+  | Eq of expr * expr
+  | Eql of expr list
+  | Distinct of expr list
+  | Builtin of bool * builtin * expr list
+  | Pred of expr * bool
+
+type form_view =
+  | Unit of expr * expr  (* unit clauses *)
+  | Clause of expr * expr * bool      (* a clause (t1 or t2) bool <-> is implication *)
+  | Iff of expr * expr
+  | Xor of expr * expr
+  | Literal of expr   (* an atom *)
+  | Lemma of quantified   (* a lemma *)
+  | Skolem of quantified  (* lazy skolemization *)
+  | Let of letin (* a binding of an expr *)
+
+
+type gformula = {
+  ff: expr;
+  nb_reductions : int;
+  trigger_depth : int;
+  age: int;
+  lem: expr option;
+  origin_name : string;
+  from_terms : expr list;
+  mf: bool;
+  gf: bool;
+  gdist : int; (* dist to goal *)
+  hdist : int; (* dist to hypotheses *)
+  theory_elim : bool;
+}
+
+type th_elt =
+  {
+    th_name : string;
+    ax_name : string;
+    ax_form : expr;
+    extends : Util.theories_extensions;
+    axiom_kind : Util.axiom_kind;
+  }
+
+
+
+
+
+type 'a ac =
+  {h: symbol ; t: Ty.t ; l: ('a * int) list; distribute: bool}
+
+
+(* bitv *)
+
+type sort_var = A | B | C
+
+type tvar = { var : int ; sorte : sort_var }
+
+
+(* Shostak *)
+
+type rview =
+  | TERM  of expr
+  | AC    of r ac
+  | ARITH    of polynome
+  | RECORDS    of records
+  | BITV    of bitv
+  | ARRAYS    of arrays
+  | ENUM    of enum
+  | ADT    of adt
+  | ITE    of ite
+
+and r = {v : rview ; id : int}
+
+and polynome = { m : (r, Numbers.Q.t) CMap.map;
+                 c : Numbers.Q.t;
+                 pty : Ty.t }
+
+and adt = (* was r Adt.abstract *)
+  | Constr of { c_name : Hstring.t ; c_ty : Ty.t ; c_args : (Hstring.t * r) list }
+  | Select of { d_name : Hstring.t ; d_ty : Ty.t ; d_arg : r }
+  | Tester of { t_name : Hstring.t ; t_arg : r } (* tester is currently not used *)
+  | Alien of r
+
+and records = (* was Records.abstract *)
+  | Record of (Hstring.t * records) list * Ty.t
+  | Access of Hstring.t * records * Ty.t
+  | ROther of r * Ty.t (* was Other *)
+
+(* bitv *)
+and xterm =
+  | BVVar of tvar (* was Var *)
+  | BVAlien of r (* was Alien *)
+
+and 'a alpha_term = {
+  bv : 'a;
+  sz : int;
+}
+
+and simple_term_aux =
+  | Cte of bool
+  | BVOther of xterm (* was Other *)
+  | Ext of xterm * int * int * int (*// id * size * i * j //*)
+
+and simple_term = simple_term_aux alpha_term
+
+and bitv =  simple_term list
+
+(* was Arrays.abstract *)
+and arrays = unit (* why ? *)
+
+(* was Enum.abstract *)
+and enum =
+    Cons of Hstring.t * Ty.t
+  | EAlien of r (* was Alien *)
+
+(* was Ite.abstract *)
+and ite = unit (* why ? *)
+
+
+
+(* for the solver *)
+
+type solver_simple_term_aux =
+  | S_Cte of bool
+  | S_Var of tvar
+
+type solver_simple_term = solver_simple_term_aux alpha_term
+
+type t

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -26,6 +26,8 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Types
+
 module X = Shostak.Combine
 
 module Ac = Shostak.Ac
@@ -37,7 +39,7 @@ module ME = Expr.Map
 module SE = Expr.Set
 
 module LX =
-  Xliteral.Make(struct type t = X.r let compare = X.hash_cmp include X end)
+  Xliteral.Make(struct type t = Types.r let compare = X.hash_cmp include X end)
 module MapL = Emap.Make(LX)
 
 module MapX = struct
@@ -47,7 +49,7 @@ end
 module SetX = Shostak.SXH
 
 module SetXX = Set.Make(struct
-    type t = X.r * X.r
+    type t = Types.r * Types.r
     let compare (r1, r1') (r2, r2') =
       let c = X.hash_cmp r1 r2 in
       if c <> 0 then c
@@ -58,7 +60,7 @@ module SetAc = Set.Make(struct type t = Ac.t let compare = Ac.compare end)
 
 module SetRL = Set.Make
     (struct
-      type t = Ac.t * X.r * Ex.t
+      type t = Ac.t * Types.r * Ex.t
       let compare (ac1,_,_) (ac2,_,_)= Ac.compare ac1 ac2
     end)
 
@@ -76,7 +78,7 @@ module RS = struct
 
 end
 
-type r = X.r
+type r = Types.r
 
 type t = {
 
@@ -1025,7 +1027,7 @@ let model_repr_of_term t env mrepr =
 let compute_concrete_model ({ make; _ } as env) =
   ME.fold
     (fun t _mk ((fprofs, cprofs, carrays, mrepr) as acc) ->
-       let { E.f; xs; ty; _ } = E.term_view t in
+       let { f; xs; ty; _ } = E.term_view t in
        if X.is_solvable_theory_symbol f ty
        || E.is_fresh t || E.is_fresh_skolem t
        || E.equal t E.vrai || E.equal t E.faux
@@ -1045,13 +1047,13 @@ let compute_concrete_model ({ make; _ } as env) =
          let rep, mrepr = model_repr_of_term t env mrepr in
          assert (is_a_good_model_value rep);
          match f, xs, ty with
-         | Sy.Op Sy.Set, _, _ -> acc
+         | Types.Op Types.Set, _, _ -> acc
 
-         | Sy.Op Sy.Get, [(_,(a,_));((_,(i,_)) as e)], _ ->
+         | Types.Op Types.Get, [(_,(a,_));((_,(i,_)) as e)], _ ->
            begin
              match X.term_extract a with
              | Some ta, true ->
-               let { E.f = f_ta; xs=xs_ta; _ } = E.term_view ta in
+               let { f = f_ta; xs=xs_ta; _ } = E.term_view ta in
                assert (xs_ta == []);
                fprofs,
                cprofs,
@@ -1083,4 +1085,3 @@ let save_cache () =
 
 let reinit_cache () =
   LX.reinit_cache ()
-

--- a/src/lib/reasoners/uf.mli
+++ b/src/lib/reasoners/uf.mli
@@ -30,7 +30,7 @@
 
 type t
 
-type r = Shostak.Combine.r
+type r = Types.r
 
 module LX : Xliteral.S with type elt = r
 

--- a/src/lib/reasoners/use.ml
+++ b/src/lib/reasoners/use.ml
@@ -41,7 +41,7 @@ module X = Shostak.Combine
 module MX = Shostak.MXH
 
 type t = (SE.t * SA.t) MX.t
-type r = X.r
+type r = Types.r
 
 let inter_tpl (x1,y1) (x2,y2) =
   Options.exec_thread_yield ();
@@ -63,7 +63,7 @@ let add_term k t mp =
 let up_add g t rt lvs =
   let g = if MX.mem rt g then g else MX.add rt (SE.empty, SA.empty) g in
   match E.term_view t with
-  | { E.xs = []; _ } -> g
+  | { xs = []; _ } -> g
   | _ -> List.fold_left (fun g x -> add_term x t g) g lvs
 
 let congr_add g lvs =

--- a/src/lib/reasoners/use.mli
+++ b/src/lib/reasoners/use.mli
@@ -29,7 +29,7 @@
 module SA : Set.S with type elt = Expr.t * Explanation.t
 
 type t
-type r = Shostak.Combine.r
+type r = Types.r
 
 val empty : t
 val find : r -> t -> Expr.Set.t * SA.t

--- a/src/lib/structures/commands.ml
+++ b/src/lib/structures/commands.ml
@@ -33,7 +33,7 @@ type sat_decl_aux =
   | PredDef of Expr.t * string (*name of the predicate*)
   | RwtDef of (Expr.t Typed.rwt_rule) list
   | Query of string *  Expr.t * Ty.goal_sort
-  | ThAssume of Expr.th_elt
+  | ThAssume of Types.th_elt
   | Push of int
   | Pop of int
 
@@ -62,4 +62,3 @@ let print_aux fmt = function
   | Pop n ->  Format.fprintf fmt "Pop %d" n
 
 let print fmt decl = print_aux fmt decl.st_decl
-

--- a/src/lib/structures/commands.mli
+++ b/src/lib/structures/commands.mli
@@ -36,7 +36,7 @@ type sat_decl_aux =
   | PredDef of Expr.t * string (*name of the predicate*)
   | RwtDef of (Expr.t rwt_rule) list
   | Query of string *  Expr.t * Ty.goal_sort
-  | ThAssume of Expr.th_elt
+  | ThAssume of Types.th_elt
   | Push of int
   | Pop of int
 

--- a/src/lib/structures/explanation.ml
+++ b/src/lib/structures/explanation.ml
@@ -155,25 +155,25 @@ let bj_formulas_of s =
     ) s E.Set.empty
 
 let rec literals_of_acc lit fs f acc = match E.form_view f with
-  | E.Literal _ ->
+  | Literal _ ->
     if lit then f :: acc else acc
-  | E.Iff(f1, f2) ->
+  | Iff(f1, f2) ->
     let g = E.elim_iff f1 f2 (E.id f) ~with_conj:true in
     literals_of_acc lit fs g acc
-  | E.Xor(f1, f2) ->
+  | Xor(f1, f2) ->
     let g = E.neg @@ E.elim_iff f1 f2 (E.id f) ~with_conj:false in
     literals_of_acc lit fs g acc
-  | E.Unit (f1,f2) ->
+  | Unit (f1,f2) ->
     let acc = literals_of_acc false fs f1 acc in
     literals_of_acc false fs f2 acc
-  | E.Clause (f1, f2, _) ->
+  | Clause (f1, f2, _) ->
     let acc = literals_of_acc true fs f1 acc in
     literals_of_acc true fs f2 acc
-  | E.Lemma _ ->
+  | Lemma _ ->
     acc
-  | E.Skolem { E.main = f; _ } ->
+  | Skolem { main = f; _ } ->
     literals_of_acc true fs f acc
-  | E.Let { E.in_e; let_e; _ } ->
+  | Let { in_e; let_e; _ } ->
     literals_of_acc true fs in_e @@ literals_of_acc true fs let_e acc
 
 let literals_of ex =

--- a/src/lib/structures/fpa_rounding.ml
+++ b/src/lib/structures/fpa_rounding.ml
@@ -19,7 +19,7 @@ module Z = Numbers.Z
 let is_rounding_mode t =
   Options.get_use_fpa() &&
   match E.term_view t with
-  | { E.ty = Ty.Tsum (hs, _); _ } ->
+  | { ty = Ty.Tsum (hs, _); _ } ->
     String.compare (Hs.view hs) "fpa_rounding_mode" = 0
   | _ -> false
 
@@ -214,7 +214,7 @@ let mode_of_term t =
 
 let int_of_term t =
   match E.term_view t with
-  | { E.f = Sy.Int n; _ } ->
+  | { f = Types.Int n; _ } ->
     let n = Hstring.view n in
     let n =
       try int_of_string n
@@ -268,40 +268,40 @@ let round_to_integer mode q =
                     having terms"]
 let make_adequate_app s l ty =
   match s with
-  | Sy.Name (hs, Sy.Other) when Options.get_use_fpa() ->
+  | Types.Name (hs, Types.Other) when Options.get_use_fpa() ->
     let s, l  =
       match Hstring.view hs, l with
-      | "float", [_;_;_;_] -> Sy.Op Sy.Float, l
-      | "float32", [_;_;] -> Sy.Op Sy.Float,(E.int "24")::(E.int "149")::l
+      | "float", [_;_;_;_] -> Types.Op Types.Float, l
+      | "float32", [_;_;] -> Types.Op Types.Float,(E.int "24")::(E.int "149")::l
       | "float32d", [_] ->
-        Sy.Op Sy.Float,
+        Types.Op Types.Float,
         (E.int "24")::
         (E.int "149")::
         _NearestTiesToEven__rounding_mode :: l
 
-      | "float64", [_;_;] -> Sy.Op Sy.Float,(E.int "53")::(E.int "1074")::l
+      | "float64", [_;_;] -> Types.Op Types.Float,(E.int "53")::(E.int "1074")::l
       | "float64d", [_] ->
-        Sy.Op Sy.Float,
+        Types.Op Types.Float,
         (E.int "53")::
         (E.int "1074")::
         _NearestTiesToEven__rounding_mode :: l
 
-      | "integer_round", [_;_] -> Sy.Op Sy.Integer_round, l
+      | "integer_round", [_;_] -> Types.Op Types.Integer_round, l
 
-      | "fixed", [_;_;_;_] -> Sy.Op Sy.Fixed, l
-      | "sqrt_real", [_] -> Sy.Op Sy.Sqrt_real, l
-      | "sqrt_real_default", [_] -> Sy.Op Sy.Sqrt_real_default, l
-      | "sqrt_real_excess", [_] -> Sy.Op Sy.Sqrt_real_excess, l
-      | "abs_int", [_] ->  Sy.Op Sy.Abs_int, l
-      | "abs_real", [_] ->  Sy.Op Sy.Abs_real, l
-      | "real_of_int", [_] -> Sy.Op Sy.Real_of_int, l
-      | "int_floor", [_] -> Sy.Op Sy.Int_floor, l
-      | "int_ceil", [_] -> Sy.Op Sy.Int_ceil, l
-      | "max_real", [_;_] -> Sy.Op Sy.Max_real, l
-      | "max_int", [_;_] -> Sy.Op Sy.Max_int, l
-      | "min_real", [_;_] -> Sy.Op Sy.Min_real, l
-      | "min_int", [_;_] -> Sy.Op Sy.Min_int, l
-      | "integer_log2", [_] -> Sy.Op Sy.Integer_log2, l
+      | "fixed", [_;_;_;_] -> Types.Op Types.Fixed, l
+      | "sqrt_real", [_] -> Types.Op Types.Sqrt_real, l
+      | "sqrt_real_default", [_] -> Types.Op Types.Sqrt_real_default, l
+      | "sqrt_real_excess", [_] -> Types.Op Types.Sqrt_real_excess, l
+      | "abs_int", [_] ->  Types.Op Types.Abs_int, l
+      | "abs_real", [_] ->  Types.Op Types.Abs_real, l
+      | "real_of_int", [_] -> Types.Op Types.Real_of_int, l
+      | "int_floor", [_] -> Types.Op Types.Int_floor, l
+      | "int_ceil", [_] -> Types.Op Types.Int_ceil, l
+      | "max_real", [_;_] -> Types.Op Types.Max_real, l
+      | "max_int", [_;_] -> Types.Op Types.Max_int, l
+      | "min_real", [_;_] -> Types.Op Types.Min_real, l
+      | "min_int", [_;_] -> Types.Op Types.Min_int, l
+      | "integer_log2", [_] -> Types.Op Types.Integer_log2, l
 
       (* should not happend thanks to well typedness *)
       | ("float"

--- a/src/lib/structures/modelMap.ml
+++ b/src/lib/structures/modelMap.ml
@@ -43,7 +43,7 @@ module P = Map.Make
 
 module V = Set.Make
     (struct
-      type t = (E.t * (X.r * string)) list * (X.r * string)
+      type t = (E.t * (Types.r * string)) list * (Types.r * string)
       let compare (l1, (v1,_)) (l2, (v2,_)) =
         let c = X.hash_cmp v1 v2 in
         if c <> 0 then c

--- a/src/lib/structures/modelMap.mli
+++ b/src/lib/structures/modelMap.mli
@@ -18,8 +18,8 @@ module P : Map.S with type key =
                         Symbols.t * Ty.t list * Ty.t
 
 module V : Set.S with type elt =
-                        (Expr.t * (Shostak.Combine.r * string)) list *
-                        (Shostak.Combine.r * string)
+                        (Expr.t * (Types.r * string)) list *
+                        (Types.r * string)
 
 type key = P.key
 type elt = V.t

--- a/src/lib/structures/parsed.ml
+++ b/src/lib/structures/parsed.ml
@@ -261,7 +261,7 @@ type decl =
   | Rewriting of Loc.t * string * lexpr list
   | Goal of Loc.t * string * lexpr
   | Check_sat of Loc.t * string * lexpr
-  | Logic of Loc.t * Symbols.name_kind * (string * string) list * plogic_type
+  | Logic of Loc.t * Types.name_kind * (string * string) list * plogic_type
   | Predicate_def of
       Loc.t * (string * string) *
       (Loc.t * string * ppure_type) list * lexpr

--- a/src/lib/structures/parsed.mli
+++ b/src/lib/structures/parsed.mli
@@ -122,7 +122,7 @@ type decl =
   | Rewriting of Loc.t * string * lexpr list
   | Goal of Loc.t * string * lexpr
   | Check_sat of Loc.t * string * lexpr
-  | Logic of Loc.t * Symbols.name_kind * (string * string) list * plogic_type
+  | Logic of Loc.t * Types.name_kind * (string * string) list * plogic_type
   | Predicate_def of
       Loc.t * (string * string) *
       (Loc.t * string * ppure_type) list * lexpr

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -855,17 +855,17 @@ module Flat_Formula : FLAT_FORMULA = struct
     let new_vars = ref new_vars in
     let rec simp topl ~parent_disj f =
       match E.form_view f with
-      | E.Literal a ->
+      | Literal a ->
         let ff, l = mk_lit hcons a !new_vars in
         new_vars := l;
         ff
 
-      | E.Lemma _   -> abstract_lemma hcons abstr f topl lem new_vars
+      | Lemma _   -> abstract_lemma hcons abstr f topl lem new_vars
 
-      | E.Skolem _ ->
+      | Skolem _ ->
         mk_not (simp false ~parent_disj:false (E.neg f))
 
-      | E.Unit(f1, f2) ->
+      | Unit(f1, f2) ->
         let x1 = simp topl ~parent_disj:false f1 in
         let x2 = simp topl ~parent_disj:false f2 in
         begin match x1.view , x2.view with
@@ -875,7 +875,7 @@ module Flat_Formula : FLAT_FORMULA = struct
           | _              -> mk_and hcons [x1; x2]
         end
 
-      | E.Clause(f1, f2, _) ->
+      | Clause(f1, f2, _) ->
         let x1 = simp false ~parent_disj:true f1 in
         let x2 = simp false ~parent_disj:true f2 in
         begin match x1.view, x2.view with
@@ -885,15 +885,15 @@ module Flat_Formula : FLAT_FORMULA = struct
           | _            -> mk_or hcons [x1; x2]
         end
 
-      | E.Iff(f1, f2) ->
+      | Iff(f1, f2) ->
         simp topl ~parent_disj @@
         E.elim_iff f1 f2 (E.id f) ~with_conj:(not parent_disj)
 
-      | E.Xor(f1, f2) ->
+      | Xor(f1, f2) ->
         let g = E.neg @@ E.elim_iff f1 f2 (E.id f) ~with_conj:parent_disj in
         simp topl ~parent_disj g
 
-      | E.Let letin ->
+      | Let letin ->
         simp false ~parent_disj:false (E.elim_let ~recursive:true letin)
     in
     let res = simp true ~parent_disj:false f in
@@ -907,7 +907,7 @@ module Flat_Formula : FLAT_FORMULA = struct
 
   let mk_new_proxy n =
     let hs = Hs.make ("PROXY__" ^ (string_of_int n)) in
-    let sy = Symbols.Name(hs, Symbols.Other) in
+    let sy = Types.Name(hs, Types.Other) in
     E.mk_term sy [] Ty.Tbool
 
   let get_proxy_of f proxies_mp =
@@ -994,7 +994,7 @@ module Proxy_formula = struct
         let inv_proxies =  Atom.Map.add a f inv_proxies in
         let inv_proxies =  Atom.Map.add na nf inv_proxies in
         match E.form_view f with
-        | E.Unit (f1,f2) ->
+        | Unit (f1,f2) ->
           let accu = (proxies, inv_proxies, new_vars, cnf) in
           let a1, accu = mk_cnf hcons f1 accu in
           let a2, (proxies, inv_proxies, new_vars, cnf) =
@@ -1003,7 +1003,7 @@ module Proxy_formula = struct
             [na; a1] :: [na; a2] :: [a; Atom.neg a1; Atom.neg a2] :: cnf in
           a, (proxies, inv_proxies, new_vars, cnf)
 
-        | E.Clause (f1, f2, _) ->
+        | Clause (f1, f2, _) ->
           let accu = (proxies, inv_proxies, new_vars, cnf) in
           let a1, accu = mk_cnf hcons f1 accu in
           let a2, (proxies, inv_proxies, new_vars, cnf) =
@@ -1012,7 +1012,7 @@ module Proxy_formula = struct
             [a; Atom.neg a1] :: [a; Atom.neg a2] :: [na; a1; a2] :: cnf in
           a,  (proxies, inv_proxies, new_vars, cnf)
 
-        | E.Let _ | E.Skolem _ | E.Lemma _ | E.Literal _ | E.Iff _
-        | E.Xor _ ->
+        | Let _ | Skolem _ | Lemma _ | Literal _ | Iff _
+        | Xor _ ->
           a, (proxies, inv_proxies, new_vars, cnf)
 end

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -26,64 +26,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type builtin =
-    LE | LT (* arithmetic *)
-  | IsConstr of Hstring.t (* ADT tester *)
+open Types
 
-type operator =
-    Plus | Minus | Mult | Div | Modulo
-  | Concat | Extract | Get | Set | Fixed | Float
-  | Reach | Access of Hstring.t | Record
-  | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
-  | Sqrt_real_default | Sqrt_real_excess
-  | Min_real | Min_int | Max_real | Max_int | Integer_log2
-  | Pow | Integer_round
-  | Constr of Hstring.t (* enums, adts *)
-  | Destruct of Hstring.t * bool
-  | Tite
-
-type lit =
-  (* literals *)
-  | L_eq
-  | L_built of builtin
-  | L_neg_eq
-  | L_neg_built of builtin
-  | L_neg_pred
-
-type form =
-  (* formulas *)
-  | F_Unit of bool
-  | F_Clause of bool
-  | F_Iff
-  | F_Xor
-  | F_Lemma
-  | F_Skolem
-
-type name_kind = Ac | Other
-
-type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
-
-type bound = (* private *)
-  { kind : bound_kind; sort : Ty.t; is_open : bool; is_lower : bool }
-
-
-type t =
-  | True
-  | False
-  | Void
-  | Name of Hstring.t * name_kind
-  | Int of Hstring.t
-  | Real of Hstring.t
-  | Bitv of string
-  | Op of operator
-  | Lit of lit
-  | Form of form
-  | Var of Var.t
-  | In of bound * bound
-  | MapsTo of Var.t
-  | Let
-
-type s = t
+type t = Types.symbol
 
 let name ?(kind=Other) s = Name (Hstring.make s, kind)
 let var s = Var s
@@ -92,8 +37,8 @@ let real r = Real (Hstring.make r)
 let constr s = Op (Constr (Hstring.make s))
 let destruct ~guarded s = Op (Destruct (Hstring.make s, guarded))
 
-let mk_bound kind sort ~is_open ~is_lower =
-  {kind; sort; is_open; is_lower}
+let mk_bound bkind sort ~is_open ~is_lower =
+  {bkind; sort; is_open; is_lower}
 
 let mk_in b1 b2 =
   assert (b1.is_lower);
@@ -110,96 +55,7 @@ let underscore =
   Random.self_init ();
   var @@ Var.of_string @@ Format.sprintf "_%d" (Random.int 1_000_000)
 
-let compare_kinds k1 k2 =
-  Util.compare_algebraic k1 k2
-    (function
-      | _, (Ac | Other) -> assert false
-    )
-
-let compare_operators op1 op2 =
-  Util.compare_algebraic op1 op2
-    (function
-      | Access h1, Access h2 | Constr h1, Constr h2 -> Hstring.compare h1 h2
-      | Destruct (h1, b1), Destruct(h2, b2) ->
-        let c = Stdlib.compare b1 b2 in
-        if c <> 0 then c else Hstring.compare h1 h2
-      | _ , (Plus | Minus | Mult | Div | Modulo
-            | Concat | Extract | Get | Set | Fixed | Float | Reach
-            | Access _ | Record | Sqrt_real | Abs_int | Abs_real
-            | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
-            | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
-            | Integer_log2 | Pow | Integer_round
-            | Constr _ | Destruct _ | Tite) -> assert false
-    )
-
-let compare_builtin b1 b2 =
-  Util.compare_algebraic b1 b2
-    (function
-      | IsConstr h1, IsConstr h2 -> Hstring.compare h1 h2
-      | _, (LT | LE | IsConstr _) -> assert false
-    )
-
-let compare_lits lit1 lit2 =
-  Util.compare_algebraic lit1 lit2
-    (function
-      | L_built b1, L_built b2 -> compare_builtin b1 b2
-      | L_neg_built b1, L_neg_built b2 -> compare_builtin b1 b2
-      | _, (L_eq | L_built _ | L_neg_eq | L_neg_built _ | L_neg_pred) ->
-        assert false
-    )
-
-let compare_forms f1 f2 =
-  Util.compare_algebraic f1 f2
-    (function
-      | F_Unit b1, F_Unit b2
-      | F_Clause b1, F_Clause b2 -> Stdlib.compare b1 b2
-      | _, (F_Unit _ | F_Clause _ | F_Lemma | F_Skolem
-           | F_Iff | F_Xor) ->
-        assert false
-    )
-
-let compare_bounds_kind a b =
-  Util.compare_algebraic a b
-    (function
-      | VarBnd h1, VarBnd h2 -> Var.compare h1 h2
-      | ValBnd q1, ValBnd q2 -> Numbers.Q.compare q1 q2
-      | _, (VarBnd _ | ValBnd _) -> assert false
-    )
-
-let compare_bounds a b =
-  let c = Ty.compare a.sort b.sort in
-  if c <> 0 then c
-  else
-    let c = Stdlib.compare a.is_open b.is_open in
-    if c <> 0 then c
-    else
-      let c = Stdlib.compare a.is_lower b.is_lower in
-      if c <> 0 then c
-      else compare_bounds_kind a.kind b.kind
-
-let compare s1 s2 =
-  Util.compare_algebraic s1 s2
-    (function
-      | Int h1, Int h2
-      | Real h1, Real h2 -> Hstring.compare h1 h2
-      | Var v1, Var v2 | MapsTo v1, MapsTo v2 -> Var.compare v1 v2
-      | Name (h1, k1), Name (h2, k2) ->
-        let c = Hstring.compare h1 h2 in
-        if c <> 0 then c else compare_kinds k1 k2
-      | Bitv s1, Bitv s2 -> String.compare s1 s2
-      | Op op1, Op op2 -> compare_operators op1 op2
-      | Lit lit1, Lit lit2 -> compare_lits lit1 lit2
-      | Form f1, Form f2 -> compare_forms f1 f2
-      | In (b1, b2), In (b1', b2') ->
-        let c = compare_bounds b1 b1' in
-        if c <> 0 then c else compare_bounds b2 b2'
-      | _ ,
-        (True | False | Void | Name _ | Int _ | Real _ | Bitv _
-        | Op _ | Lit _ | Form _ | Var _ | In _ | MapsTo _ | Let) ->
-        assert false
-    )
-
-let equal s1 s2 = compare s1 s2 = 0
+let equal s1 s2 = Types.SYMBOL.compare s1 s2 = 0
 
 let hash x =
   abs @@
@@ -224,7 +80,7 @@ let string_of_bound_kind x = match x with
   | ValBnd v -> Numbers.Q.to_string v
 
 let string_of_bound b =
-  let kd = string_of_bound_kind b.kind in
+  let kd = string_of_bound_kind b.bkind in
   if b.is_lower then
     Format.sprintf "%s %s" (if b.is_open then "]" else "[") kd
   else
@@ -342,7 +198,7 @@ let fake_le  =  name "@le"
 
 
 module Labels = Hashtbl.Make(struct
-    type t = s
+    type t = Types.symbol
     let equal = equal
     let hash = hash
   end)
@@ -355,16 +211,12 @@ let label t = try Labels.find labels t with Not_found -> Hstring.empty
 
 let clear_labels () = Labels.clear labels
 
-module Set : Set.S with type elt = t =
-  Set.Make (struct type t=s let compare=compare end)
+module Set = Types.SYMBOL.Set
 
-module Map : sig
-  include Map.S with type key = t
-  val print :
-    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-end = struct
-  include Map.Make (struct type t = s let compare = compare end)
-  let print pr_elt fmt sbt =
-    iter (fun k v -> Format.fprintf fmt "%a -> %a  " print k pr_elt v) sbt
-end
+module Map = Types.SYMBOL.Map
 
+let print_map pr_elt fmt sbt =
+  Map.iter (fun k v -> Format.fprintf fmt "%a -> %a  " print k pr_elt v) sbt
+
+let compare = Types.SYMBOL.compare
+let compare_bounds = Types.SYMBOL.compare_bounds

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -26,61 +26,9 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type builtin =
-    LE | LT (* arithmetic *)
-  | IsConstr of Hstring.t (* ADT tester *)
+open Types
 
-type operator =
-  | Plus | Minus | Mult | Div | Modulo
-  | Concat | Extract | Get | Set | Fixed | Float
-  | Reach | Access of Hstring.t | Record
-  | Sqrt_real | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
-  | Sqrt_real_default | Sqrt_real_excess
-  | Min_real | Min_int | Max_real | Max_int | Integer_log2
-  | Pow | Integer_round
-  | Constr of Hstring.t (* enums, adts *)
-  | Destruct of Hstring.t * bool
-  | Tite
-
-type lit =
-  (* literals *)
-  | L_eq
-  | L_built of builtin
-  | L_neg_eq
-  | L_neg_built of builtin
-  | L_neg_pred
-
-type form =
-  (* formulas *)
-  | F_Unit of bool
-  | F_Clause of bool
-  | F_Iff
-  | F_Xor
-  | F_Lemma
-  | F_Skolem
-
-type name_kind = Ac | Other
-
-type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
-
-type bound = private
-  { kind : bound_kind; sort : Ty.t; is_open : bool; is_lower : bool }
-
-type t =
-  | True
-  | False
-  | Void
-  | Name of Hstring.t * name_kind
-  | Int of Hstring.t
-  | Real of Hstring.t
-  | Bitv of string
-  | Op of operator
-  | Lit of lit
-  | Form of form
-  | Var of Var.t
-  | In of bound * bound
-  | MapsTo of Var.t
-  | Let
+type t = Types.symbol
 
 val name : ?kind:name_kind -> string -> t
 val var : Var.t -> t
@@ -131,10 +79,9 @@ val string_of_bound : bound -> string
 val clear_labels : unit -> unit
 (** Empties the labels Hashtable *)
 
-module Set : Set.S with type elt = t
+module Set = Types.SYMBOL.Set
 
-module Map : sig
-  include Map.S with type key = t
-  val print :
-    (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-end
+module Map = Types.SYMBOL.Map
+
+val print_map :
+  (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a Map.t -> unit

--- a/src/lib/structures/typed.ml
+++ b/src/lib/structures/typed.ml
@@ -73,7 +73,7 @@ and 'a tt_desc =
   | TTprefix of Symbols.t * 'a atterm
   | TTapp of Symbols.t * 'a atterm list
   | TTmapsTo of Var.t * 'a atterm
-  | TTinInterval of 'a atterm * Symbols.bound * Symbols.bound
+  | TTinInterval of 'a atterm * Types.bound * Types.bound
   (* bool = true <-> interval is_open *)
 
   | TTget of 'a atterm * 'a atterm

--- a/src/lib/structures/typed.mli
+++ b/src/lib/structures/typed.mli
@@ -101,7 +101,7 @@ and 'a tt_desc =
   | TTmapsTo of Var.t * 'a atterm
   (** Used in semantic triggers for floating point arithmetic.
       See sources/preludes/fpa-theory-2017-01-04-16h00.ae *)
-  | TTinInterval of 'a atterm * Symbols.bound * Symbols.bound
+  | TTinInterval of 'a atterm * Types.bound * Types.bound
   (** Represent floating point intervals (used for triggers in Floating
       point arithmetic theory).
       [TTinInterval (lower, l_strict, t, upper, u_strict)] is a constraint

--- a/src/lib/structures/xliteral.ml
+++ b/src/lib/structures/xliteral.ml
@@ -26,7 +26,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type builtin = Symbols.builtin =
+type builtin = Types.builtin =
     LE | LT | (* arithmetic *)
     IsConstr of Hstring.t (* ADT tester *)
 

--- a/src/lib/structures/xliteral.mli
+++ b/src/lib/structures/xliteral.mli
@@ -26,7 +26,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type builtin = Symbols.builtin =
+type builtin = Types.builtin =
     LE | LT | (* arithmetic *)
     IsConstr of Hstring.t (* ADT tester *)
 

--- a/src/parsers/native_parser.mly
+++ b/src/parsers/native_parser.mly
@@ -175,8 +175,8 @@ theory_elt:
 
 
 ac_modifier:
-| /* */ { Symbols.Other }
-| AC    { Symbols.Ac }
+| /* */ { Types.Other }
+| AC    { Types.Ac }
 
 primitive_type:
 | INT  { int_type }

--- a/src/parsers/psmt2_to_alt_ergo.ml
+++ b/src/parsers/psmt2_to_alt_ergo.ml
@@ -322,7 +322,7 @@ module Translate = struct
 
   let translate_decl_fun f params ret =
     let logic_type = mk_logic_type params (Some ret) in
-    mk_logic (pos f) Symbols.Other [(f.c,f.c)] logic_type
+    mk_logic (pos f) Types.Other [(f.c,f.c)] logic_type
 
   let translate_fun_dec (_,sl,s) =
     List.map translate_sort sl, translate_sort s
@@ -453,13 +453,13 @@ module Translate = struct
       (* assert false; *)
       let logic_type = mk_logic_type [real_type] (Some int_type) in
       let to_int =
-        mk_logic dummy_pos Symbols.Other [("to_int","to_int")] logic_type in
+        mk_logic dummy_pos Types.Other [("to_int","to_int")] logic_type in
       let logic_type = mk_logic_type [int_type] (Some real_type) in
       let to_real =
-        mk_logic dummy_pos Symbols.Other [("to_real","to_real")] logic_type in
+        mk_logic dummy_pos Types.Other [("to_real","to_real")] logic_type in
       let logic_type = mk_logic_type [real_type] (Some bool_type) in
       let is_int =
-        mk_logic dummy_pos Symbols.Other [("is_int","is_int")] logic_type in
+        mk_logic dummy_pos Types.Other [("is_int","is_int")] logic_type in
       [to_int;to_real;is_int]
     else []
 

--- a/src/plugins/AB-Why3/why3_parser.mly
+++ b/src/plugins/AB-Why3/why3_parser.mly
@@ -68,7 +68,7 @@ open Parsed
       List.map (fun (_, _, pty) -> pty ) params in
     let logic_type =
       mk_logic_type ppure_type_list pptyop in
-    mk_logic loc Symbols.Other ssl logic_type
+    mk_logic loc Types.Other ssl logic_type
 
   let mk_tuple pl loc =
     let length =  string_of_int (List.length pl) in

--- a/src/plugins/fm-simplex/fmSimplexIneqs.ml
+++ b/src/plugins/fm-simplex/fmSimplexIneqs.ml
@@ -17,7 +17,7 @@ module Q = Numbers.Q
 
 module Container : Inequalities.Container_SIG = struct
   module Make
-      (P : Polynome.T with type r = Shostak.Combine.r)
+      (P : Polynome.T)
     : Inequalities.S with module P = P = struct
 
     module X = Shostak.Combine
@@ -33,7 +33,7 @@ module Container : Inequalities.Container_SIG = struct
     module SCache =
       Simplex_cache.MAKE(
       struct
-        type t = X.r
+        type t = Types.r
         let compare = X.hash_cmp
         include X
       end)


### PR DESCRIPTION
Currently, the code of alt-ergo is hard to enter because it is a huge recursive mess, where all theories are functors with a `Sig.SHOSTAK` interface and they are all gathered together in the `shostak.ml` using a big `module rec`.

This patch is probably not intented to be merged at any point, but it might be interesting as it simplifies the code by removing this use of functors and module rec : 

* Types from `symbols.ml`, `expr.ml` and all theories are gathered together in a file `types.ml` (which makes it easier to understand what they are ...)
* A `shostak_pre.ml` file exposes `shostak.ml` functions before they are available, to allow a huge recursion between modules. It exposes a set of refs, which are set from  the `shostak.ml` file at the end.
* Most of the changes are replacements of scopes changes to use `Types` instead of `Symbols` or `Expr`.
