### PR TITLE
Support preludes with the dolmen frontend

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -525,7 +525,13 @@ let main () =
       Options.with_timelimit_if (not (Options.get_timelimit_per_goal ()))
       @@ fun () ->
 
-      let st, g = Parser.parse_logic [] st (State.get State.logic_file st) in
+      let preludes =
+        List.map (fun f -> Dolmen_std.Statement.include_ f [])
+          (Options.get_preludes ())
+      in
+      let st, g =
+        Parser.parse_logic preludes st (State.get State.logic_file st)
+      in
       let all_used_context = FE.init_all_used_context () in
       let finally = finally ~handle_exn in
       let st =

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -526,7 +526,7 @@ let main () =
       @@ fun () ->
 
       let preludes =
-        List.map (fun f -> Dolmen_std.Statement.include_ f [])
+        List.map Dolmen_std.Statement.import
           (Options.get_preludes ())
       in
       let st, g =


### PR DESCRIPTION
Fixes #585
While adding the fix I noticed an error in Dolmen:
https://github.com/Gbury/dolmen/blob/a5632a000a8c4ed10c7653574fdf9d9af11a0b05/src/standard/expr.ml#L1848-L1850
It expects the in_interval trigger to only support integers, while in the fpa preludes files it also supports reals.
In the legacy frontend it's apparently polymorphic and just expects the bounds to be of the same type as the expression for which the check is done:
https://github.com/OCamlPro/alt-ergo/blob/959f56880f1dbb9426aed842c345d00c0a9493df/src/lib/frontend/typechecker.ml#L1252-L1258
I will first add the fix in Dolmen before this PR can be merged.