### PR TITLE
Set option support

### DIFF
--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -581,9 +581,12 @@ let mk_opts file () () debug_flags ddebug_flags dddebug_flags rule () halt_opt
     `Ok true
   end
 
-let mk_output_channel_opt std_output err_output mdl_output =
+let mk_output_channel_opt std_output deprecated_std_output err_output
+    deprecated_err_output mdl_output =
   Options.Output.(of_filename std_output |> set_std);
+  Options.Output.(of_filename deprecated_std_output |> set_std);
   Options.Output.(of_filename err_output |> set_err);
+  Options.Output.(of_filename deprecated_err_output |> set_err);
   Options.Output.(of_filename mdl_output |> set_mdl);
   `Ok()
 
@@ -1207,27 +1210,32 @@ let parse_theory_opt =
 let parse_fmt_opt =
 
   let docs = s_fmt in
+  let docv = "CHANNEL" in
 
-  let std_output =
+  let std_output, deprecated_std_output =
     let doc =
       Format.sprintf
         "Set the standard output used by default to print the results,
     models and unsat cores. Possible values are %s."
         (Arg.doc_alts ["stdout"; "stderr"; "<filename>"])
     in
-    Arg.(value & opt string "stdout" & info ["std-output"] ~docv:"CHANNEL"
-           ~docs ~doc)
+    let deprecated = "this option is depreciated. Please use --std-output." in
+    Arg.(value & opt string "stdout" & info ["std-output"] ~docv ~docs ~doc),
+    Arg.(value & opt string "stdout" & info ~deprecated ["std-formatter"]
+           ~docv ~docs ~doc)
   in
 
-  let err_output =
+  let err_output, deprecate_err_output =
     let doc =
       Format.sprintf
         "Set the error output used by default to print error, debug and
          warning informations. Possible values are %s."
         (Arg.doc_alts ["stdout"; "stderr"; "<filename>"])
     in
-    Arg.(value & opt string "stderr" & info ["err-output"] ~docv:"CHANNEL"
-           ~docs ~doc)
+    let deprecated = "this option is depreciated. Please use --err-output." in
+    Arg.(value & opt string "stderr" & info ["err-output"] ~docv ~docs ~doc),
+    Arg.(value & opt string "stderr" & info ~deprecated ["err-formatter"]
+           ~docv ~docs ~doc)
   in
 
   let model_output =
@@ -1236,12 +1244,11 @@ let parse_fmt_opt =
         "Set the output used for the model generation. Possible values are %s."
         (Arg.doc_alts ["stdout"; "stderr"; "<filename>"])
     in
-    Arg.(value & opt string "stdout" & info ["model-output"] ~docv:"CHANNEL"
-           ~docs ~doc)
+    Arg.(value & opt string "stdout" & info ["model-output"] ~docv ~docs ~doc)
   in
 
-  Term.(ret (const mk_output_channel_opt $ std_output $ err_output
-             $ model_output))
+  Term.(ret (const mk_output_channel_opt $ std_output $ deprecated_std_output
+             $ err_output $ deprecate_err_output $ model_output))
 
 let main =
 

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -582,9 +582,9 @@ let mk_opts file () () debug_flags ddebug_flags dddebug_flags rule () halt_opt
   end
 
 let mk_output_channel_opt std_output err_output mdl_output =
-  Options.Output.(create_channel std_output |> set_std);
-  Options.Output.(create_channel err_output |> set_err);
-  Options.Output.(create_channel mdl_output |> set_mdl);
+  Options.Output.(of_filename std_output |> set_std);
+  Options.Output.(of_filename err_output |> set_err);
+  Options.Output.(of_filename mdl_output |> set_mdl);
   `Ok()
 
 (* Custom sections *)

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -1321,7 +1321,7 @@ let main =
   Cmd.v info term
 
 let parse_cmdline_arguments () =
-  at_exit Options.Output.at_exit;
+  at_exit Options.Output.close_all;
   let r = Cmd.eval_value main in
   match r with
   | Ok `Ok true -> ()

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -125,31 +125,6 @@ let model_type_printer fmt format =
 let model_type_conv =
   Arg.conv ~docv:"MTYP" (model_type_parser, model_type_printer)
 
-type formatter = Stdout | Stderr | Other of string
-
-let value_of_fmt = function
-  | Stdout -> Format.std_formatter
-  | Stderr -> Format.err_formatter
-  | Other s ->
-    let oc = open_out s in
-    at_exit (fun () -> close_out oc);
-    Format.formatter_of_out_channel oc
-
-let formatter_parser = function
-  | "stdout" -> Ok Stdout
-  | "stderr" -> Ok Stderr
-  | s -> Ok (Other s)
-
-let formatter_to_string = function
-  | Stdout -> "stdout"
-  | Stderr -> "stderr"
-  | Other s -> s
-
-let formatter_printer fmt formatter =
-  Format.fprintf fmt "%s" (formatter_to_string formatter)
-
-let formatter_conv = Arg.conv ~docv:"FMT" (formatter_parser, formatter_printer)
-
 module Rule = struct
   type t = RParsing | RTyping | RSat | RCC | RArith | RNone
 
@@ -603,11 +578,10 @@ let mk_opts file () () debug_flags ddebug_flags dddebug_flags rule () halt_opt
     `Ok true
   end
 
-let mk_fmt_opt std_fmt err_fmt mdl_fmt
-  =
-  set_std_fmt (value_of_fmt std_fmt);
-  set_err_fmt (value_of_fmt err_fmt);
-  set_fmt_mdl (value_of_fmt mdl_fmt);
+let mk_output_channel_opt std_output err_output mdl_output =
+  Options.Output.(create_channel std_output |> set_std);
+  Options.Output.(create_channel err_output |> set_err);
+  Options.Output.(create_channel mdl_output |> set_mdl);
   `Ok()
 
 (* Custom sections *)
@@ -1231,32 +1205,40 @@ let parse_fmt_opt =
 
   let docs = s_fmt in
 
-  let std_formatter =
-    let doc = Format.sprintf
-        "Set the standard formatter used by default to output the results,
+  let std_output =
+    let doc =
+      Format.sprintf
+        "Set the standard output used by default to print the results,
     models and unsat cores. Possible values are %s."
-        (Arg.doc_alts ["stdout"; "stderr"; "<filename>"]) in
-    Arg.(value & opt formatter_conv Stdout & info ["std-formatter"] ~docs ~doc)
+        (Arg.doc_alts ["stdout"; "stderr"; "<filename>"])
+    in
+    Arg.(value & opt string "stdout" & info ["std-output"] ~docv:"CHANNEL"
+           ~docs ~doc)
   in
 
-  let err_formatter =
-    let doc = Format.sprintf
-        "Set the error formatter used by default to output error, debug and
+  let err_output =
+    let doc =
+      Format.sprintf
+        "Set the error output used by default to print error, debug and
          warning informations. Possible values are %s."
-        (Arg.doc_alts ["stdout"; "stderr"; "<filename>"]) in
-    Arg.(value & opt formatter_conv Stderr & info ["err-formatter"] ~docs ~doc)
+        (Arg.doc_alts ["stdout"; "stderr"; "<filename>"])
+    in
+    Arg.(value & opt string "stderr" & info ["err-output"] ~docv:"CHANNEL"
+           ~docs ~doc)
   in
 
   let model_output =
-    let doc = Format.sprintf
+    let doc =
+      Format.sprintf
         "Set the output used for the model generation. Possible values are %s."
-        (Arg.doc_alts ["stdout"; "stderr"; "<filename>"]) in
-    Arg.(value & opt formatter_conv Stdout & info ["model-output"] ~docs ~doc)
+        (Arg.doc_alts ["stdout"; "stderr"; "<filename>"])
+    in
+    Arg.(value & opt string "stdout" & info ["model-output"] ~docv:"CHANNEL"
+           ~docs ~doc)
   in
 
-  Term.(ret (const mk_fmt_opt $
-             std_formatter $ err_formatter $ model_output
-            ))
+  Term.(ret (const mk_output_channel_opt $ std_output $ err_output
+             $ model_output))
 
 let main =
 
@@ -1336,6 +1318,7 @@ let main =
   Cmd.v info term
 
 let parse_cmdline_arguments () =
+  at_exit Options.Output.at_exit;
   let r = Cmd.eval_value main in
   match r with
   | Ok `Ok true -> ()

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -583,11 +583,11 @@ let mk_opts file () () debug_flags ddebug_flags dddebug_flags rule () halt_opt
 
 let mk_output_channel_opt std_output deprecated_std_output err_output
     deprecated_err_output mdl_output =
-  Options.Output.(of_filename std_output |> set_std);
-  Options.Output.(of_filename deprecated_std_output |> set_std);
-  Options.Output.(of_filename err_output |> set_err);
-  Options.Output.(of_filename deprecated_err_output |> set_err);
-  Options.Output.(of_filename mdl_output |> set_mdl);
+  Options.Output.(create_channel std_output |> set_std);
+  Options.Output.(create_channel deprecated_std_output |> set_std);
+  Options.Output.(create_channel err_output |> set_err);
+  Options.Output.(create_channel deprecated_err_output |> set_err);
+  Options.Output.(create_channel mdl_output |> set_mdl);
   `Ok()
 
 (* Custom sections *)

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -388,6 +388,8 @@ let mk_limit_opt age_bound fm_cross_limit timelimit_interpretation
 let mk_models_opt b =
   if b then begin
     set_interpretation ILast;
+    (* TODO: The generation of models is supported only with the SAT solver
+       Tableaux. Remove this line after merging the OptimAE PR. *)
     set_sat_solver Tableaux
   end;
   `Ok ()

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -389,7 +389,8 @@ let mk_models_opt b =
   if b then begin
     set_interpretation ILast;
     (* TODO: The generation of models is supported only with the SAT solver
-       Tableaux. Remove this line after merging the OptimAE PR. *)
+       Tableaux. Remove this line after merging the OptimAE PR.
+       See https://github.com/OCamlPro/alt-ergo/pull/553 *)
     set_sat_solver Tableaux
   end;
   `Ok ()

--- a/src/bin/common/signals_profiling.ml
+++ b/src/bin/common/signals_profiling.ml
@@ -29,7 +29,6 @@
 (**************************************************************************)
 
 open AltErgoLib
-open Options
 
 let timers = Timers.empty ()
 
@@ -39,7 +38,8 @@ let init_sigterm_6 () =
   (* what to do with Ctrl+C ? *)
   Sys.set_signal Sys.sigint(*-6*)
     (Sys.Signal_handle (fun _ ->
-         if Options.get_profiling() then Profiling.switch (get_fmt_err ())
+         if Options.get_profiling() then
+           Profiling.switch (Options.Output.get_fmt_err ())
          else begin
            Printer.print_wrn "User wants me to stop.";
            Printer.print_std "unknown";
@@ -58,7 +58,7 @@ let init_sigterm_11_9 () =
            (Sys.Signal_handle
               (fun _ ->
                  Profiling.print true (Steps.get_steps ())
-                   timers (get_fmt_err ());
+                   timers (Options.Output.get_fmt_err ());
                  exit 1
               )
            )
@@ -71,7 +71,8 @@ let init_sigterm_21 () =
     Sys.set_signal Sys.sigprof (*-21*)
       (Sys.Signal_handle
          (fun _ ->
-            Profiling.print false (Steps.get_steps ()) timers (get_fmt_err ());
+            Profiling.print false (Steps.get_steps ()) timers
+              (Options.Output.get_fmt_err ());
          )
       )
 

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -297,7 +297,7 @@ let main () =
     | ":produce-models", Symbol { name = Simple "true"; _ } ->
       (* TODO: The generation of models is supported only with the SAT
          solver Tableaux. Remove this line after merging the OptimAE
-         PR. *)
+         PR. See https://github.com/OCamlPro/alt-ergo/pull/553 *)
       if Stdlib.(Options.get_sat_solver () = Tableaux) then
         Options.set_interpretation ILast
       else Printer.print_wrn "%a The generation of models is not supported \

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -386,6 +386,9 @@ let main () =
           ) st
 
       | {contents = `Set_option _; _ } ->
+        (* These statements shouldn't be run again during the processing
+           of check-sat statements. Thus, we put them in the local stack
+           which is flushed after each check-sat statement. *)
         let cnf =
           D_cnf.make (State.get State.logic_file st).loc [] td
         in

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -81,7 +81,7 @@ let main () =
         Profiling.print true
           (Steps.get_steps ())
           (Signals_profiling.get_timers ())
-          (get_fmt_err ())
+          (Options.Output.get_fmt_err ())
     with Util.Timeout ->
       if not (Options.get_timelimit_per_goal()) then exit 142
   in
@@ -384,6 +384,16 @@ let main () =
             let solver_ctx = State.get solver_ctx_key st in
             { solver_ctx with local = [] }
           ) st
+
+      | {contents = `Set_option _; _ } ->
+        let cnf =
+          D_cnf.make (State.get State.logic_file st).loc [] td
+        in
+        State.set solver_ctx_key (
+          let solver_ctx = State.get solver_ctx_key st in
+          { solver_ctx with local = cnf @ solver_ctx.local }
+        ) st
+
       | _ ->
         (* TODO:
            - Separate statements that should be ignored from unsupported

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -307,9 +307,8 @@ let main () =
     | ":produce-models", Symbol { name = Simple "false"; _ } ->
       Options.set_interpretation INone
     | ":produce-unsat-cores", Symbol { name = Simple "true"; _ } ->
-      (* TODO: The generation of models is supported only with the SAT
-         solver Tableaux. Remove this line after merging the OptimAE
-         PR. *)
+      (* The generation of unsat core is supported only with the SAT
+         solver Tableaux. *)
       if Stdlib.(Options.get_sat_solver () = Tableaux) then
         Options.set_unsat_core true
       else Printer.print_wrn "%a The generation of unsat cores is not \
@@ -344,9 +343,7 @@ let main () =
       | ":produce-proofs"
       | ":produce-unsat-assumptions"
       | ":print-success"
-      | ":random-seed"
-      | ":reproducible-resource-limit"
-      | ":verbosity"), _
+      | ":random-seed"), _
       -> Printer.print_wrn "unsupported option %s" name
     | _ -> Printer.print_wrn "unsupported option %s" name
   in

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -289,10 +289,10 @@ let main () =
   let handle_option st_loc name (value : DStd.Term.t) =
     match name, value.term with
     | ":regular-output-channel", Symbol { name = Simple name; _ } ->
-      Options.Output.create_channel name
+      Options.Output.of_filename name
       |> Options.Output.set_regular
     | ":diagnostic-output-channel", Symbol { name = Simple name; _ } ->
-      Options.Output.create_channel name
+      Options.Output.of_filename name
       |> Options.Output.set_diagnostic
     | ":produce-models", Symbol { name = Simple "true"; _ } ->
       (* TODO: The generation of models is supported only with the SAT

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -289,10 +289,10 @@ let main () =
   let handle_option st_loc name (value : DStd.Term.t) =
     match name, value.term with
     | ":regular-output-channel", Symbol { name = Simple name; _ } ->
-      Options.Output.of_filename name
+      Options.Output.create_channel name
       |> Options.Output.set_regular
     | ":diagnostic-output-channel", Symbol { name = Simple name; _ } ->
-      Options.Output.of_filename name
+      Options.Output.create_channel name
       |> Options.Output.set_diagnostic
     | ":produce-models", Symbol { name = Simple "true"; _ } ->
       (* TODO: The generation of models is supported only with the SAT

--- a/src/bin/gui/main_gui.ml
+++ b/src/bin/gui/main_gui.ml
@@ -499,7 +499,7 @@ let update_status image label buttonclean env s steps =
     else
       Printer.print_std "@{<C.F_Green>Valid@} (%2.4f) (%d)" time steps;
     if get_unsat_core () then begin
-      Printer.print_fmt (Options.get_fmt_usc ()) "unsat-core:@ %a"
+      Printer.print_fmt (Options.Output.get_fmt_usc ()) "unsat-core:@ %a"
         (Explanation.print_unsat_core ~tab:true) dep;
       show_used_lemmas env dep
     end;

--- a/src/bin/js/worker_js.ml
+++ b/src/bin/js/worker_js.ml
@@ -42,8 +42,9 @@ type 'a state = {
 }
 
 (* If the buffer is not empty split the string in strings at each newline *)
-let check_buffer_content b =
-  let buf_cont = Buffer.contents b in
+let check_buffer_content (buf, output) =
+  Format.pp_print_flush (Options.Output.to_formatter output) ();
+  let buf_cont = Buffer.contents buf in
   if String.equal buf_cont "" then
     None
   else
@@ -67,18 +68,18 @@ let main worker_id content =
   try
     (* Create buffer for each formatter
        The content of this buffers are then retrieved and send as results *)
-    let buf_std, output_std = create_buffer () in
-    Options.Output.set_std output_std;
-    let buf_err, output_err = create_buffer () in
-    Options.Output.set_err output_err;
-    let buf_wrn, output_wrn = create_buffer () in
-    Options.Output.set_wrn output_wrn;
-    let buf_dbg, output_dbg = create_buffer () in
-    Options.Output.set_dbg output_dbg;
-    let buf_mdl, output_mdl = create_buffer () in
-    Options.Output.set_mdl output_mdl;
-    let buf_usc, output_usc = create_buffer () in
-    Options.Output.set_usc output_usc;
+    let buf_std = create_buffer () in
+    Options.Output.set_std (snd buf_std);
+    let buf_err = create_buffer () in
+    Options.Output.set_err (snd buf_err);
+    let buf_wrn = create_buffer () in
+    Options.Output.set_wrn (snd buf_wrn);
+    let buf_dbg = create_buffer () in
+    Options.Output.set_dbg (snd buf_dbg);
+    let buf_mdl = create_buffer () in
+    Options.Output.set_mdl (snd buf_mdl);
+    let buf_usc = create_buffer () in
+    Options.Output.set_usc (snd buf_usc);
 
     (* Status updated regarding if AE succed or failed
        (error or steplimit reached) *)

--- a/src/bin/js/worker_js.ml
+++ b/src/bin/js/worker_js.ml
@@ -43,7 +43,7 @@ type 'a state = {
 
 (* If the buffer is not empty split the string in strings at each newline *)
 let check_buffer_content b =
-  let buf_cont = Options.Output.contents b in
+  let buf_cont = Buffer.contents b in
   if String.equal buf_cont "" then
     None
   else
@@ -55,22 +55,30 @@ let check_context_content c =
   | [] -> None
   | _ -> Some c
 
+let create_buffer () =
+  let buf = Buffer.create 10 in
+  let output =
+    Format.formatter_of_buffer buf
+    |> Options.Output.of_formatter
+  in
+  buf, output
+
 let main worker_id content =
   try
     (* Create buffer for each formatter
        The content of this buffers are then retrieved and send as results *)
-    let buf_std = Options.Output.create_buffer () in
-    Options.Output.set_std buf_std;
-    let buf_err = Options.Output.create_buffer () in
-    Options.Output.set_err buf_err;
-    let buf_wrn = Options.Output.create_buffer () in
-    Options.Output.set_wrn buf_wrn;
-    let buf_dbg = Options.Output.create_buffer () in
-    Options.Output.set_dbg buf_dbg;
-    let buf_mdl = Options.Output.create_buffer () in
-    Options.Output.set_dbg buf_mdl;
-    let buf_usc = Options.Output.create_buffer () in
-    Options.Output.set_dbg buf_usc;
+    let buf_std, output_std = create_buffer () in
+    Options.Output.set_std output_std;
+    let buf_err, output_err = create_buffer () in
+    Options.Output.set_err output_err;
+    let buf_wrn, output_wrn = create_buffer () in
+    Options.Output.set_wrn output_wrn;
+    let buf_dbg, output_dbg = create_buffer () in
+    Options.Output.set_dbg output_dbg;
+    let buf_mdl, output_mdl = create_buffer () in
+    Options.Output.set_mdl output_mdl;
+    let buf_usc, output_usc = create_buffer () in
+    Options.Output.set_usc output_usc;
 
     (* Status updated regarding if AE succed or failed
        (error or steplimit reached) *)

--- a/src/bin/js/worker_js.ml
+++ b/src/bin/js/worker_js.ml
@@ -281,6 +281,7 @@ let main worker_id content =
     and the corresponding set of options
     Return a couple of list for status (one per goal) and errors *)
 let () =
+  at_exit Options.Output.close_all;
   Worker.set_onmessage (fun (json_file,json_options) ->
       Lwt_js_events.async (fun () ->
           let filename,worker_id,filecontent =

--- a/src/bin/js/worker_js.ml
+++ b/src/bin/js/worker_js.ml
@@ -43,7 +43,7 @@ type 'a state = {
 
 (* If the buffer is not empty split the string in strings at each newline *)
 let check_buffer_content b =
-  let buf_cont = Buffer.contents b in
+  let buf_cont = Options.Output.contents b in
   if String.equal buf_cont "" then
     None
   else
@@ -59,18 +59,18 @@ let main worker_id content =
   try
     (* Create buffer for each formatter
        The content of this buffers are then retrieved and send as results *)
-    let buf_std = Buffer.create 10 in
-    Options.set_fmt_std (Format.formatter_of_buffer buf_std);
-    let buf_err = Buffer.create 10 in
-    Options.set_fmt_err (Format.formatter_of_buffer buf_err);
-    let buf_wrn = Buffer.create 10 in
-    Options.set_fmt_wrn (Format.formatter_of_buffer buf_wrn);
-    let buf_dbg = Buffer.create 10 in
-    Options.set_fmt_dbg (Format.formatter_of_buffer buf_dbg);
-    let buf_mdl = Buffer.create 10 in
-    Options.set_fmt_mdl (Format.formatter_of_buffer buf_mdl);
-    let buf_usc = Buffer.create 10 in
-    Options.set_fmt_usc (Format.formatter_of_buffer buf_usc);
+    let buf_std = Options.Output.create_buffer () in
+    Options.Output.set_std buf_std;
+    let buf_err = Options.Output.create_buffer () in
+    Options.Output.set_err buf_err;
+    let buf_wrn = Options.Output.create_buffer () in
+    Options.Output.set_wrn buf_wrn;
+    let buf_dbg = Options.Output.create_buffer () in
+    Options.Output.set_dbg buf_dbg;
+    let buf_mdl = Options.Output.create_buffer () in
+    Options.Output.set_dbg buf_mdl;
+    let buf_usc = Options.Output.create_buffer () in
+    Options.Output.set_dbg buf_usc;
 
     (* Status updated regarding if AE succed or failed
        (error or steplimit reached) *)

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1416,6 +1416,33 @@ let make dloc_file acc stmt =
       aux [] dcl;
       acc
 
+    | {contents = `Set_option
+           { term =
+               App ({ term = Symbol { name = Simple name; _ }; _ }, [value]); _
+           }; _ }
+      ->
+      let handle_option name (value : DStd.Term.t) =
+        match name, value.term with
+        | (":diagnostic-output-channel"
+          | ":global-declarations"
+          | ":interactive-mode"
+          | ":produce-assertions"
+          | ":produce-assignments"
+          | ":produce-models"
+          | ":produce-proofs"
+          | ":produce-unsat-assumptions"
+          | ":produce-unsat-cores"
+          | ":print-success"
+          | ":random-seed"
+          | ":regular-output-channel"
+          | ":reproducible-resource-limit"
+          | ":verbosity"), _
+          -> Printer.print_wrn "Unsupported option %s" name
+        | _ -> Printer.print_wrn "Unsupported option %s" name
+      in
+      handle_option name value;
+      acc
+
     | _ -> acc
     (* TODO:
        - Separate statements that should be ignored from unsupported

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1178,7 +1178,8 @@ let handle_option acc st_loc name (value : DStd.Term.t) =
         Options.set_sat_solver Tableaux
       end
     else Printer.print_wrn "%a The generation of models is not supported yet \
-                            for the current SAT solver. Please choose the SAT solver Tableaux."
+                            for the current SAT solver. Please choose the SAT \
+                            solver Tableaux."
         Loc.report st_loc;
     acc
   | ":produce-models", Symbol { name = Simple "false"; _ } ->

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1425,12 +1425,12 @@ let make dloc_file acc stmt =
         let st_loc = dl_to_ael dloc_file loc in
         match name, value.term with
         | ":regular-output-channel", Symbol { name = Simple name; _ } ->
-          let cout = C.cout_of_string name in
-          let st_decl = C.SetOption (OutputChannel (`Regular, cout)) in
+          let st_decl = Commands.SetOption (OutputChannel (`Regular, name)) in
           C.{st_decl; st_loc} :: acc
         | ":diagnostic-output-channel", Symbol { name = Simple name; _ } ->
-          let cout = C.cout_of_string name in
-          let st_decl = C.SetOption (OutputChannel (`Diagnostic, cout)) in
+          let st_decl =
+            Commands.SetOption (OutputChannel (`Diagnostic, name))
+          in
           C.{st_decl; st_loc} :: acc
         | (":global-declarations"
           | ":interactive-mode"

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1154,75 +1154,6 @@ and make_trigger ?(loc = Loc.dummy) ~name_base ~decl_kind
   in
   E.clean_trigger ~in_theory name trigger
 
-let print_wrn_opt ~name loc ty value =
-  Printer.print_wrn "%a The option %s expects a %s, got %a"
-    Loc.report loc name ty DStd.Term.print value
-
-let handle_option acc st_loc name (value : DStd.Term.t) =
-  match name, value.term with
-  | ":regular-output-channel", Symbol { name = Simple name; _ } ->
-    let st_decl = Commands.SetOption (OutputChannel (`Regular, name)) in
-    C.{st_decl; st_loc} :: acc
-  | ":diagnostic-output-channel", Symbol { name = Simple name; _ } ->
-    let st_decl =
-      Commands.SetOption (OutputChannel (`Diagnostic, name))
-    in
-    C.{st_decl; st_loc} :: acc
-  | ":produce-models", Symbol { name = Simple "true"; _ } ->
-    if Stdlib.(Options.get_sat_solver () = Tableaux) then
-      begin
-        Options.set_interpretation ILast;
-        (* TODO: The generation of models is supported only with the SAT
-           solver Tableaux. Remove this line after merging the OptimAE
-           PR. *)
-        Options.set_sat_solver Tableaux
-      end
-    else Printer.print_wrn "%a The generation of models is not supported yet \
-                            for the current SAT solver. Please choose the SAT \
-                            solver Tableaux."
-        Loc.report st_loc;
-    acc
-  | ":produce-models", Symbol { name = Simple "false"; _ } ->
-    Options.set_interpretation INone; acc
-  | ":produce-unsat-cores", Symbol { name = Simple "true"; _ } ->
-    Options.set_unsat_core true; acc
-  | ":produce-unsat-cores", Symbol { name = Simple "false"; _ } ->
-    Options.set_unsat_core false; acc
-  | (":produce-models" | ":produce-unsat-cores" as name), _ ->
-    print_wrn_opt ~name st_loc "bool" value; acc
-  | ":verbosity", Symbol { name = Simple level; _ } ->
-    begin
-      match int_of_string_opt level with
-      | Some i ->
-        let st_decl = Commands.SetOption (Verbosity i) in
-        C.{st_decl; st_loc} :: acc
-      | None ->
-        print_wrn_opt ~name:":verbosity" st_loc "int" value;
-        acc
-    end
-  | ":reproducible-resource-limit", Symbol { name = Simple level; _ } ->
-    begin
-      match int_of_string_opt level with
-      | Some i ->
-        let st_decl = Commands.SetOption (ReproducibleResourceLimit i) in
-        C.{st_decl; st_loc} :: acc
-      | None ->
-        print_wrn_opt ~name:":reproducible-resource-limit" st_loc "int" value;
-        acc
-    end
-  | (":global-declarations"
-    | ":interactive-mode"
-    | ":produce-assertions"
-    | ":produce-assignments"
-    | ":produce-proofs"
-    | ":produce-unsat-assumptions"
-    | ":print-success"
-    | ":random-seed"
-    | ":reproducible-resource-limit"
-    | ":verbosity"), _
-    -> Printer.print_wrn "unsupported option %s" name; acc
-  | _ -> Printer.print_wrn "unsupported option %s" name; acc
-
 (** Preprocesses the body of a goal by:
     - removing the top-level universal quantifiers and considering their
       quantified variables as uninsterpreted symbols.
@@ -1483,14 +1414,6 @@ let make dloc_file acc stmt =
       in
       aux [] dcl;
       acc
-
-    | {contents = `Set_option
-           { term =
-               App ({ term = Symbol { name = Simple name; _ }; _ }, [value]); _
-           }; loc; _ }
-      ->
-      let st_loc = dl_to_ael dloc_file loc in
-      handle_option acc st_loc name value
 
     | _ -> acc
     (* TODO:

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -143,6 +143,18 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     if Options.get_unsat_core () then Ex.singleton (Ex.RootDep {name;f;loc})
     else Ex.empty
 
+  let set_output_fmt typ cout =
+    let fmt =
+      match cout with
+      | `Stdout -> Format.std_formatter
+      | `Stderr -> Format.err_formatter
+      | `Channel cout ->
+        open_out cout |> Format.formatter_of_out_channel
+    in
+    match typ with
+    | `Regular -> Options.set_std_fmt fmt
+    | `Diagnostic -> Options.set_err_fmt fmt
+
   let process_decl print_status used_context consistent_dep_stack
       ((env, consistent, dep) as acc) d =
     try
@@ -157,6 +169,16 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
             ~max:n ~elt:() ~init:(consistent,dep)
         in
         SAT.pop env n, consistent, dep
+      | SetOption opt ->
+        begin
+          let _ =
+            match opt with
+            | Verbosity _ | PrintSuccess _ | ReproducibleResourceLimit _ ->
+              Printer.print_wrn "unsupported option %a" Commands.print_opt opt
+            | OutputChannel (typ, cout) -> set_output_fmt typ cout
+          in
+          env, consistent, dep
+        end
       | Assume(n, f, mf) ->
         let is_hyp = try (Char.equal '@' n.[0]) with _ -> false in
         if not is_hyp && unused_context n used_context then

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -167,7 +167,13 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
         begin
           let _ =
             match opt with
-            | Verbosity _ | PrintSuccess _ | ReproducibleResourceLimit _ ->
+            | Verbosity i ->
+              if i > 0 then Options.set_verbose true
+              else Options.set_verbose false
+            | ReproducibleResourceLimit i ->
+              if i > 0 then Options.set_timelimit_per_goal true
+              else Options.set_timelimit_per_goal false
+            | PrintSuccess _ ->
               Printer.print_wrn "unsupported option %a" Commands.print_opt opt
             | OutputChannel (typ, name) -> set_output typ name
           in

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -143,17 +143,11 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     if Options.get_unsat_core () then Ex.singleton (Ex.RootDep {name;f;loc})
     else Ex.empty
 
-  let set_output_fmt typ cout =
-    let fmt =
-      match cout with
-      | `Stdout -> Format.std_formatter
-      | `Stderr -> Format.err_formatter
-      | `Channel cout ->
-        open_out cout |> Format.formatter_of_out_channel
-    in
+  let set_output typ name =
+    let output = Options.Output.create_channel name in
     match typ with
-    | `Regular -> Options.set_std_fmt fmt
-    | `Diagnostic -> Options.set_err_fmt fmt
+    | `Regular -> Options.Output.set_regular output
+    | `Diagnostic -> Options.Output.set_diagnostic output
 
   let process_decl print_status used_context consistent_dep_stack
       ((env, consistent, dep) as acc) d =
@@ -175,7 +169,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
             match opt with
             | Verbosity _ | PrintSuccess _ | ReproducibleResourceLimit _ ->
               Printer.print_wrn "unsupported option %a" Commands.print_opt opt
-            | OutputChannel (typ, cout) -> set_output_fmt typ cout
+            | OutputChannel (typ, name) -> set_output typ name
           in
           env, consistent, dep
         end
@@ -313,7 +307,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
          not (get_debug_unsat_core()) &&
          not (get_save_used_context())
       then
-        Printer.print_fmt (Options.get_fmt_usc ())
+        Printer.print_fmt (Options.Output.get_fmt_usc ())
           "unsat-core:@,%a@."
           (Ex.print_unsat_core ~tab:true) dep;
       check_status_consistency status;

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -143,12 +143,6 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     if Options.get_unsat_core () then Ex.singleton (Ex.RootDep {name;f;loc})
     else Ex.empty
 
-  let set_output typ name =
-    let output = Options.Output.create_channel name in
-    match typ with
-    | `Regular -> Options.Output.set_regular output
-    | `Diagnostic -> Options.Output.set_diagnostic output
-
   let process_decl print_status used_context consistent_dep_stack
       ((env, consistent, dep) as acc) d =
     try
@@ -163,22 +157,6 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
             ~max:n ~elt:() ~init:(consistent,dep)
         in
         SAT.pop env n, consistent, dep
-      | SetOption opt ->
-        begin
-          let _ =
-            match opt with
-            | Verbosity i ->
-              if i > 0 then Options.set_verbose true
-              else Options.set_verbose false
-            | ReproducibleResourceLimit i ->
-              if i > 0 then Options.set_timelimit_per_goal true
-              else Options.set_timelimit_per_goal false
-            | PrintSuccess _ ->
-              Printer.print_wrn "unsupported option %a" Commands.print_opt opt
-            | OutputChannel (typ, name) -> set_output typ name
-          in
-          env, consistent, dep
-        end
       | Assume(n, f, mf) ->
         let is_hyp = try (Char.equal '@' n.[0]) with _ -> false in
         if not is_hyp && unused_context n used_context then

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1166,18 +1166,19 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     begin
       match !latest_saved_env with
       | None ->
-        Printer.print_fmt (Options.get_fmt_mdl ())
+        Printer.print_fmt (Options.Output.get_fmt_mdl ())
           "@[<v 0>[FunSat]@, \
            It seems that no model has been computed so far.@,\
            You may need to change your model generation strategy@,\
            or to increase your timeout.@]"
       | Some env ->
-        Printer.print_fmt (Options.get_fmt_mdl ())
+        Printer.print_fmt (Options.Output.get_fmt_mdl ())
           "@[<v 0>[FunSat]@, \
            A model has been computed. However, I failed \
            while computing it so may be incorrect.@]";
         let prop_model = extract_prop_model ~complete_model:true env in
-        Th.output_concrete_model (Options.get_fmt_mdl ()) ~prop_model env.tbox;
+        Th.output_concrete_model (Options.Output.get_fmt_mdl ()) ~prop_model
+          env.tbox;
     end;
     return_function ()
 
@@ -1193,7 +1194,8 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     Options.Time.unset_timeout ~is_gui:(Options.get_is_gui());
 
     let prop_model = extract_prop_model ~complete_model:true env in
-    Th.output_concrete_model (Options.get_fmt_mdl ()) ~prop_model env.tbox;
+    Th.output_concrete_model (Options.Output.get_fmt_mdl ()) ~prop_model
+      env.tbox;
 
     terminated_normally := true;
     return_function env

--- a/src/lib/structures/commands.ml
+++ b/src/lib/structures/commands.ml
@@ -30,18 +30,11 @@
 
 (* Sat entry *)
 
-type cout = [`Stdout | `Stderr | `Channel of string]
-
-let cout_of_string = function
-  | "stdout" -> `Stdout
-  | "stderr" -> `Stderr
-  | str -> `Channel str
-
 type opt =
   | Verbosity of int
   | PrintSuccess of bool
   | ReproducibleResourceLimit of int
-  | OutputChannel of [`Regular | `Diagnostic] * cout
+  | OutputChannel of [`Regular | `Diagnostic] * string
 
 type sat_decl_aux =
   | Assume of string * Expr.t * bool
@@ -58,23 +51,16 @@ type sat_tdecl = {
   st_decl : sat_decl_aux
 }
 
-let print_cout fmt =
-  let open Format in
-  function
-  | `Stdout -> fprintf fmt "<stdout>"
-  | `Stderr -> fprintf fmt "<stderr>"
-  | `Channel cout -> fprintf fmt "%s" cout
-
 let print_opt fmt =
   let open Format in
   function
   | Verbosity i -> fprintf fmt "verbosity: %i" i
   | PrintSuccess b -> fprintf fmt "print-success: %B" b
   | ReproducibleResourceLimit i -> fprintf fmt "reproduce-resource-limit: %i" i
-  | OutputChannel (`Regular, cout) ->
-    fprintf fmt "regular-output-channel: %a" print_cout cout
-  | OutputChannel (`Diagnostic, cout) ->
-    fprintf fmt "diagnostic-output-channel: %a" print_cout cout
+  | OutputChannel (`Regular, name) ->
+    fprintf fmt "regular-output-channel: %s" name
+  | OutputChannel (`Diagnostic, name) ->
+    fprintf fmt "diagnostic-output-channel: %s" name
 
 let print_aux fmt = function
   | Assume (name, e, b) ->

--- a/src/lib/structures/commands.ml
+++ b/src/lib/structures/commands.ml
@@ -30,12 +30,6 @@
 
 (* Sat entry *)
 
-type opt =
-  | Verbosity of int
-  | PrintSuccess of bool
-  | ReproducibleResourceLimit of int
-  | OutputChannel of [`Regular | `Diagnostic] * string
-
 type sat_decl_aux =
   | Assume of string * Expr.t * bool
   | PredDef of Expr.t * string (*name of the predicate*)
@@ -44,23 +38,11 @@ type sat_decl_aux =
   | ThAssume of Expr.th_elt
   | Push of int
   | Pop of int
-  | SetOption of opt
 
 type sat_tdecl = {
   st_loc : Loc.t;
   st_decl : sat_decl_aux
 }
-
-let print_opt fmt =
-  let open Format in
-  function
-  | Verbosity i -> fprintf fmt "verbosity: %i" i
-  | PrintSuccess b -> fprintf fmt "print-success: %B" b
-  | ReproducibleResourceLimit i -> fprintf fmt "reproduce-resource-limit: %i" i
-  | OutputChannel (`Regular, name) ->
-    fprintf fmt "regular-output-channel: %s" name
-  | OutputChannel (`Diagnostic, name) ->
-    fprintf fmt "diagnostic-output-channel: %s" name
 
 let print_aux fmt = function
   | Assume (name, e, b) ->
@@ -80,7 +62,6 @@ let print_aux fmt = function
     Format.fprintf fmt "th assume %a" Expr.print_th_elt t
   | Push n -> Format.fprintf fmt "Push %d" n
   | Pop n ->  Format.fprintf fmt "Pop %d" n
-  | SetOption opt -> Format.fprintf fmt "set-option %a" print_opt opt
 
 let print fmt decl = print_aux fmt decl.st_decl
 

--- a/src/lib/structures/commands.mli
+++ b/src/lib/structures/commands.mli
@@ -30,12 +30,6 @@
 
 (* Sat entry *)
 
-type opt =
-  | Verbosity of int
-  | PrintSuccess of bool
-  | ReproducibleResourceLimit of int
-  | OutputChannel of [`Regular | `Diagnostic] * string
-
 type sat_decl_aux =
   | Assume of string * Expr.t * bool
   | PredDef of Expr.t * string (*name of the predicate*)
@@ -44,7 +38,6 @@ type sat_decl_aux =
   | ThAssume of Expr.th_elt
   | Push of int
   | Pop of int
-  | SetOption of opt
 
 type sat_tdecl = {
   st_loc : Loc.t;
@@ -52,4 +45,3 @@ type sat_tdecl = {
 }
 
 val print : Format.formatter -> sat_tdecl -> unit
-val print_opt : Format.formatter -> opt -> unit

--- a/src/lib/structures/commands.mli
+++ b/src/lib/structures/commands.mli
@@ -30,15 +30,11 @@
 
 (* Sat entry *)
 
-type cout = [`Stdout | `Stderr | `Channel of string]
-
-val cout_of_string : string -> cout
-
 type opt =
   | Verbosity of int
   | PrintSuccess of bool
   | ReproducibleResourceLimit of int
-  | OutputChannel of [`Regular | `Diagnostic] * cout
+  | OutputChannel of [`Regular | `Diagnostic] * string
 
 type sat_decl_aux =
   | Assume of string * Expr.t * bool

--- a/src/lib/structures/commands.mli
+++ b/src/lib/structures/commands.mli
@@ -28,19 +28,27 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open Typed
-
-
 (* Sat entry *)
+
+type cout = [`Stdout | `Stderr | `Channel of string]
+
+val cout_of_string : string -> cout
+
+type opt =
+  | Verbosity of int
+  | PrintSuccess of bool
+  | ReproducibleResourceLimit of int
+  | OutputChannel of [`Regular | `Diagnostic] * cout
 
 type sat_decl_aux =
   | Assume of string * Expr.t * bool
   | PredDef of Expr.t * string (*name of the predicate*)
-  | RwtDef of (Expr.t rwt_rule) list
+  | RwtDef of (Expr.t Typed.rwt_rule) list
   | Query of string *  Expr.t * Ty.goal_sort
   | ThAssume of Expr.th_elt
   | Push of int
   | Pop of int
+  | SetOption of opt
 
 type sat_tdecl = {
   st_loc : Loc.t;
@@ -48,3 +56,4 @@ type sat_tdecl = {
 }
 
 val print : Format.formatter -> sat_tdecl -> unit
+val print_opt : Format.formatter -> opt -> unit

--- a/src/lib/structures/errors.ml
+++ b/src/lib/structures/errors.ml
@@ -231,21 +231,21 @@ let report_run_error fmt = function
 
 let report fmt = function
   | Parser_error s ->
-    Options.print_output_format fmt
+    Options.pp_comment fmt
       (Format.sprintf "Parser Error: %s" s);
   | Lexical_error (l,s) ->
     Loc.report fmt l;
-    Options.print_output_format fmt
+    Options.pp_comment fmt
       (Format.sprintf "Lexical Error: %s" s);
   | Syntax_error (l,s) ->
     Loc.report fmt l;
-    Options.print_output_format fmt
+    Options.pp_comment fmt
       (Format.sprintf "Syntax Error: %s" s);
   | Typing_error (l,e) ->
     Loc.report fmt l;
-    Options.print_output_format fmt "Typing Error: ";
+    Options.pp_comment fmt "Typing Error: ";
     report_typing_error fmt e
   | Run_error e ->
-    Options.print_output_format fmt "Fatal Error: ";
+    Options.pp_comment fmt "Fatal Error: ";
     report_run_error fmt e
   | Warning_as_error -> ()

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -38,7 +38,7 @@ module Output = struct
 
   let of_formatter fmt = Fmt fmt
 
-  let of_filename = function
+  let create_channel = function
     | "stdout" -> Stdout
     | "stderr" -> Stderr
     | str ->

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -33,13 +33,10 @@ module Output = struct
     | Stdout
     | Stderr
     | Channel of out_channel * Format.formatter
-    | Buffer of Buffer.t * Format.formatter
+    | Fmt of Format.formatter
     | Invalid
 
-  let create_buffer () =
-    let buf = Buffer.create 10 in
-    let fmt = Format.formatter_of_buffer buf in
-    Buffer (buf, fmt)
+  let of_formatter fmt = Fmt fmt
 
   let of_filename = function
     | "stdout" -> Stdout
@@ -56,20 +53,16 @@ module Output = struct
   let mdl_output = ref Stdout
   let usc_output = ref Stdout
 
-  let contents = function
-    | Stdout | Stderr | Channel _ | Invalid -> ""
-    | Buffer (buf, _) -> Buffer.contents buf
-
   let get_fmt = function
     | Stdout -> Format.std_formatter
     | Stderr -> Format.err_formatter
     | Channel (_, fmt) -> fmt
-    | Buffer (_, fmt) -> fmt
+    | Fmt fmt -> fmt
     | Invalid -> assert false
 
   let close o =
     match o with
-    | Stdout | Stderr | Buffer _ ->
+    | Stdout | Stderr | Fmt _ ->
       Format.pp_print_flush (get_fmt o) ();
     | Channel (cout, _) ->
       Format.pp_print_flush (get_fmt o) ();

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -80,7 +80,7 @@ module Output = struct
     close !output;
     output := o
 
-  let at_exit () =
+  let close_all () =
     set_output std_output Invalid;
     set_output err_output Invalid;
     set_output wrn_output Invalid;

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -41,7 +41,7 @@ module Output = struct
     let fmt = Format.formatter_of_buffer buf in
     Buffer (buf, fmt)
 
-  let create_channel = function
+  let of_filename = function
     | "stdout" -> Stdout
     | "stderr" -> Stderr
     | str ->
@@ -652,7 +652,7 @@ let set_file_for_js filename =
   set_js_mode true
 
 (* Printer **)
-let print_output_format fmt msg =
+let pp_comment fmt msg =
   match get_output_format () with
   | Smtlib2 -> Format.fprintf fmt "; %s" msg;
   | Native | Why3 | Unknown _ -> Format.fprintf fmt "%s" msg

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -68,10 +68,13 @@ module Output = struct
     | Invalid -> assert false
 
   let close o =
-    Format.pp_print_flush (get_fmt o) ();
     match o with
-    | Stdout | Stderr | Buffer _ | Invalid -> ()
-    | Channel (cout, _) -> close_out cout
+    | Stdout | Stderr | Buffer _ ->
+      Format.pp_print_flush (get_fmt o) ();
+    | Channel (cout, _) ->
+      Format.pp_print_flush (get_fmt o) ();
+      close_out cout
+    | Invalid -> ()
 
   let set_output output o =
     close !output;

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -38,6 +38,13 @@ module Output = struct
 
   let of_formatter fmt = Fmt fmt
 
+  let to_formatter = function
+    | Stdout -> Format.std_formatter
+    | Stderr -> Format.err_formatter
+    | Channel (_, fmt) -> fmt
+    | Fmt fmt -> fmt
+    | Invalid -> assert false
+
   let create_channel = function
     | "stdout" -> Stdout
     | "stderr" -> Stderr
@@ -53,19 +60,12 @@ module Output = struct
   let mdl_output = ref Stdout
   let usc_output = ref Stdout
 
-  let get_fmt = function
-    | Stdout -> Format.std_formatter
-    | Stderr -> Format.err_formatter
-    | Channel (_, fmt) -> fmt
-    | Fmt fmt -> fmt
-    | Invalid -> assert false
-
   let close o =
     match o with
     | Stdout | Stderr | Fmt _ ->
-      Format.pp_print_flush (get_fmt o) ();
+      Format.pp_print_flush (to_formatter o) ();
     | Channel (cout, _) ->
-      Format.pp_print_flush (get_fmt o) ();
+      Format.pp_print_flush (to_formatter o) ();
       close_out cout
     | Invalid -> ()
 
@@ -91,12 +91,12 @@ module Output = struct
     set_output wrn_output o;
     set_output dbg_output o
 
-  let get_fmt_std () = get_fmt !std_output
-  let get_fmt_err () = get_fmt !err_output
-  let get_fmt_wrn () = get_fmt !wrn_output
-  let get_fmt_dbg () = get_fmt !dbg_output
-  let get_fmt_mdl () = get_fmt !mdl_output
-  let get_fmt_usc () = get_fmt !usc_output
+  let get_fmt_std () = to_formatter !std_output
+  let get_fmt_err () = to_formatter !err_output
+  let get_fmt_wrn () = to_formatter !wrn_output
+  let get_fmt_dbg () = to_formatter !dbg_output
+  let get_fmt_mdl () = to_formatter !mdl_output
+  let get_fmt_usc () = to_formatter !usc_output
 
   let set_std = set_output std_output
   let set_err = set_output err_output

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1054,6 +1054,7 @@ val get_is_gui : unit -> bool
 (** This functions are use to print or set the output used to print debug or
     error informations *)
 
+(** Output channels manager. *)
 module Output : sig
   type t = private
     | Stdout
@@ -1063,62 +1064,71 @@ module Output : sig
     | Invalid
 
   val create_buffer : unit -> t
+  (** Create a new buffer. *)
+
   val create_channel : string -> t
+  (** [create_channel filename] create an out channel on the file [filename].
+      If the file does not exist, the procedure creates it. An existant file
+      is truncated to zero length. *)
+
   val contents : t -> string
+  (** Retrieve the content of the underlying buffer if any. *)
 
   val at_exit : unit -> unit
+  (** This function is run at exit in order to flush and close of the
+      remaining output channels. *)
 
+  val set_regular : t -> unit
   (** Set the regular output channel used by default to output results,
       models and unsat cores. *)
-  val set_regular : t -> unit
   (** Default to [Format.std_formatter] *)
 
+  val set_diagnostic : t -> unit
   (** Set the diagnostic output channel used by default to output errors,
       debug and warning informations. *)
-  val set_diagnostic : t -> unit
   (** Default to [Format.err_formatter] *)
 
-  (** Value specifying the formatter used to output results. *)
   val get_fmt_std : unit -> Format.formatter
+  (** Value specifying the formatter used to output results. *)
   (** Default to [Format.std_formatter] *)
 
-  (** Value specifying the formatter used to output errors. *)
   val get_fmt_err : unit -> Format.formatter
+  (** Value specifying the formatter used to output errors. *)
   (** Default to [Format.err_formatter] *)
 
-  (** Value specifying the formatter used to output warnings. *)
   val get_fmt_wrn : unit -> Format.formatter
+  (** Value specifying the formatter used to output warnings. *)
   (** Default to [Format.err_formatter] *)
 
-  (** Value specifying the formatter used to output debug informations. *)
   val get_fmt_dbg : unit -> Format.formatter
+  (** Value specifying the formatter used to output debug informations. *)
   (** Default to [Format.err_formatter] *)
 
-  (** Value specifying the formatter used to output models. *)
   val get_fmt_mdl : unit -> Format.formatter
+  (** Value specifying the formatter used to output models. *)
   (** Default to [Format.std_formatter] *)
 
-  (** Value specifying the formatter used to output unsat cores. *)
   val get_fmt_usc : unit -> Format.formatter
+  (** Value specifying the formatter used to output unsat cores. *)
   (** Default to [Format.std_formatter] *)
 
-  (** Set [fmt_std] accessible with {!val:get_fmt_std} *)
   val set_std : t -> unit
+  (** Set [fmt_std] accessible with {!val:get_fmt_std} *)
 
-  (** Set [fmt_err] accessible with {!val:get_fmt_err} *)
   val set_err : t -> unit
+  (** Set [fmt_err] accessible with {!val:get_fmt_err} *)
 
-  (** Set [fmt_wrn] accessible with {!val:get_fmt_wrn} *)
   val set_wrn : t -> unit
+  (** Set [fmt_wrn] accessible with {!val:get_fmt_wrn} *)
 
-  (** Set [fmt_dbg] accessible with {!val:get_fmt_dbg} *)
   val set_dbg : t -> unit
+  (** Set [fmt_dbg] accessible with {!val:get_fmt_dbg} *)
 
-  (** Set [fmt_mdl] accessible with {!val:get_fmt_mdl} *)
   val set_mdl : t -> unit
+  (** Set [fmt_mdl] accessible with {!val:get_fmt_mdl} *)
 
-  (** Set [fmt_usc] accessible with {!val:get_fmt_usc} *)
   val set_usc : t -> unit
+  (** Set [fmt_usc] accessible with {!val:get_fmt_usc} *)
 end
 
 (** Print message as comment in the corresponding output format *)

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1074,9 +1074,8 @@ module Output : sig
   val contents : t -> string
   (** Retrieve the content of the underlying buffer if any. *)
 
-  val at_exit : unit -> unit
-  (** This function is run at exit in order to flush and close of the
-      remaining output channels. *)
+  val close_all : unit -> unit
+  (** Flushing and closing all the remaining output channels. *)
 
   val set_regular : t -> unit
   (** Set the regular output channel used by default to output results,

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1051,60 +1051,75 @@ val get_is_gui : unit -> bool
 
 
 (** {3 Printer and formatter } *)
-(** This functions are use to print or set the formatter used to output results
-    debug or error informations *)
+(** This functions are use to print or set the output used to print debug or
+    error informations *)
+
+module Output : sig
+  type t = private
+    | Stdout
+    | Stderr
+    | Channel of out_channel * Format.formatter
+    | Buffer of Buffer.t * Format.formatter
+    | Invalid
+
+  val create_buffer : unit -> t
+  val create_channel : string -> t
+  val contents : t -> string
+
+  val at_exit : unit -> unit
+
+  (** Set the regular output channel used by default to output results,
+      models and unsat cores. *)
+  val set_regular : t -> unit
+  (** Default to [Format.std_formatter] *)
+
+  (** Set the diagnostic output channel used by default to output errors,
+      debug and warning informations. *)
+  val set_diagnostic : t -> unit
+  (** Default to [Format.err_formatter] *)
+
+  (** Value specifying the formatter used to output results. *)
+  val get_fmt_std : unit -> Format.formatter
+  (** Default to [Format.std_formatter] *)
+
+  (** Value specifying the formatter used to output errors. *)
+  val get_fmt_err : unit -> Format.formatter
+  (** Default to [Format.err_formatter] *)
+
+  (** Value specifying the formatter used to output warnings. *)
+  val get_fmt_wrn : unit -> Format.formatter
+  (** Default to [Format.err_formatter] *)
+
+  (** Value specifying the formatter used to output debug informations. *)
+  val get_fmt_dbg : unit -> Format.formatter
+  (** Default to [Format.err_formatter] *)
+
+  (** Value specifying the formatter used to output models. *)
+  val get_fmt_mdl : unit -> Format.formatter
+  (** Default to [Format.std_formatter] *)
+
+  (** Value specifying the formatter used to output unsat cores. *)
+  val get_fmt_usc : unit -> Format.formatter
+  (** Default to [Format.std_formatter] *)
+
+  (** Set [fmt_std] accessible with {!val:get_fmt_std} *)
+  val set_std : t -> unit
+
+  (** Set [fmt_err] accessible with {!val:get_fmt_err} *)
+  val set_err : t -> unit
+
+  (** Set [fmt_wrn] accessible with {!val:get_fmt_wrn} *)
+  val set_wrn : t -> unit
+
+  (** Set [fmt_dbg] accessible with {!val:get_fmt_dbg} *)
+  val set_dbg : t -> unit
+
+  (** Set [fmt_mdl] accessible with {!val:get_fmt_mdl} *)
+  val set_mdl : t -> unit
+
+  (** Set [fmt_usc] accessible with {!val:get_fmt_usc} *)
+  val set_usc : t -> unit
+end
 
 (** Print message as comment in the corresponding output format *)
 val print_output_format: Format.formatter -> string -> unit
-
-(** Set the std formatter used by default to output the results [fmt_std],
-    model [fmt_mdl] and unsat core [fmt_usc]. *)
-val set_std_fmt : Format.formatter -> unit
-(** Default to [Format.std_formatter] *)
-
-(** Set the err formatter used by default to output error [fmt_err],
-    debug [fmt_dbg] and warning [fmt_wrn] informations. *)
-val set_err_fmt : Format.formatter -> unit
-(** Default to [Format.err_formatter] *)
-
-(** Value specifying the formatter used to output results *)
-val get_fmt_std : unit -> Format.formatter
-(** Default to [Format.std_formatter] *)
-
-(** Value specifying the formatter used to output errors *)
-val get_fmt_err : unit -> Format.formatter
-(** Default to [Format.err_formatter] *)
-
-(** Value specifying the formatter used to output warnings *)
-val get_fmt_wrn : unit -> Format.formatter
-(** Default to [Format.err_formatter] *)
-
-(** Value specifying the formatter used to output debug informations *)
-val get_fmt_dbg : unit -> Format.formatter
-(** Default to [Format.err_formatter] *)
-
-(** Value specifying the formatter used to output model *)
-val get_fmt_mdl : unit -> Format.formatter
-(** Default to [Format.std_formatter] *)
-
-(** Value specifying the formatter used to output unsat core *)
-val get_fmt_usc : unit -> Format.formatter
-(** Default to [Format.std_formatter] *)
-
-(** Set [fmt_std] accessible with {!val:get_fmt_std} *)
-val set_fmt_std : Format.formatter -> unit
-
-(** Set [fmt_err] accessible with {!val:get_fmt_err} *)
-val set_fmt_err : Format.formatter -> unit
-
-(** Set [fmt_wrn] accessible with {!val:get_fmt_wrn} *)
-val set_fmt_wrn : Format.formatter -> unit
-
-(** Set [fmt_dbg] accessible with {!val:get_fmt_dbg} *)
-val set_fmt_dbg : Format.formatter -> unit
-
-(** Set [fmt_mdl] accessible with {!val:get_fmt_mdl} *)
-val set_fmt_mdl : Format.formatter -> unit
-
-(** Set [fmt_usc] accessible with {!val:get_fmt_usc} *)
-val set_fmt_usc : Format.formatter -> unit

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1066,6 +1066,9 @@ module Output : sig
   val of_formatter : Format.formatter -> t
   (** [of_formatter fmt] create an out channel of the formatter [fmt]. *)
 
+  val to_formatter : t -> Format.formatter
+  (** [to_formatter fmt] return the underlying formatter. *)
+
   val create_channel : string -> t
   (** [create_filename filename] create an out channel to the file [filename].
       If the argument is "stdout", respectively "stderr", the channel is the

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1080,37 +1080,45 @@ module Output : sig
 
   val set_regular : t -> unit
   (** Set the regular output channel used by default to output results,
-      models and unsat cores. *)
-  (** Default to [Format.std_formatter] *)
+      models and unsat cores.
+
+      Default to [Format.std_formatter]. *)
 
   val set_diagnostic : t -> unit
   (** Set the diagnostic output channel used by default to output errors,
-      debug and warning informations. *)
-  (** Default to [Format.err_formatter] *)
+      debug and warning informations.
+
+      Default to [Format.err_formatter]. *)
 
   val get_fmt_std : unit -> Format.formatter
-  (** Value specifying the formatter used to output results. *)
-  (** Default to [Format.std_formatter] *)
+  (** Value specifying the formatter used to output results.
+
+      Default to [Format.std_formatter]. *)
 
   val get_fmt_err : unit -> Format.formatter
-  (** Value specifying the formatter used to output errors. *)
-  (** Default to [Format.err_formatter] *)
+  (** Value specifying the formatter used to output errors.
+
+      Default to [Format.err_formatter]. *)
 
   val get_fmt_wrn : unit -> Format.formatter
-  (** Value specifying the formatter used to output warnings. *)
-  (** Default to [Format.err_formatter] *)
+  (** Value specifying the formatter used to output warnings.
+
+      Default to [Format.err_formatter]. *)
 
   val get_fmt_dbg : unit -> Format.formatter
-  (** Value specifying the formatter used to output debug informations. *)
-  (** Default to [Format.err_formatter] *)
+  (** Value specifying the formatter used to output debug informations.
+
+      Default to [Format.err_formatter]. *)
 
   val get_fmt_mdl : unit -> Format.formatter
-  (** Value specifying the formatter used to output models. *)
-  (** Default to [Format.std_formatter] *)
+  (** Value specifying the formatter used to output models.
+
+      Default to [Format.std_formatter]. *)
 
   val get_fmt_usc : unit -> Format.formatter
-  (** Value specifying the formatter used to output unsat cores. *)
-  (** Default to [Format.std_formatter] *)
+  (** Value specifying the formatter used to output unsat cores.
+
+      Default to [Format.std_formatter]. *)
 
   val set_std : t -> unit
   (** Set [fmt_std] accessible with {!val:get_fmt_std} *)

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1066,8 +1066,10 @@ module Output : sig
   val of_formatter : Format.formatter -> t
   (** [of_formatter fmt] create an out channel of the formatter [fmt]. *)
 
-  val of_filename : string -> t
-  (** [of_filename filename] create an out channel to the file [filename].
+  val create_channel : string -> t
+  (** [create_filename filename] create an out channel to the file [filename].
+      If the argument is "stdout", respectively "stderr", the channel is the
+      standard output, respectively the standard error.
       If the file does not exist, the procedure creates it. An existant file
       is truncated to zero length. *)
 

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1066,8 +1066,8 @@ module Output : sig
   val create_buffer : unit -> t
   (** Create a new buffer. *)
 
-  val create_channel : string -> t
-  (** [create_channel filename] create an out channel on the file [filename].
+  val of_filename : string -> t
+  (** [of_filename filename] create an out channel to the file [filename].
       If the file does not exist, the procedure creates it. An existant file
       is truncated to zero length. *)
 
@@ -1139,4 +1139,4 @@ module Output : sig
 end
 
 (** Print message as comment in the corresponding output format *)
-val print_output_format: Format.formatter -> string -> unit
+val pp_comment: Format.formatter -> string -> unit

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1060,19 +1060,16 @@ module Output : sig
     | Stdout
     | Stderr
     | Channel of out_channel * Format.formatter
-    | Buffer of Buffer.t * Format.formatter
+    | Fmt of Format.formatter
     | Invalid
 
-  val create_buffer : unit -> t
-  (** Create a new buffer. *)
+  val of_formatter : Format.formatter -> t
+  (** [of_formatter fmt] create an out channel of the formatter [fmt]. *)
 
   val of_filename : string -> t
   (** [of_filename filename] create an out channel to the file [filename].
       If the file does not exist, the procedure creates it. An existant file
       is truncated to zero length. *)
-
-  val contents : t -> string
-  (** Retrieve the content of the underlying buffer if any. *)
 
   val close_all : unit -> unit
   (** Flushing and closing all the remaining output channels. *)

--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -134,10 +134,10 @@ let add_colors formatter =
 
 let init_colors () =
   if Options.get_output_with_colors () then begin
-    add_colors (Options.get_fmt_std ());
-    add_colors (Options.get_fmt_wrn ());
-    add_colors (Options.get_fmt_err ());
-    add_colors (Options.get_fmt_dbg ())
+    add_colors (Options.Output.get_fmt_std ());
+    add_colors (Options.Output.get_fmt_wrn ());
+    add_colors (Options.Output.get_fmt_err ());
+    add_colors (Options.Output.get_fmt_dbg ())
   end
 
 (************** Output Format *************)
@@ -158,14 +158,14 @@ let pp_std_smt () =
   | true, true -> ()
   | false, true ->
     clean_dbg_print := true;
-    Format.fprintf (Options.get_fmt_std ()) "@,"
+    Format.fprintf (Options.Output.get_fmt_std ()) "@,"
   | true, false ->
     clean_wrn_print := true;
-    Format.fprintf (Options.get_fmt_std ()) "@,"
+    Format.fprintf (Options.Output.get_fmt_std ()) "@,"
   | false, false ->
     clean_dbg_print := true;
     clean_wrn_print := true;
-    Format.fprintf (Options.get_fmt_std ()) "@,"
+    Format.fprintf (Options.Output.get_fmt_std ()) "@,"
 
 let add_smt formatter =
   let old_fs = Format_shims.pp_get_formatter_out_functions formatter () in
@@ -194,8 +194,8 @@ let force_new_line formatter =
 let init_output_format () =
   match Options.get_output_format () with
   | Smtlib2 ->
-    add_smt (Options.get_fmt_wrn ());
-    add_smt (Options.get_fmt_dbg ())
+    add_smt (Options.Output.get_fmt_wrn ());
+    add_smt (Options.Output.get_fmt_dbg ())
   | Native | Why3 | Unknown _ -> ()
 
 
@@ -204,14 +204,14 @@ let flush fmt = Format.fprintf fmt "@."
 
 let print_std ?(flushed=true) s =
   pp_std_smt ();
-  let fmt = Options.get_fmt_std () in
+  let fmt = Options.Output.get_fmt_std () in
   if flushed || Options.get_output_with_forced_flush ()
   then Format.kfprintf flush fmt s else Format.fprintf fmt s
 
 let print_err ?(flushed=true) ?(header=(Options.get_output_with_headers ()))
     ?(error=true) s =
   if error then begin
-    let fmt = Options.get_fmt_err () in
+    let fmt = Options.Output.get_fmt_err () in
     Format.fprintf fmt "@[<v 0>";
     if header then
       if Options.get_output_with_colors () then
@@ -229,7 +229,7 @@ let print_wrn ?(flushed=true) ?(header=(Options.get_output_with_headers ()))
     print_err ~flushed ~header ~error:warning s
   else
   if warning then begin
-    let fmt = Options.get_fmt_wrn () in
+    let fmt = Options.Output.get_fmt_wrn () in
     Format.fprintf fmt "@[<v 0>%s" (pp_smt clean_wrn_print);
     if header then
       if Options.get_output_with_colors () then
@@ -243,7 +243,7 @@ let print_wrn ?(flushed=true) ?(header=(Options.get_output_with_headers ()))
 
 let print_dbg ?(flushed=true) ?(header=(Options.get_output_with_headers ()))
     ?(module_name="") ?(function_name="") s =
-  let fmt = Options.get_fmt_dbg () in
+  let fmt = Options.Output.get_fmt_dbg () in
   Format.fprintf fmt "@[<v 0>%s" (pp_smt clean_dbg_print);
   if header then begin
     let fname =
@@ -317,12 +317,12 @@ let print_status_value fmt (v,color) =
     Format.fprintf fmt "%s" v
 
 let print_status ?(validity_mode=true)
-    ?(formatter=Options.get_fmt_std ())
+    ?(formatter=Options.Output.get_fmt_std ())
     (validity_status,unsat_status,color) loc time steps goal =
   pp_std_smt ();
   let native_output_fmt, comment_if_smt2 =
     if validity_mode then formatter, ""
-    else (Options.get_fmt_dbg ()), (pp_smt clean_dbg_print)
+    else (Options.Output.get_fmt_dbg ()), (pp_smt clean_dbg_print)
   in
   (* print validity status. Commented and in debug fmt if in unsat mode *)
   Format.fprintf native_output_fmt
@@ -352,7 +352,7 @@ let print_status_sat ?(validity_mode=true) loc
 let print_status_inconsistent ?(validity_mode=true) loc
     time steps goal =
   print_status ~validity_mode
-    ~formatter:(Options.get_fmt_dbg ())
+    ~formatter:(Options.Output.get_fmt_dbg ())
     ("Inconsistent assumption","","fg_red") loc
     time steps goal
 
@@ -371,6 +371,6 @@ let print_status_timeout ?(validity_mode=true) loc
 let print_status_preprocess ?(validity_mode=true)
     time steps =
   print_status ~validity_mode
-    ~formatter:(Options.get_fmt_dbg ())
+    ~formatter:(Options.Output.get_fmt_dbg ())
     ("Preprocessing","","fg_magenta") None
     time steps None

--- a/src/parsers/psmt2_to_alt_ergo.ml
+++ b/src/parsers/psmt2_to_alt_ergo.ml
@@ -40,7 +40,6 @@ module Smtlib_parser = Psmt2Frontend.Smtlib_parser
 module Smtlib_lexer = Psmt2Frontend.Smtlib_lexer
 
 open Smtlib_syntax
-open Options
 open Parsed_interface
 
 

--- a/src/parsers/psmt2_to_alt_ergo.ml
+++ b/src/parsers/psmt2_to_alt_ergo.ml
@@ -504,7 +504,7 @@ let aux aux_fun token lexbuf =
     let loc = (Lexing.lexeme_start_p lexbuf, Lexing.lexeme_end_p lexbuf) in
     let lex = Lexing.lexeme lexbuf in
     Parsing.clear_parser ();
-    Smtlib_error.print (Options.get_fmt_err ()) (Options.get_file ())
+    Smtlib_error.print (Options.Output.get_fmt_err ()) (Options.get_file ())
       (Syntax_error (lex)) loc;
     Errors.error (Errors.Syntax_error (loc,""))
   | Smtlib_error.Error (e , p) ->
@@ -514,7 +514,8 @@ let aux aux_fun token lexbuf =
         Some loc -> loc
       | None -> Lexing.dummy_pos,Lexing.dummy_pos
     in
-    Smtlib_error.print (get_fmt_err ()) (Options.get_file ()) e loc;
+    Smtlib_error.print (Options.Output.get_fmt_err ())
+      (Options.get_file ()) e loc;
     Errors.error (Errors.Syntax_error (loc,""))
 
 let file_parser token lexbuf =


### PR DESCRIPTION
This PR aims to make AE fit better the SMT-LIB standards by adding the support for `set-option`.

- [x] support `:regular-output-channel` and `:diagnostic-output-channel`
- [x] support `:produce-models`
- [x] partial support `:verbosity`
- [x] partial support `:reproducible-resource-limit`
- [x] support `:produce-unsat-cores`

I don't plan to support other standard options in this PR. Maybe we could add `print-success` later. 

I had to refactor the way AE manages its output channels in order to be able to change the channel during the execution of smt2 scripts. 