### PR TITLE
Add timelimit support in dolmen frontend

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -201,6 +201,10 @@ let main () =
   let handle_exn _ bt = function
     | Dolmen.Std.Loc.Syntax_error (_, `Regular msg) ->
       Printer.print_err "%t" msg;
+      exit 1
+    | Util.Timeout ->
+      Printer.print_status_timeout None None None None;
+      exit 142
     | _ as exn -> Printexc.raise_with_backtrace exn bt
   in
   let finally ~handle_exn st e =
@@ -485,6 +489,11 @@ let main () =
   let d_fe filename =
     let st = mk_state filename in
     try
+      Options.with_timelimit_if
+        ~is_gui:false
+        (not (Options.get_timelimit_per_goal ()))
+      @@ fun () ->
+
       let st, g = Parser.parse_logic [] st (State.get State.logic_file st) in
       let all_used_context = FE.init_all_used_context () in
       let finally = finally ~handle_exn in

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -629,7 +629,19 @@ module Time = struct
     if Float.compare (get_timelimit ()) 0. <> 0 then
       MyUnix.unset_timeout ~is_gui
 
+  let with_timeout ~is_gui tm f =
+    Fun.protect
+      ~finally:(fun () -> unset_timeout ~is_gui)
+      (fun () ->
+         set_timeout ~is_gui tm;
+         f())
 end
+
+let with_timelimit_if ~is_gui cond f =
+  if cond then
+    Time.with_timeout ~is_gui (get_timelimit ()) f
+  else
+    f ()
 
 (** globals **)
 

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -1032,7 +1032,24 @@ module Time : sig
   val set_timeout : is_gui:bool -> float -> unit
   val unset_timeout : is_gui:bool -> unit
 
+  (** [with_timeout ~is_gui tm f] calls [f ()] with a timeout of [tm], and
+      unsets the timeout once the call to [f ()] completes or raises an
+      exception.
+
+      @raises Util.Timeout if the timeout is reached before [f ()] completes.
+  *)
+  val with_timeout : is_gui:bool -> float -> (unit -> 'a) -> 'a
 end
+
+(** [with_timelimit_if ~is_gui cond f] is:
+
+    - [Time.with_timeout ~is_gui (get_timeout ()) f] when [cond] is [true]
+    - [f ()] otherwise
+
+    @raises Util.Timeout if the [cond] is [true] and the timeout is reached
+            before the calls to [f ()] completes.
+*)
+val with_timelimit_if : is_gui:bool -> bool -> (unit -> 'a) -> 'a
 
 (** {2 Globals} *)
 (** Global functions used throughout the whole program *)


### PR DESCRIPTION
This patch adds timelimit support to the dolmen frontend, which was previously ignoring the `--timelimit` option when `--timelimit-per-goal` was not set.