### PR TITLE
Do not sort fields according to the first appearance of their name

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -255,7 +255,7 @@ and handle_ty_app ?(update = false) ty_c l =
 let mk_ty_decl (ty_c: DE.ty_cst) =
   match DT.definition ty_c with
   | Some (
-      Adt { cases = [| { cstr = { id_ty; _ }; dstrs; _ } |]; _ }
+      Adt { cases = [| { cstr = { id_ty; path; _ }; dstrs; _ } |]; _ }
     ) ->
     (* Records and adts that only have one case are treated in the same way,
        and considered as records. *)
@@ -276,7 +276,8 @@ let mk_ty_decl (ty_c: DE.ty_cst) =
       ) [] dstrs
     in
     let lbs = List.rev rev_lbs in
-    let ty = Ty.trecord tyvl (get_basename ty_c.path) lbs in
+    let record_constr = Format.asprintf "%a" DStd.Path.print path in
+    let ty = Ty.trecord ~record_constr tyvl (get_basename ty_c.path) lbs in
     Cache.store_ty (DE.Ty.Const.hash ty_c) ty
 
   | Some (
@@ -445,7 +446,11 @@ let mk_mr_ty_decls (tdl: DE.ty_cst list) =
           else (
             let ty =
               if (record || Array.length cases = 1) && not contains_adts
-              then Ty.trecord tyvl name []
+              then
+                let record_constr =
+                  Format.asprintf "%a" DStd.Path.print ty_c.path
+                in
+                Ty.trecord ~record_constr tyvl name []
               else Ty.t_adt name tyvl
             in
             Cache.store_ty (DE.Ty.Const.hash ty_c) ty;

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -140,7 +140,8 @@ module Types = struct
     | Record (record_constr, lbs) ->
       let lbs =
         List.map (fun (x, pp) -> x, ty_of_pp loc env None pp) lbs in
-      let ty = Ty.trecord ~record_constr ty_vars id lbs in
+      let sort_fields = String.equal record_constr "{" in
+      let ty = Ty.trecord ~sort_fields ~record_constr ty_vars id lbs in
       ty, { to_ty = MString.add id ty env.to_ty;
             from_labels =
               List.fold_left

--- a/src/lib/reasoners/records.ml
+++ b/src/lib/reasoners/records.ml
@@ -256,7 +256,9 @@ module Shostak (X : ALIEN) = struct
           in
           let record = is_mine (Record (flds, tyr)) in
           record, (left_abs_xe2, record) :: acc
-        | _ -> assert false
+        | ty ->
+          Util.failwith
+            "Not a record type: `%a" Ty.print_full ty
     in
     let abs_access = normalize (Access (field, embed abs_right_xe, ty)) in
     is_mine abs_access, acc

--- a/src/lib/structures/ty.ml
+++ b/src/lib/structures/ty.ml
@@ -543,10 +543,10 @@ let t_adt ?(body=None) s ty_vars =
   end;
   ty
 
-let trecord ?(record_constr="{") lv n lbs =
+let trecord ?(sort_fields = false) ~record_constr lv n lbs =
   let lbs = List.map (fun (l,ty) -> Hstring.make l, ty) lbs in
   let lbs, record_constr =
-    if String.equal record_constr "{" then
+    if sort_fields then
       List.sort (fun (l1, _) (l2, _) -> Hstring.compare l1 l2) lbs,
       Format.sprintf "%s___%s" record_constr n
     else lbs, record_constr

--- a/src/lib/structures/ty.mli
+++ b/src/lib/structures/ty.mli
@@ -180,9 +180,14 @@ val t_adt :
     of arguments. *)
 
 val trecord :
-  ?record_constr:string -> t list -> string -> (string * t) list -> t
+  ?sort_fields:bool ->
+  record_constr:string -> t list -> string -> (string * t) list -> t
 (** Create a record type. [trecord args name lbs] creates a record
-    type with name [name], arguments [args] and fields [lbs]. *)
+    type with name [name], arguments [args] and fields [lbs].
+
+    If [sort_fields] is true, the record fields are sorted according to
+    [Hstring.compare]. This is to preserve compatibility with the old
+    typechecker behavior and should not be used in new code. *)
 
 
 (** {2 Substitutions} *)


### PR DESCRIPTION
Currently if you were to write the following code:

```
predicate sneaky(b: int, c: int) = true
type pair = { a: int ; b: bool ; c : bool }
logic p : pair
axiom p_def : p = { a = 0 ; b = false ; c = true }
```

it would be incorrectly treated by the Dolmen frontend as a "type-safe" (quotes for obvious reasons) version of:

```
predicate sneaky(b: int, c: int) = true
type pair = { a: int ; b: bool ; c : bool }
logic p : pair
axiom p_def : p = { b = 0 ; c = false ; a = true }
```

What?? That is because `Ty.trecord` when called without a `record_constr` argument re-orders the field name according to their weak-table order (i.e., roughly, the order in which they appear in the program source) and d_cnf (sanely) doesn't properly account for that.

This patch makes it so that `Ty.trecord` only performs this reordering when explicitly asked, and the only place where we explicitly ask for this reordering is in the old typechecker. We *probably* could get away with not doing it at all, but I am scared it will break something else at this point, so I err on the side of safety.

There is also an actual error message in `records.ml` instead of an [assert false].