### PR TITLE
Do not print warning with dolmen frontend

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -235,7 +235,7 @@ let main () =
   let mk_state ?(debug = false) ?(report_style = State.Contextual)
       ?(reports =
         Dolmen_loop.Report.Conf.mk
-          ~default:Dolmen_loop.Report.Warning.Status.Enabled)
+          ~default:Dolmen_loop.Report.Warning.Status.Disabled)
       ?(max_warn = max_int) ?(time_limit = Float.infinity)
       ?(size_limit = Float.infinity) ?(type_check = true)
       ?(solver_ctx = empty_solver_ctx) path =


### PR DESCRIPTION
On automatically generated files coming from provers, it is not rare for there to be unused arguments to functions and other "bad practice" that usually warrants a warning in programming languages.

However, when running an automated prover on these files, it does not make much sense to print warnings, because they will probably not be read by the user — and so they just slow us down.