### PR TITLE
Fix the leak memory in Vec

### DIFF
--- a/src/lib/util/vec.ml
+++ b/src/lib/util/vec.ml
@@ -52,7 +52,10 @@ let shrink t i fill_with_dummy =
     done;
   t.sz <- t.sz - i
 
-let pop t = assert (t.sz >=1); t.sz <- t.sz - 1
+let pop t =
+  assert (t.sz >=1);
+  Array.unsafe_set t.data (t.sz-1) t.dummy;
+  t.sz <- t.sz - 1
 
 let size t = t.sz
 


### PR DESCRIPTION
This PR fixes the memory leak in the module `Vec.ml`. The leak comes from the function: 
```ocaml 
let pop t = assert (t.sz >=1); t.sz <- t.sz - 1
```
The pop function does not replace the popped value by the dummy value.