### PR TITLE
Fix memory leak

### DIFF
--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -390,10 +390,9 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
   let clause_bump_activity env (c : Atom.clause) =
     c.activity <- c.activity +. env.clause_inc;
     if (Stdlib.compare c.activity 1e20) > 0 then begin
-      for i = 0 to env.learnts.Vec.sz - 1 do
-        (Vec.get env.learnts i).activity <-
-          (Vec.get env.learnts i).activity *. 1e-20;
-      done;
+      Vec.iter (fun (clause : Atom.clause) ->
+          clause.activity <- clause.activity *. 1e-20
+        ) env.learnts;
       env.clause_inc <- env.clause_inc *. 1e-20
     end
 
@@ -437,13 +436,9 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
   let remove_clause env c = detach_clause env c
 
   let satisfied (c : Atom.clause) =
-    try
-      for i = 0 to Vec.size c.atoms - 1 do
-        let a = Vec.get c.atoms i in
-        if a.is_true && a.var.level ==0 then raise Exit
-      done;
-      false
-    with Exit -> true
+    Vec.exists (fun (atom : Atom.atom) ->
+        atom.is_true && atom.var.level == 0
+      ) c.atoms
 
   let is_assigned (a : Atom.atom) =
     a.is_true || a.neg.is_true
@@ -561,10 +556,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     | None -> ()
     | Some (c : Atom.clause) ->
       let maxi = ref min_int in
-      for i = 0 to Vec.size c.atoms - 1 do
-        let b = Vec.get c.atoms i in
-        if not (Atom.eq_atom a b) then maxi := max !maxi b.var.level
-      done;
+      Vec.iter (fun (atom : Atom.atom) ->
+          if not (Atom.eq_atom a atom) then
+            maxi := max !maxi atom.var.level
+        ) c.atoms;
       assert (!maxi = lvl)
 
   let max_level_in_clause (c : Atom.clause) =
@@ -675,10 +670,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     let new_sz_w = ref 0 in
     begin
       try
-        for i = 0 to Vec.size watched - 1 do
-          let c = Vec.get watched i in
-          if not c.removed then propagate_in_clause env a c i watched new_sz_w
-        done;
+        Vec.iteri (fun i (clause : Atom.clause) ->
+            if not clause.removed then
+              propagate_in_clause env a clause i watched new_sz_w
+          ) watched;
       with Conflict c -> assert (!res == C_none); res := C_bool c
     end;
     let dead_part = Vec.size watched - !new_sz_w in
@@ -990,11 +985,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       | [{ Atom.atoms; _ }] ->
         assert (Options.get_unsat_core ());
         let l = ref linit in
-        for i = 0 to Vec.size atoms - 1 do
-          let v = (Vec.get atoms i).var in
-          l := List.rev_append v.vpremise !l;
-          match v.reason with None -> () | Some c -> l := c :: !l
-        done;
+        Vec.iter (fun (atom : Atom.atom) ->
+            l := List.rev_append atom.var.vpremise !l;
+            match atom.var.reason with None -> () | Some c -> l := c :: !l
+          ) atoms;
         Printer.print_dbg ~header:false
           "@[<v 2>UNSAT Deduction made from:@ %a@]"
           (Printer.pp_list_no_space print_aux) !l;
@@ -1003,14 +997,13 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
           match todo with
           | [] -> ()
           | (c : Atom.clause) ::r ->
-            for i = 0 to Vec.size c.atoms - 1 do
-              let v = (Vec.get c.atoms i).var in
-              if not v.seen then begin
-                v.seen <- true;
-                roots v.vpremise;
-                match v.reason with None -> () | Some r -> roots [r];
-              end
-            done;
+            Vec.iter (fun (atom : Atom.atom) ->
+                if not atom.var.seen then begin
+                  atom.var.seen <- true;
+                  roots atom.var.vpremise;
+                  match atom.var.reason with None -> () | Some r -> roots [r]
+                end
+              ) c.atoms;
             match c.cpremise with
             | []    -> if not (HUC.mem uc c) then HUC.add uc c (); roots r
             | prems -> roots prems; roots r
@@ -1052,14 +1045,13 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         match todo with
         | [] -> ()
         | (c : Atom.clause) ::r ->
-          for i = 0 to Vec.size c.atoms - 1 do
-            let v = (Vec.get c.atoms i).var in
-            if not v.seen then begin
-              v.seen <- true;
-              roots v.vpremise;
-              match v.reason with None -> () | Some r -> roots [r];
-            end
-          done;
+          Vec.iter (fun (atom : Atom.atom) ->
+              if not atom.var.seen then begin
+                atom.var.seen <- true;
+                roots atom.var.vpremise;
+                match atom.var.reason with None -> () | Some r -> roots [r]
+              end
+            ) c.atoms;
           match c.cpremise with
           | []    -> if not (HUC.mem uc c) then HUC.add uc c (); roots r
           | prems -> roots prems; roots r
@@ -1715,12 +1707,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     not (Options.get_cdcl_tableaux ()) ||
     MFF.mem f' env.ff_lvl
 
-  let boolean_model env =
-    let l = ref [] in
-    for i = Vec.size env.trail - 1 downto 0 do
-      l := (Vec.get env.trail i) :: !l
-    done;
-    !l
+  let boolean_model env = Vec.to_list env.trail
 
   let instantiation_context env hcons =
     if Options.get_cdcl_tableaux_th () then

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -84,7 +84,7 @@ module type ATOM = sig
 
   val fresh_dname : unit -> string
 
-  val make_clause : string -> atom list -> E.t -> int -> bool ->
+  val make_clause : string -> atom list -> E.t -> bool ->
     premise-> clause
 
   (*val made_vars_info : unit -> int * var list*)
@@ -300,7 +300,7 @@ module Atom : ATOM = struct
       and pa =
         { var = var;
           lit = lit;
-          watched = Vec.make 10 dummy_clause;
+          watched = Vec.make 10 ~dummy:dummy_clause;
           neg = na;
           is_true = false;
           is_guard = false;
@@ -309,7 +309,7 @@ module Atom : ATOM = struct
       and na =
         { var = var;
           lit = E.neg lit;
-          watched = Vec.make 10 dummy_clause;
+          watched = Vec.make 10 ~dummy:dummy_clause;
           neg = pa;
           is_true = false;
           is_guard = false;
@@ -347,8 +347,8 @@ module Atom : ATOM = struct
     try (HT.find hcons.tbl (E.neg lit)).na
     with Not_found -> assert false
 
-  let make_clause name ali f sz_ali is_learnt premise =
-    let atoms = Vec.from_list ali sz_ali dummy_atom in
+  let make_clause name ali f is_learnt premise =
+    let atoms = Vec.of_list ali ~dummy:dummy_atom in
     { name  = name;
       atoms = atoms;
       removed = false;

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -246,11 +246,7 @@ module Atom : ATOM = struct
         (sign a) (a.var.vid+1) (value a) a.var.index E.print a.lit
         premise a.var.vpremise
 
-
-    let atoms_vec fmt vec =
-      for i = 0 to Vec.size vec - 1 do
-        Format.fprintf fmt "%a ; " atom (Vec.get vec i)
-      done
+    let atoms_vec = Vec.pp ~sep:";" atom
 
     let clause fmt { name; atoms=arr; cpremise=cp; _ } =
       Format.fprintf fmt "%s:{ %a} cpremise={{%a}}" name atoms_vec
@@ -395,11 +391,12 @@ module Atom : ATOM = struct
     | Some c ->
       let cpt = ref 0 in
       let l = ref [] in
-      for i = 0 to Vec.size c.atoms - 1 do
-        let b = Vec.get c.atoms i in
-        if eq_atom a b then incr cpt
-        else l := b :: !l
-      done;
+      Vec.iter (fun (atom : atom) ->
+          if eq_atom a atom then
+            incr cpt
+          else
+            l := atom :: !l
+        ) c.atoms;
       if !cpt <> 1 then begin
         Printer.print_err
           "cpt = %d@ a = %a@ c = %a"

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -81,7 +81,7 @@ module type ATOM = sig
 
   val fresh_dname : unit -> string
 
-  val make_clause : string -> atom list -> Expr.t -> int -> bool ->
+  val make_clause : string -> atom list -> Expr.t -> bool ->
     premise-> clause
 
   (*val made_vars_info : unit -> int * var list*)

--- a/src/lib/util/iheap.ml
+++ b/src/lib/util/iheap.ml
@@ -14,8 +14,9 @@ type t = {heap : int Vec.t; indices : int Vec.t }
 let dummy = -100
 
 let init sz =
-  { heap    =  Vec.init sz (fun i -> i) dummy;
-    indices =  Vec.init sz (fun i -> i) dummy}
+  let lst = List.init sz (fun i -> i) in
+  { heap    =  Vec.of_list lst ~dummy;
+    indices =  Vec.of_list lst ~dummy}
 
 let left i   = (i lsl 1) + 1 (* i*2 + 1 *)
 let right i  = (i + 1) lsl 1 (* (i+1)*2 *)
@@ -87,7 +88,7 @@ let filter s filt cmp =
     end
     else Vec.set s.indices (Vec.get s.heap i) (-1);
   done;
-  Vec.shrink s.heap (lim - !j) true;
+  Vec.shrink s.heap (lim - !j);
   for i = (lim / 2) - 1 downto 0 do
     percolate_down cmp s i
   done
@@ -127,6 +128,6 @@ let remove_min cmp ({heap=heap; indices=indices} as s) =
   Vec.set heap 0 (Vec.last heap); (*heap.last()*)
   Vec.set indices (Vec.get heap 0) 0;
   Vec.set indices x (-1);
-  Vec.pop s.heap;
+  ignore(Vec.pop s.heap);
   if Vec.size s.heap > 1 then percolate_down cmp s 0;
   x

--- a/src/lib/util/iheap.ml
+++ b/src/lib/util/iheap.ml
@@ -79,15 +79,15 @@ let increase cmp s n =
 
 let filter s filt cmp =
   let j = ref 0 in
+  Vec.iter (fun elt ->
+      if filt elt then begin
+        Vec.set s.heap !j elt;
+        Vec.set s.indices elt !j;
+        incr j
+      end
+      else Vec.set s.indices elt (-1)
+    ) s.heap;
   let lim = Vec.size s.heap in
-  for i = 0 to lim - 1 do
-    if filt (Vec.get s.heap i) then begin
-      Vec.set s.heap !j (Vec.get s.heap i);
-      Vec.set s.indices (Vec.get s.heap i) !j;
-      incr j;
-    end
-    else Vec.set s.indices (Vec.get s.heap i) (-1);
-  done;
   Vec.shrink s.heap (lim - !j);
   for i = (lim / 2) - 1 downto 0 do
     percolate_down cmp s i

--- a/src/lib/util/vec.mli
+++ b/src/lib/util/vec.mli
@@ -14,7 +14,7 @@ type 'a t = {
   mutable sz : int;
   dummy: 'a;
 }
-(** Type of sparse vectors of 'a elements. *)
+(** Type of vectors of 'a elements. *)
 
 val make : int -> dummy:'a -> 'a t
 (** [make cap dummy] creates a new vector filled with [dummy]. The vector
@@ -63,11 +63,12 @@ val push : 'a t -> 'a -> unit
 (** Push element into the vector. *)
 
 val get : 'a t -> int -> 'a
-(** get the element at the given index, or
-    @raise Invalid_argument if the index is not valid. *)
+(** Get the element at the given index, or
+    @raise Invalid_argument if the index is not valid.
+    @raise Not_found if the retrieved value is dummy. *)
 
 val set : 'a t -> int -> 'a -> unit
-(** set the element at the given index, either already set or the first
+(** Set the element at the given index, either already set or the first
     free slot if [not (is_full vec)], or
     @raise Invalid_argument if the index is not valid. *)
 
@@ -79,8 +80,8 @@ val fast_remove : 'a t -> int -> unit
     (swap with last element). *)
 
 val filter_in_place : ('a -> bool) -> 'a t -> unit
-(** [filter_in_place f v] removes from [v] the elements that do
-    not satisfy [f] *)
+(** [filter_in_place p vec] removes from [vec] the elements that do
+    not satisfy [p]. *)
 
 val sort : 'a t -> ('a -> 'a -> int) -> unit
 (** Sort in place the vector. *)

--- a/src/lib/util/vec.mli
+++ b/src/lib/util/vec.mli
@@ -9,31 +9,100 @@
 (*                                                                            *)
 (******************************************************************************)
 
-type 'a t = { mutable dummy: 'a; mutable data : 'a array; mutable sz : int }
-val make : int -> 'a -> 'a t
-val init : int -> (int -> 'a) -> 'a -> 'a t
-val from_array : 'a array -> int -> 'a -> 'a t
-val from_list : 'a list -> int -> 'a -> 'a t
-val clear : 'a t -> unit
+type 'a t = {
+  mutable data : 'a array;
+  mutable sz : int;
+  dummy: 'a;
+}
+(** Type of sparse vectors of 'a elements. *)
 
-(* if bool is true, then put "dummy" is unreachable cells *)
-val shrink : 'a t -> int -> bool -> unit
-val pop : 'a t -> unit
-val size : 'a t -> int
-val is_empty : 'a t -> bool
-val grow_to : 'a t -> int -> unit
-val grow_to_double_size : 'a t -> unit
-val grow_to_by_double : 'a t -> int -> unit
-val is_full : 'a t -> bool
-val push : 'a t -> 'a -> unit
-val push_none : 'a t -> unit
+val make : int -> dummy:'a -> 'a t
+(** [make cap dummy] creates a new vector filled with [dummy]. The vector
+    is initially empty but its underlying array has capacity [cap].
+    [dummy] will stay alive as long as the vector *)
+
+val create : dummy:'a -> 'a t
+(** [create ~dummy] creates an empty vector using [dummy] as dummy values. *)
+
+val to_list : 'a t -> 'a list
+(** Returns the list of elements of the vector. *)
+
+val to_array : 'a t -> 'a array
+
+val of_list : 'a list -> dummy:'a -> 'a t
+
+val clear : 'a t -> unit
+(** Set size to zero, doesn't free elements. *)
+
+val shrink : 'a t -> int -> unit
+(** [shrink vec sz] resets size of [vec] to [sz] and frees its elements.
+    Assumes [sz >=0 && sz <= size vec]. *)
+
+val pop : 'a t -> 'a
+(** Pop last element, free and return it.
+    @raise Invalid_argument if the vector is empty. *)
+
 val last : 'a t -> 'a
+(** Return the last element.
+    @raise Invalid_argument if the vector is empty. *)
+
+val grow_to_by_double : 'a t -> int -> unit
+(** [grow_to_by_double vec c] grow the capacity of the vector
+    by double it. *)
+
+val size : 'a t -> int
+(** Returns the size of the vector. *)
+
+val is_empty : 'a t -> bool
+(** Returns [true] if and only if the vector is of size 0. *)
+
+val is_full : 'a t -> bool
+(** Is the capacity of the vector equal to the number of its elements? *)
+
+val push : 'a t -> 'a -> unit
+(** Push element into the vector. *)
+
 val get : 'a t -> int -> 'a
+(** get the element at the given index, or
+    @raise Invalid_argument if the index is not valid. *)
+
 val set : 'a t -> int -> 'a -> unit
-val set_size : 'a t -> int -> unit
+(** set the element at the given index, either already set or the first
+    free slot if [not (is_full vec)], or
+    @raise Invalid_argument if the index is not valid. *)
+
 val copy : 'a t -> 'a t
-val move_to : 'a t -> 'a t -> unit
-val remove : 'a t -> 'a -> unit
-val fast_remove : 'a t -> 'a -> unit
+(** Fresh copy. *)
+
+val fast_remove : 'a t -> int -> unit
+(** Remove element at index [i] without preserving order
+    (swap with last element). *)
+
+val filter_in_place : ('a -> bool) -> 'a t -> unit
+(** [filter_in_place f v] removes from [v] the elements that do
+    not satisfy [f] *)
+
 val sort : 'a t -> ('a -> 'a -> int) -> unit
-val iter : 'a t -> ('a -> unit) -> unit
+(** Sort in place the vector. *)
+
+val iter : ('a -> unit) -> 'a t -> unit
+(** Iterate on elements. Ignore dummy elements. *)
+
+val iteri : (int -> 'a -> unit) -> 'a t -> unit
+(** Iterate on elements with their index. Ignore dummy elements. *)
+
+val fold : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
+(** Fold over elements. Ignore dummy elements. Ignore dummy elements. *)
+
+val exists : ('a -> bool) -> 'a t -> bool
+(** Does there exist a non-dummy element that satisfies the predicate? *)
+
+val for_all : ('a -> bool) -> 'a t -> bool
+(** Do all non-dummy elements satisfy the predicate? *)
+
+val pp :
+  ?sep:string ->
+  (Format.formatter -> 'a -> unit) ->
+  Format.formatter -> 'a t -> unit
+(** [pp ~sep pp_elt fmt vec] prints on the formatter [fmt]
+    all the elements of [vec] using the printer [pp_elt] for each element. *)

--- a/src/plugins/fm-simplex/simplex.ml
+++ b/src/plugins/fm-simplex/simplex.ml
@@ -373,26 +373,19 @@ module Simplex (C : Coef_Type) = struct
     let z_subst_in_p p s = p.a.(s) <- s, C.zero
 
     let normalize_poly p sbt zsbt =
-      for i = 0 to Vec.size sbt - 1 do subst_in_p p (Vec.get sbt i) done;
-      for i = 0 to Vec.size zsbt - 1 do z_subst_in_p p (Vec.get zsbt i) done
+      Vec.iter (subst_in_p p) sbt;
+      Vec.iter (z_subst_in_p p) zsbt
 
     let normalize_sbt sbt zsbt =
-      for i = 0 to Vec.size sbt - 1 do
-        for j = 0 to Vec.size zsbt - 1 do
-          z_subst_in_p (snd (Vec.get sbt i)) (Vec.get zsbt j)
-        done;
-      done;
+      Vec.iter (fun elt ->
+          Vec.iter (z_subst_in_p (snd elt)) zsbt
+        ) sbt;
       for i = Vec.size sbt - 1 downto 1 do
         for j = i - 1 downto 0 do
           subst_in_p (snd (Vec.get sbt j)) (Vec.get sbt i)
         done;
       done;
-      let l1 = ref [] in
-      let l2 = ref [] in
-      for i = 0 to Vec.size sbt - 1  do l1 := (Vec.get sbt i)  :: !l1 done;
-      for i = 0 to Vec.size zsbt - 1 do l2 := (Vec.get zsbt i) :: !l2 done;
-      !l2, !l1
-
+      Vec.to_list zsbt, Vec.to_list sbt
 
     let sbt = Vec.make 107 ~dummy:((0,0),{a=[||]; c=Q.zero, Q.zero})
     let zsbt = Vec.make 107 ~dummy:(-2)

--- a/src/plugins/fm-simplex/simplex.ml
+++ b/src/plugins/fm-simplex/simplex.ml
@@ -394,8 +394,8 @@ module Simplex (C : Coef_Type) = struct
       !l2, !l1
 
 
-    let sbt = Vec.make 107 ((0,0),{a=[||]; c=Q.zero, Q.zero})
-    let zsbt = Vec.make 107 (-2)
+    let sbt = Vec.make 107 ~dummy:((0,0),{a=[||]; c=Q.zero, Q.zero})
+    let zsbt = Vec.make 107 ~dummy:(-2)
 
     let solve_zero_arr zsbt zsbt_inv a =
       Array.iter


### PR DESCRIPTION
This PR fixes the memory leak in the module `Vec.ml`. The leak comes from the function: 
```ocaml 
let pop t = assert (t.sz >=1); t.sz <- t.sz - 1
```
The pop function does not replace the popped value by the dummy value.

Basically, I replace the old module `Vec.ml` by its clean version from mSAT repository. 
I also replaced as much as I can the for-loops in the codebase by iterators from the Vec module.
Yet, as I noticed months ago, I cannot abstract the vector type because of this code in Satml: 
```ocaml
  let rec dummy_var =
    { vid = -101;
      pa = dummy_atom;
      na = dummy_atom;
      level = -1;
      index = -1;
      reason = None;
      weight = -1.;
      sweight = 0;
      seen = false;
      vpremise = [] }
  and dummy_atom =
    { var = dummy_var;
      timp = 0;
      lit = dummy_lit;
      watched = {Vec.dummy=dummy_clause; data=[||]; sz=0};
      neg = dummy_atom;
      is_true = false;
      is_guard = false;
      aid = -102 }
  and dummy_clause =
    { name = "";
      atoms = {Vec.dummy=dummy_atom; data=[||]; sz=0};
      activity = -1.;
      removed = false;
      learnt = false;
      cpremise = [];
      form = vraie_form }
```