### PR TITLE
New vec module

### DIFF
--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -244,21 +244,22 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
       unsat_core = None;
 
-      clauses = Vec.make 0 Atom.dummy_clause;
+      clauses = Vec.make 0 ~dummy:Atom.dummy_clause;
       (*sera mis a jour lors du parsing*)
 
-      learnts = Vec.make 0 Atom.dummy_clause;
+      learnts = Vec.make 0 ~dummy:Atom.dummy_clause;
       (*sera mis a jour lors du parsing*)
 
       clause_inc = 1.;
 
       var_inc = 1.;
 
-      vars = Vec.make 0 Atom.dummy_var; (*sera mis a jour lors du parsing*)
+      vars = Vec.make 0 ~dummy:Atom.dummy_var;
+      (*sera mis a jour lors du parsing*)
 
-      trail = Vec.make 601 Atom.dummy_atom;
+      trail = Vec.make 601 ~dummy:Atom.dummy_atom;
 
-      trail_lim = Vec.make 601 (-105);
+      trail_lim = Vec.make 601 ~dummy:(-105);
 
       qhead = 0;
 
@@ -312,7 +313,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
       unit_tenv = Th.empty();
 
-      tenv_queue = Vec.make 100 (Th.empty());
+      tenv_queue = Vec.make 100 ~dummy:(Th.empty());
 
       tatoms_queue = Queue.create ();
 
@@ -326,16 +327,16 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
       lazy_cnf_queue =
         Vec.make 100
-          (Matoms.singleton (Atom.faux_atom) (MFF.empty, FF.faux));
+          ~dummy:(Matoms.singleton (Atom.faux_atom) (MFF.empty, FF.faux));
 
       relevants = SFF.empty;
-      relevants_queue = Vec.make 100 (SFF.singleton (FF.faux));
+      relevants_queue = Vec.make 100 ~dummy:(SFF.singleton (FF.faux));
 
       ff_lvl = MFF.empty;
 
       lvl_ff = Util.MI.empty;
 
-      increm_guards = Vec.make 1 Atom.dummy_atom;
+      increm_guards = Vec.make 1 ~dummy:Atom.dummy_atom;
 
       next_dec_guard = 0;
     }
@@ -389,9 +390,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
   let var_bump_activity env (v : Atom.var) =
     v.weight <- v.weight +. env.var_inc;
     if (Stdlib.compare v.weight 1e100) > 0 then begin
-      for i = 0 to env.vars.Vec.sz - 1 do
-        (Vec.get env.vars i).weight <- (Vec.get env.vars i).weight *. 1e-100
-      done;
+      Vec.iter
+        (fun (v : Atom.var) ->
+           v.weight <- v.weight *. 1e-100
+        ) env.vars;
       env.var_inc <- env.var_inc *. 1e-100;
     end;
     if Iheap.in_heap env.order v.vid then
@@ -527,14 +529,14 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         env.lazy_cnf <- Vec.get env.lazy_cnf_queue lvl;
         env.relevants <- Vec.get env.relevants_queue lvl;
       end;
-      Vec.shrink env.trail ((Vec.size env.trail) - env.qhead) true;
-      Vec.shrink env.trail_lim ((Vec.size env.trail_lim) - lvl) true;
-      Vec.shrink env.tenv_queue ((Vec.size env.tenv_queue) - lvl) true;
+      Vec.shrink env.trail ((Vec.size env.trail) - env.qhead);
+      Vec.shrink env.trail_lim ((Vec.size env.trail_lim) - lvl);
+      Vec.shrink env.tenv_queue ((Vec.size env.tenv_queue) - lvl);
       if Options.get_cdcl_tableaux () then begin
         Vec.shrink
-          env.lazy_cnf_queue ((Vec.size env.lazy_cnf_queue) - lvl) true;
+          env.lazy_cnf_queue ((Vec.size env.lazy_cnf_queue) - lvl);
         Vec.shrink env.relevants_queue
-          ((Vec.size env.relevants_queue) - lvl) true
+          ((Vec.size env.relevants_queue) - lvl)
         [@ocaml.ppwarning "TODO: try to disable 'fill_with_dummy'"]
       end;
       (try
@@ -585,8 +587,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
   let max_level_in_clause (c : Atom.clause) =
     let max_lvl = ref 0 in
-    Vec.iter c.atoms (fun a ->
-        max_lvl := max !max_lvl a.var.level);
+    Vec.iter (fun (a : Atom.atom) ->
+        max_lvl := max !max_lvl a.var.level) c.atoms;
     !max_lvl
 
   let enqueue env (a : Atom.atom) lvl reason =
@@ -698,7 +700,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       with Conflict c -> assert (!res == C_none); res := C_bool c
     end;
     let dead_part = Vec.size watched - !new_sz_w in
-    Vec.shrink watched dead_part true
+    Vec.shrink watched dead_part
 
 
   let do_case_split env origin =
@@ -988,7 +990,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         incr j
       end
     done;
-    Vec.shrink vec (k + 1 - !j) true
+    Vec.shrink vec (k + 1 - !j)
 
 
   module HUC = Hashtbl.Make
@@ -1169,7 +1171,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     end
 
 
-  let record_learnt_clause env ~is_T_learn blevel learnt history size =
+  let record_learnt_clause env ~is_T_learn blevel learnt history =
     let curr_level = decision_level env in
     if not is_T_learn || Options.get_minimal_bj () ||
        blevel = curr_level then begin
@@ -1182,7 +1184,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       | fuip :: _ ->
         let name = Atom.fresh_lname () in
         let lclause =
-          Atom.make_clause name learnt vraie_form size true history
+          Atom.make_clause name learnt vraie_form true history
         in
         Vec.push env.learnts lclause;
         attach_clause env lclause;
@@ -1207,7 +1209,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     while !cond do
       if !c.learnt then clause_bump_activity env !c;
       history := !c :: !history;
-      Vec.iter !c.atoms (fun a ->
+      Vec.iter (fun (a : Atom.atom) ->
           assert (a.is_true || a.neg.is_true && a.var.level >= 0);
           if not a.var.seen && a.var.level > 0 then begin
             var_bump_activity env a.var;
@@ -1219,7 +1221,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
               blevel := max !blevel a.var.level
             end
           end
-        );
+        ) !c.atoms;
 
       while assert (!tr_ind >= 0);
         let v = (Vec.get env.trail !tr_ind).var in
@@ -1241,7 +1243,6 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     let learnt = SA.elements !learnt in
     let learnt = List.fast_sort (fun (a : Atom.atom) (b : Atom.atom) ->
         b.var.level - a.var.level) learnt in
-    let size = List.length learnt in
     let bj_level =
       if Options.get_minimal_bj () then
         match learnt with
@@ -1249,7 +1250,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         | a :: _ -> max 0 (a.var.level - 1)
       else !blevel
     in
-    bj_level, learnt, !history, size
+    bj_level, learnt, !history
 
   let fixable_with_simple_backjump (confl : Atom.clause) max_lvl lv =
     if not (Options.get_minimal_bj ()) then None
@@ -1288,19 +1289,19 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     match confl with
     | C_none -> assert false
     | C_theory dep ->
-      let atoms, sz, max_lvl, c_hist =
+      let atoms, max_lvl, c_hist =
         Ex.fold_atoms
-          (fun ex (acc, sz, max_lvl, c_hist) ->
+          (fun ex (acc, max_lvl, c_hist) ->
              match ex with
              | Ex.Literal a ->
                let c_hist = List.rev_append a.var.vpremise c_hist in
                let c_hist = match a.var.reason with
                  | None -> c_hist | Some r -> r:: c_hist
                in
-               if a.var.level = 0 then acc, sz, max_lvl, c_hist
-               else a.neg :: acc, sz + 1, max max_lvl a.var.level, c_hist
+               if a.var.level = 0 then acc, max_lvl, c_hist
+               else a.neg :: acc, max max_lvl a.var.level, c_hist
              | _ -> assert false (* TODO *)
-          ) dep ([], 0, 0, [])
+          ) dep ([], 0, [])
       in
       if atoms == [] || max_lvl == 0 then begin
         (* check_inconsistence_of dep; *)
@@ -1308,26 +1309,25 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         (* une conjonction de faits unitaires etaient deja unsat *)
       end;
       let name = Atom.fresh_dname() in
-      let c = Atom.make_clause name atoms vraie_form sz false c_hist in
+      let c = Atom.make_clause name atoms vraie_form false c_hist in
       c.removed <- true;
-      let blevel, learnt, history, size = conflict_analyze_aux env c max_lvl in
+      let blevel, learnt, history = conflict_analyze_aux env c max_lvl in
       cancel_until env blevel;
-      record_learnt_clause env ~is_T_learn:false blevel learnt history size
+      record_learnt_clause env ~is_T_learn:false blevel learnt history
 
     | C_bool c ->
       let max_lvl = ref 0 in
       let lv = ref [] in
-      Vec.iter c.atoms (fun a ->
+      Vec.iter (fun (a : Atom.atom) ->
           max_lvl := max !max_lvl a.var.level;
           lv := a.var :: !lv
-        );
+        ) c.atoms;
       if !max_lvl == 0 then report_b_unsat env [c];
       match fixable_with_simple_backjump c !max_lvl !lv with
       | None  ->
-        let blevel, learnt, history, size =
-          conflict_analyze_aux env c !max_lvl in
+        let blevel, learnt, history = conflict_analyze_aux env c !max_lvl in
         cancel_until env blevel;
-        record_learnt_clause env ~is_T_learn:false blevel learnt history size
+        record_learnt_clause env ~is_T_learn:false blevel learnt history
       | Some (a, blevel, propag_lvl) ->
         assert (a.neg.is_true);
         cancel_until env blevel;
@@ -1370,8 +1370,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
           res := SA.add (if a.is_true then a else a.neg) !res
 
         | Some r ->
-          Vec.iter r.atoms
-            (fun a -> if not (SA.mem a !seen) then Queue.push a q)
+          Vec.iter
+            (fun a -> if not (SA.mem a !seen) then Queue.push a q) r.atoms
       end
     done;
     raise (Last_UIP_reason !res)
@@ -1384,7 +1384,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
   let reason_of_conflict (confl_clause : Atom.clause) =
     let q = Queue.create () in
-    Vec.iter confl_clause.atoms (fun a -> Queue.push a q);
+    Vec.iter (fun a -> Queue.push a q) confl_clause.atoms;
     find_uip_reason q
 
   let rec propagate_and_stabilize env propagator conflictC strat =
@@ -1484,8 +1484,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         if Options.get_debug_sat () then
           Printer.print_dbg "[satml] decide: %a" Atom.pr_atom next;
         enqueue env next current_level None
-      | Some(c,sz) ->
-        record_learnt_clause env ~is_T_learn:true (decision_level env) c [] sz
+      | Some(c, _) ->
+        record_learnt_clause env ~is_T_learn:true (decision_level env) c []
         (* right decision level will be set inside record_learnt_clause *)
     done
 
@@ -1555,7 +1555,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     let init_name = string_of_int cnumber in
     let init0 =
       if Options.get_unsat_core () then
-        [Atom.make_clause init_name atoms f (List.length atoms) false []]
+        [Atom.make_clause init_name atoms f false []]
       else
         [] (* no deps if unsat cores generation is not enabled *)
     in
@@ -1575,14 +1575,13 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
               a.var.vid - b.var.vid) atoms, init
         else partition atoms init0
       in
-      let size = List.length atoms in
       match atoms with
       | [] ->
         report_b_unsat env init0;
 
       | a::b::_ ->
         let name = Atom.fresh_name () in
-        let clause = Atom.make_clause name atoms vraie_form size false init in
+        let clause = Atom.make_clause name atoms vraie_form false init in
         attach_clause env clause;
         Vec.push env.clauses clause;
         if Options.(get_debug_sat () && get_verbose ()) then
@@ -1828,8 +1827,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
   let pop env =
     (assert (not (Vec.is_empty env.increm_guards)));
-    let g = Vec.last env.increm_guards in
-    Vec.pop env.increm_guards;
+    let g = Vec.pop env.increm_guards in
     g.is_guard <- false;
     g.neg.is_guard <- false;
     assert (not g.var.na.is_true); (* atom not false *)

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -103,7 +103,7 @@ module type ATOM = sig
 
   val fresh_dname : unit -> string
 
-  val make_clause : string -> atom list -> E.t -> int -> bool ->
+  val make_clause : string -> atom list -> E.t -> bool ->
     premise-> clause
 
   (*val made_vars_info : unit -> int * var list*)
@@ -319,7 +319,7 @@ module Atom : ATOM = struct
       and pa =
         { var = var;
           lit = lit;
-          watched = Vec.make 10 dummy_clause;
+          watched = Vec.make 10 ~dummy:dummy_clause;
           neg = na;
           is_true = false;
           is_guard = false;
@@ -328,7 +328,7 @@ module Atom : ATOM = struct
       and na =
         { var = var;
           lit = E.neg lit;
-          watched = Vec.make 10 dummy_clause;
+          watched = Vec.make 10 ~dummy:dummy_clause;
           neg = pa;
           is_true = false;
           is_guard = false;
@@ -366,8 +366,8 @@ module Atom : ATOM = struct
     try (HT.find hcons.tbl (E.neg lit)).na
     with Not_found -> assert false
 
-  let make_clause name ali f sz_ali is_learnt premise =
-    let atoms = Vec.from_list ali sz_ali dummy_atom in
+  let make_clause name ali f is_learnt premise =
+    let atoms = Vec.of_list ali ~dummy:dummy_atom in
     { name  = name;
       atoms = atoms;
       removed = false;

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -265,11 +265,7 @@ module Atom : ATOM = struct
         (sign a) (a.var.vid+1) (value a) a.var.index E.print a.lit
         premise a.var.vpremise
 
-
-    let atoms_vec fmt vec =
-      for i = 0 to Vec.size vec - 1 do
-        Format.fprintf fmt "%a ; " atom (Vec.get vec i)
-      done
+    let atoms_vec = Vec.pp ~sep:";" atom
 
     let clause fmt { name; atoms=arr; cpremise=cp; _ } =
       Format.fprintf fmt "%s:{ %a} cpremise={{%a}}" name atoms_vec
@@ -414,11 +410,12 @@ module Atom : ATOM = struct
     | Some c ->
       let cpt = ref 0 in
       let l = ref [] in
-      for i = 0 to Vec.size c.atoms - 1 do
-        let b = Vec.get c.atoms i in
-        if eq_atom a b then incr cpt
-        else l := b :: !l
-      done;
+      Vec.iter (fun (atom : atom) ->
+          if eq_atom a atom then
+            incr cpt
+          else
+            l := atom :: !l
+        ) c.atoms;
       if !cpt <> 1 then begin
         Printer.print_err
           "cpt = %d@ a = %a@ c = %a"

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -265,7 +265,7 @@ module Atom : ATOM = struct
         (sign a) (a.var.vid+1) (value a) a.var.index E.print a.lit
         premise a.var.vpremise
 
-    let atoms_vec = Vec.pp ~sep:";" atom
+    let atoms_vec = Vec.pp atom
 
     let clause fmt { name; atoms=arr; cpremise=cp; _ } =
       Format.fprintf fmt "%s:{ %a} cpremise={{%a}}" name atoms_vec

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -100,7 +100,7 @@ module type ATOM = sig
 
   val fresh_dname : unit -> string
 
-  val make_clause : string -> atom list -> Expr.t -> int -> bool ->
+  val make_clause : string -> atom list -> Expr.t -> bool ->
     premise-> clause
 
   (*val made_vars_info : unit -> int * var list*)

--- a/src/lib/util/iheap.ml
+++ b/src/lib/util/iheap.ml
@@ -33,8 +33,9 @@ type t = {heap : int Vec.t; indices : int Vec.t }
 let dummy = -100
 
 let init sz =
-  { heap    =  Vec.init sz (fun i -> i) dummy;
-    indices =  Vec.init sz (fun i -> i) dummy}
+  let lst = List.init sz (fun i -> i) in
+  { heap    =  Vec.of_list lst ~dummy;
+    indices =  Vec.of_list lst ~dummy}
 
 let left i   = (i lsl 1) + 1 (* i*2 + 1 *)
 let right i  = (i + 1) lsl 1 (* (i+1)*2 *)
@@ -106,7 +107,7 @@ let filter s filt cmp =
     end
     else Vec.set s.indices (Vec.get s.heap i) (-1);
   done;
-  Vec.shrink s.heap (lim - !j) true;
+  Vec.shrink s.heap (lim - !j);
   for i = (lim / 2) - 1 downto 0 do
     percolate_down cmp s i
   done
@@ -146,6 +147,6 @@ let remove_min cmp ({heap=heap; indices=indices} as s) =
   Vec.set heap 0 (Vec.last heap); (*heap.last()*)
   Vec.set indices (Vec.get heap 0) 0;
   Vec.set indices x (-1);
-  Vec.pop s.heap;
+  ignore(Vec.pop s.heap);
   if Vec.size s.heap > 1 then percolate_down cmp s 0;
   x

--- a/src/lib/util/iheap.ml
+++ b/src/lib/util/iheap.ml
@@ -98,15 +98,15 @@ let increase cmp s n =
 
 let filter s filt cmp =
   let j = ref 0 in
+  Vec.iter (fun elt ->
+      if filt elt then begin
+        Vec.set s.heap !j elt;
+        Vec.set s.indices elt !j;
+        incr j
+      end
+      else Vec.set s.indices elt (-1)
+    ) s.heap;
   let lim = Vec.size s.heap in
-  for i = 0 to lim - 1 do
-    if filt (Vec.get s.heap i) then begin
-      Vec.set s.heap !j (Vec.get s.heap i);
-      Vec.set s.indices (Vec.get s.heap i) !j;
-      incr j;
-    end
-    else Vec.set s.indices (Vec.get s.heap i) (-1);
-  done;
   Vec.shrink s.heap (lim - !j);
   for i = (lim / 2) - 1 downto 0 do
     percolate_down cmp s i

--- a/src/lib/util/iheap.ml
+++ b/src/lib/util/iheap.ml
@@ -98,14 +98,15 @@ let increase cmp s n =
 
 let filter s filt cmp =
   let j = ref 0 in
-  Vec.iter (fun elt ->
-      if filt elt then begin
-        Vec.set s.heap !j elt;
-        Vec.set s.indices elt !j;
-        incr j
-      end
-      else Vec.set s.indices elt (-1)
-    ) s.heap;
+  for i = 0 to Vec.size s.heap - 1 do
+    let elt = Vec.get s.heap i in
+    if filt elt then begin
+      Vec.set s.heap !j elt;
+      Vec.set s.indices elt !j;
+      incr j
+    end
+    else Vec.set s.indices elt (-1)
+  done;
   let lim = Vec.size s.heap in
   Vec.shrink s.heap (lim - !j);
   for i = (lim / 2) - 1 downto 0 do

--- a/src/lib/util/vec.ml
+++ b/src/lib/util/vec.ml
@@ -34,11 +34,17 @@ type 'a t = {
   dummy: 'a;
 }
 
+let[@inline] size vec = vec.sz
+
 let make n ~dummy = {data = Array.make n dummy; sz = 0; dummy}
 
 let[@inline] create ~dummy = {data = [||]; sz = 0; dummy}
 
-let[@inline] clear vec = vec.sz <- 0
+let[@inline] clear vec =
+  for i = 0 to size vec - 1 do
+    Array.unsafe_set vec.data i vec.dummy
+  done;
+  vec.sz <- 0
 
 let[@inline] shrink vec i =
   assert (i >= 0);
@@ -58,8 +64,6 @@ let[@inline] pop vec =
 let[@inline] last vec =
   assert (vec.sz > 0);
   Array.unsafe_get vec.data (vec.sz - 1)
-
-let[@inline] size vec = vec.sz
 
 let[@inline] is_empty vec = vec.sz = 0
 

--- a/src/lib/util/vec.ml
+++ b/src/lib/util/vec.ml
@@ -139,7 +139,7 @@ let exists p vec =
   try
     for i = 0 to size vec - 1 do
       let elt = Array.unsafe_get vec.data i in
-      if p elt && not (elt == vec.dummy) then raise Terminate
+      if not (elt == vec.dummy) && p elt then raise Terminate
     done;
     false
   with Terminate -> true
@@ -155,8 +155,8 @@ let fold f acc vec =
   done;
   !acc
 
-let to_list a = Array.to_seq a.data |> List.of_seq
 let to_array a = Array.sub a.data 0 a.sz
+let to_list a = Array.to_seq (to_array a) |> List.of_seq
 
 let of_list l ~dummy : _ t =
   match l with

--- a/src/lib/util/vec.ml
+++ b/src/lib/util/vec.ml
@@ -163,6 +163,10 @@ let sort vec f : unit =
   Array.fast_sort f arr;
   vec.data <- arr
 
-let pp ?(sep=", ") pp fmt a =
-  let pp_sep fmt () = Format.fprintf fmt "%s@," sep in
-  Format.pp_print_list ~pp_sep pp fmt (to_list a)
+let internal_iter f vec =
+  for i = 0 to size vec - 1 do
+    f (Array.unsafe_get vec.data i)
+  done
+
+let pp pp_elt =
+  Fmt.iter ~sep:Fmt.comma internal_iter pp_elt |> Fmt.box

--- a/src/lib/util/vec.ml
+++ b/src/lib/util/vec.ml
@@ -78,7 +78,7 @@ let[@inline never] grow_to vec cap : unit =
   in
   assert (cap > vec.sz);
   let arr' = Array.make cap vec.dummy in
-  assert (Array.length vec.data > vec.sz);
+  assert (Array.length arr' > vec.sz);
   Array.blit vec.data 0 arr' 0 (Array.length vec.data);
   vec.data <- arr'
 

--- a/src/lib/util/vec.ml
+++ b/src/lib/util/vec.ml
@@ -148,7 +148,14 @@ let fold f acc vec =
   !acc
 
 let to_array a = Array.sub a.data 0 a.sz
-let to_list a = Array.to_seq (to_array a) |> List.of_seq
+let to_list vec = Array.to_seq (to_array vec) |> List.of_seq
+
+let to_rev_list { data; sz; _ } =
+  let l = ref [] in
+  for i = 0 to sz - 1 do
+    l := Array.unsafe_get data i :: !l
+  done;
+  !l
 
 let of_list l ~dummy : _ t =
   match l with

--- a/src/lib/util/vec.ml
+++ b/src/lib/util/vec.ml
@@ -28,147 +28,144 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a t = { mutable dummy: 'a; mutable data : 'a array; mutable sz : int }
+type 'a t = {
+  mutable data : 'a array;
+  mutable sz : int;
+  dummy: 'a;
+}
 
-let make capa d = {data = Array.make capa d; sz = 0; dummy = d}
+let make n ~dummy = {data = Array.make n dummy; sz = 0; dummy}
 
-let init capa f d =
-  {data = Array.init capa (fun i -> f i); sz = capa; dummy = d}
+let[@inline] create ~dummy = {data = [||]; sz = 0; dummy}
 
-let from_array data sz d = {data = data; sz = sz; dummy = d}
+let[@inline] clear vec = vec.sz <- 0
 
-let from_list l sz d =
-  let l = ref l in
-  let f_init _ = match !l with [] -> assert false | e::r -> l := r; e in
-  {data = Array.init sz f_init; sz = sz; dummy = d}
+let[@inline] shrink vec i =
+  assert (i >= 0);
+  assert (i <= vec.sz);
+  for j = vec.sz - i to vec.sz - 1 do
+    Array.unsafe_set vec.data j vec.dummy
+  done;
+  vec.sz <- vec.sz - i
 
-let clear s = s.sz <- 0
+let[@inline] pop vec =
+  assert (vec.sz > 0);
+  let x = Array.unsafe_get vec.data (vec.sz - 1) in
+  Array.unsafe_set vec.data (vec.sz - 1) vec.dummy;
+  vec.sz <- vec.sz - 1;
+  x
 
-let shrink t i fill_with_dummy =
-  assert (i >= 0 && i<=t.sz);
-  if fill_with_dummy then
-    for i = t.sz - i to t.sz - 1 do
-      t.data.(i) <- t.dummy
-    done;
-  t.sz <- t.sz - i
+let[@inline] last vec =
+  assert (vec.sz > 0);
+  Array.unsafe_get vec.data (vec.sz - 1)
 
-let pop t =
-  assert (t.sz >=1);
-  Array.unsafe_set t.data (t.sz-1) t.dummy;
-  t.sz <- t.sz - 1
+let[@inline] size vec = vec.sz
 
-let size t = t.sz
+let[@inline] is_empty vec = vec.sz = 0
 
-let is_empty t = t.sz = 0
+let[@inline] is_full vec = Array.length vec.data = vec.sz
 
-let grow_to t new_capa =
-  let data = t.data in
-  let capa = Array.length data in
-  if new_capa > capa then
-    t.data <-
-      Array.init new_capa
-        (fun i -> if i < capa then data.(i) else t.dummy)
+let[@inline] copy vec : _ t =
+  let data = Array.copy vec.data in
+  {vec with data}
 
-let grow_to_double_size t =
-  let n = max 1 (Array.length t.data) in grow_to t (2 * n)
+(* grow the array *)
 
-let grow_to_by_double t new_capa =
-  let new_capa = max 1 new_capa in
-  let data = t.data in
-  let capa = ref (max 1 (Array.length data)) in
-  while !capa < new_capa do capa := 2 * !capa done;
-  grow_to t !capa
+let[@inline never] grow_to vec cap : unit =
+  assert (Array.length vec.data < Sys.max_array_length);
+  let cap =
+    min Sys.max_array_length (max 4 cap)
+  in
+  let arr' = Array.make cap vec.dummy in
+  Array.blit vec.data 0 arr' 0 (Array.length vec.data);
+  vec.data <- arr';
+  assert (Array.length vec.data > vec.sz);
+  ()
 
+let[@inline never] grow_to_double_size vec : unit =
+  grow_to vec (2 * Array.length vec.data)
 
-let is_full t = Array.length t.data = t.sz
+let[@inline never] grow_to_by_double vec cap =
+  let cap = max 1 cap in
+  let c = ref (max 1 (Array.length vec.data)) in
+  while !c < cap do c := 2 * !c done;
+  grow_to vec !c
 
-let push t e =
-  (* Printer.print_dbg
-     "push; sz = %d et capa=%d@." t.sz (Array.length t.data);*)
-  if is_full t then grow_to_double_size t;
-  t.data.(t.sz) <- e;
-  t.sz <- t.sz + 1
+let[@inline] push vec x : unit =
+  if is_full vec then grow_to_double_size vec;
+  Array.unsafe_set vec.data vec.sz x;
+  vec.sz <- vec.sz + 1
 
-let push_none t =
-  if is_full t then grow_to_double_size t;
-  t.data.(t.sz) <- t.dummy;
-  t.sz <- t.sz + 1
+let[@inline] get vec i =
+  assert (0 <= i && i < vec.sz);
+  let res = Array.unsafe_get vec.data i  in
+  if res == vec.dummy then raise Not_found;
+  res
 
-let last t =
-  let e = t.data.(t.sz - 1) in
-  assert (not (e == t.dummy));
-  e
+let[@inline] set vec i elt =
+  assert (not (elt == vec.dummy));
+  vec.data.(i) <- elt;
+  vec.sz <- max vec.sz (i+1)
 
-let get t i =
-  assert (i < t.sz);
-  let e = t.data.(i) in
-  if e == t.dummy then raise Not_found
-  else e
+let[@inline] fast_remove vec i =
+  assert (i>= 0 && i < vec.sz);
+  Array.unsafe_set vec.data i @@ Array.unsafe_get vec.data (vec.sz - 1);
+  vec.sz <- vec.sz - 1
 
-let set t i v =
-  t.data.(i) <- v;
-  t.sz <- max t.sz (i + 1)
-
-let set_size t sz = t.sz <- sz
-
-let copy t =
-  let data = t.data in
-  let len = Array.length data in
-  let data = Array.init len (fun i -> data.(i)) in
-  { data=data; sz=t.sz; dummy = t.dummy }
-
-let move_to t t' =
-  let data = t.data in
-  let len = Array.length data in
-  let data = Array.init len (fun i -> data.(i)) in
-  t'.data <- data;
-  t'.sz <- t.sz
-
-
-let remove t e =
-  let j = ref 0 in
-  while (!j < t.sz && not (t.data.(!j) == e)) do incr j done;
-  assert (!j < t.sz);
-  for i = !j to t.sz - 2 do t.data.(i) <- t.data.(i+1) done;
-  pop t
-
-
-let fast_remove t e =
-  let j = ref 0 in
-  while (!j < t.sz && not (t.data.(!j) == e)) do incr j done;
-  assert (!j < t.sz);
-  t.data.(!j) <- last t;
-  pop t
-
-
-let sort t f =
-  let sub_arr = Array.sub t.data 0 t.sz in
-  Array.fast_sort f sub_arr;
-  t.data <- sub_arr
-
-let iter vec f =
-  for i = 0 to size vec - 1 do
-    f (get vec i)
+let filter_in_place f vec =
+  let i = ref 0 in
+  while !i < size vec do
+    if f (Array.unsafe_get vec.data !i) then incr i else fast_remove vec !i
   done
-(*
-template<class V, class T>
-static inline void remove(V& ts, const T& t)
-{
-    int j = 0;
-    for (; j < ts.size() && ts[j] != t; j++);
-    assert(j < ts.size());
-    ts[j] = ts.last();
-    ts.pop();
-}
-#endif
 
-template<class V, class T>
-static inline bool find(V& ts, const T& t)
-{
-    int j = 0;
-    for (; j < ts.size() && ts[j] != t; j++);
-    return j < ts.size();
-}
+let sort vec f : unit =
+  let sub_arr =
+    if is_full vec then vec.data else Array.sub vec.data 0 vec.sz
+  in
+  Array.fast_sort f sub_arr;
+  vec.data <- sub_arr
 
-#endif
-*)
+let[@inline] iteri f vec =
+  for i = 0 to size vec - 1 do
+    let elt = Array.unsafe_get vec.data i in
+    if not (elt == vec.dummy) then
+      f i elt
+  done
+
+let[@inline] iter f = iteri (fun _ elt -> f elt)
+
+let exists p vec =
+  let exception Terminate in
+  try
+    for i = 0 to size vec - 1 do
+      let elt = Array.unsafe_get vec.data i in
+      if p elt && not (elt == vec.dummy) then raise Terminate
+    done;
+    false
+  with Terminate -> true
+
+let for_all p vec = not @@ exists (fun x -> not @@ p x) vec
+
+let fold f acc vec =
+  let acc = ref acc in
+  for i = 0 to size vec - 1 do
+    let elt = Array.unsafe_get vec.data i in
+    if not (elt == vec.dummy) then
+      acc := f !acc elt
+  done;
+  !acc
+
+let to_list a = Array.to_seq a.data |> List.of_seq
+let to_array a = Array.sub a.data 0 a.sz
+
+let of_list l ~dummy : _ t =
+  match l with
+  | [] -> create ~dummy
+  | _ :: tl ->
+    let v = make (List.length tl+1) ~dummy in
+    List.iter (push v) l;
+    v
+
+let pp ?(sep=", ") pp fmt a =
+  let pp_sep fmt () = Format.fprintf fmt "%s@," sep in
+  Format.pp_print_list ~pp_sep pp fmt (to_list a)

--- a/src/lib/util/vec.mli
+++ b/src/lib/util/vec.mli
@@ -46,6 +46,9 @@ val create : dummy:'a -> 'a t
 val to_list : 'a t -> 'a list
 (** Returns the list of elements of the vector. *)
 
+val to_rev_list : 'a t -> 'a list
+(** Returns the list of elements of the vector in reversed order. *)
+
 val to_array : 'a t -> 'a array
 
 val of_list : 'a list -> dummy:'a -> 'a t

--- a/src/lib/util/vec.mli
+++ b/src/lib/util/vec.mli
@@ -51,7 +51,7 @@ val to_array : 'a t -> 'a array
 val of_list : 'a list -> dummy:'a -> 'a t
 
 val clear : 'a t -> unit
-(** Set size to zero, doesn't free elements. *)
+(** [clear vec] sets the size of [vec] to zero and free the elements. *)
 
 val shrink : 'a t -> int -> unit
 (** [shrink vec sz] resets size of [vec] to [sz] and frees its elements.
@@ -112,7 +112,7 @@ val iteri : (int -> 'a -> unit) -> 'a t -> unit
 (** Iterate on elements with their index. Ignore dummy elements. *)
 
 val fold : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
-(** Fold over elements. Ignore dummy elements. Ignore dummy elements. *)
+(** Fold over elements. Ignore dummy elements. *)
 
 val exists : ('a -> bool) -> 'a t -> bool
 (** Does there exist a non-dummy element that satisfies the predicate? *)
@@ -120,9 +120,6 @@ val exists : ('a -> bool) -> 'a t -> bool
 val for_all : ('a -> bool) -> 'a t -> bool
 (** Do all non-dummy elements satisfy the predicate? *)
 
-val pp :
-  ?sep:string ->
-  (Format.formatter -> 'a -> unit) ->
-  Format.formatter -> 'a t -> unit
-(** [pp ~sep pp_elt fmt vec] prints on the formatter [fmt]
-    all the elements of [vec] using the printer [pp_elt] for each element. *)
+val pp : 'a Fmt.t -> 'a t Fmt.t
+(** [pp pp_elt ppf vec] prints on the formatter [ppf] all the elements of [vec]
+    using the printer [pp_elt]. Dummy values are also printed. *)

--- a/src/lib/util/vec.mli
+++ b/src/lib/util/vec.mli
@@ -33,7 +33,7 @@ type 'a t = {
   mutable sz : int;
   dummy: 'a;
 }
-(** Type of sparse vectors of 'a elements. *)
+(** Type of vectors of 'a elements. *)
 
 val make : int -> dummy:'a -> 'a t
 (** [make cap dummy] creates a new vector filled with [dummy]. The vector
@@ -82,11 +82,12 @@ val push : 'a t -> 'a -> unit
 (** Push element into the vector. *)
 
 val get : 'a t -> int -> 'a
-(** get the element at the given index, or
-    @raise Invalid_argument if the index is not valid. *)
+(** Get the element at the given index, or
+    @raise Invalid_argument if the index is not valid.
+    @raise Not_found if the retrieved value is dummy. *)
 
 val set : 'a t -> int -> 'a -> unit
-(** set the element at the given index, either already set or the first
+(** Set the element at the given index, either already set or the first
     free slot if [not (is_full vec)], or
     @raise Invalid_argument if the index is not valid. *)
 
@@ -98,8 +99,8 @@ val fast_remove : 'a t -> int -> unit
     (swap with last element). *)
 
 val filter_in_place : ('a -> bool) -> 'a t -> unit
-(** [filter_in_place f v] removes from [v] the elements that do
-    not satisfy [f] *)
+(** [filter_in_place p vec] removes from [vec] the elements that do
+    not satisfy [p]. *)
 
 val sort : 'a t -> ('a -> 'a -> int) -> unit
 (** Sort in place the vector. *)

--- a/src/plugins/fm-simplex/simplex.ml
+++ b/src/plugins/fm-simplex/simplex.ml
@@ -393,8 +393,8 @@ module Simplex (C : Coef_Type) = struct
       !l2, !l1
 
 
-    let sbt = Vec.make 107 ((0,0),{a=[||]; c=Q.zero, Q.zero})
-    let zsbt = Vec.make 107 (-2)
+    let sbt = Vec.make 107 ~dummy:((0,0),{a=[||]; c=Q.zero, Q.zero})
+    let zsbt = Vec.make 107 ~dummy:(-2)
 
     let solve_zero_arr zsbt zsbt_inv a =
       Array.iter

--- a/src/plugins/fm-simplex/simplex.ml
+++ b/src/plugins/fm-simplex/simplex.ml
@@ -372,26 +372,19 @@ module Simplex (C : Coef_Type) = struct
     let z_subst_in_p p s = p.a.(s) <- s, C.zero
 
     let normalize_poly p sbt zsbt =
-      for i = 0 to Vec.size sbt - 1 do subst_in_p p (Vec.get sbt i) done;
-      for i = 0 to Vec.size zsbt - 1 do z_subst_in_p p (Vec.get zsbt i) done
+      Vec.iter (subst_in_p p) sbt;
+      Vec.iter (z_subst_in_p p) zsbt
 
     let normalize_sbt sbt zsbt =
-      for i = 0 to Vec.size sbt - 1 do
-        for j = 0 to Vec.size zsbt - 1 do
-          z_subst_in_p (snd (Vec.get sbt i)) (Vec.get zsbt j)
-        done;
-      done;
+      Vec.iter (fun elt ->
+          Vec.iter (z_subst_in_p (snd elt)) zsbt
+        ) sbt;
       for i = Vec.size sbt - 1 downto 1 do
         for j = i - 1 downto 0 do
           subst_in_p (snd (Vec.get sbt j)) (Vec.get sbt i)
         done;
       done;
-      let l1 = ref [] in
-      let l2 = ref [] in
-      for i = 0 to Vec.size sbt - 1  do l1 := (Vec.get sbt i)  :: !l1 done;
-      for i = 0 to Vec.size zsbt - 1 do l2 := (Vec.get zsbt i) :: !l2 done;
-      !l2, !l1
-
+      Vec.to_list zsbt, Vec.to_list sbt
 
     let sbt = Vec.make 107 ~dummy:((0,0),{a=[||]; c=Q.zero, Q.zero})
     let zsbt = Vec.make 107 ~dummy:(-2)

--- a/src/plugins/fm-simplex/simplex.ml
+++ b/src/plugins/fm-simplex/simplex.ml
@@ -384,7 +384,7 @@ module Simplex (C : Coef_Type) = struct
           subst_in_p (snd (Vec.get sbt j)) (Vec.get sbt i)
         done;
       done;
-      Vec.to_list zsbt, Vec.to_list sbt
+      Vec.to_rev_list zsbt, Vec.to_rev_list sbt
 
     let sbt = Vec.make 107 ~dummy:((0,0),{a=[||]; c=Q.zero, Q.zero})
     let zsbt = Vec.make 107 ~dummy:(-2)


### PR DESCRIPTION
This PR is proposition for a new vector module.

Basically, I replace the old module `Vec.ml` by its clean version from mSAT repository. 
I also replaced as much as I can the for-loops in the codebase by iterators from the Vec module.
Yet, as I noticed months ago, I cannot abstract the vector type because of this code in Satml: 
```ocaml
  let rec dummy_var =
    { vid = -101;
      pa = dummy_atom;
      na = dummy_atom;
      level = -1;
      index = -1;
      reason = None;
      weight = -1.;
      sweight = 0;
      seen = false;
      vpremise = [] }
  and dummy_atom =
    { var = dummy_var;
      timp = 0;
      lit = dummy_lit;
      watched = {Vec.dummy=dummy_clause; data=[||]; sz=0};
      neg = dummy_atom;
      is_true = false;
      is_guard = false;
      aid = -102 }
  and dummy_clause =
    { name = "";
      atoms = {Vec.dummy=dummy_atom; data=[||]; sz=0};
      activity = -1.;
      removed = false;
      learnt = false;
      cpremise = [];
      form = vraie_form }
```