### PR TITLE
Actually use a weak cache for Shostak.Combine

### DIFF
--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -765,33 +765,26 @@ and AC : Ac.S
 module Combine = struct
   include CX
 
-  type weak_t = { t : Expr.t ; mutable r : (r * Expr.t list) option }
-
-  module H = Weak.Make(struct
-      type t = weak_t
-
-      let equal { t = t1; _ } { t = t2 ; _ } = Expr.equal t1 t2
-      let hash { t; _ } = Expr.hash t
-    end)
+  module H = Ephemeron.K1.Make(Expr)
 
   let make, save_cache, reinit_cache =
-    let cache = H.create 1024 in
+    let cache = ref (H.create 1024) in
     let cache_copy = ref None in
     let make t =
-      match H.merge cache { t ; r = None } with
-      | { r = Some res ; _ } -> res
-      | weak -> let res = make t in weak.r <- Some res; res
+      match H.find !cache t with
+      | r -> r
+      | exception Not_found ->
+        let r = make t in
+        H.add !cache t r;
+        r
     in
     let save_cache_aux () =
       save_cache ();
-      let copy = H.create (H.count cache) in
-      H.iter (H.add copy) cache;
-      cache_copy := (Some copy);
+      cache_copy := (Some (H.copy !cache));
     in
     let reinit_cache_aux () =
       reinit_cache ();
-      H.clear cache;
-      H.iter (H.add cache) (Option.get !cache_copy)
+      cache := H.copy (Option.get !cache_copy);
     in
     make, save_cache_aux, reinit_cache_aux
 


### PR DESCRIPTION
PR #580 was hilariously wrong, but nobody noticed. In that implementation, we only keep a hold on the key, but not the [weak_t] value --- so it is immediately dead and will be collected in the next GC cycle.

This PR use `Ephemeron.K1.Make` instead, which is the appropriate structure for weak hash tables.