### PR TITLE
Restore floating-point prelude support

### DIFF
--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -115,7 +115,7 @@ module Shostak
     match sy with
     | Int _ | Real _ -> true
     | Op (Plus | Minus | Mult | Div | Modulo
-         | Float _ | Fixed | Abs_int | Abs_real | Sqrt_real
+         | Float | Fixed | Abs_int | Abs_real | Sqrt_real
          | Sqrt_real_default | Sqrt_real_excess
          | Real_of_int | Int_floor | Int_ceil
          | Max_int | Max_real | Min_int | Min_real
@@ -295,7 +295,15 @@ module Shostak
         P.add p (P.mult_const coef p3), ctx
 
     (*** <begin>: partial handling of some arith/FPA operators **)
-    | Sy.Op Sy.Float (prec, exp), [mode; x] ->
+    | Sy.Op Sy.Float, [prec; exp; mode; x] ->
+      let int_of_term t =
+        try
+          E.int_view t (* ! may be negative or null *)
+        with Failure e ->
+          Printer.print_err "%s" e;
+          assert false
+      in
+      let prec = int_of_term prec and exp = int_of_term exp in
       let aux_func e =
         let res, _, _ = Fpa_rounding.float_of_rational prec exp mode e in
         res

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -296,14 +296,7 @@ module Shostak
 
     (*** <begin>: partial handling of some arith/FPA operators **)
     | Sy.Op Sy.Float, [prec; exp; mode; x] ->
-      let int_of_term t =
-        try
-          E.int_view t (* ! may be negative or null *)
-        with Failure e ->
-          Printer.print_err "%s" e;
-          assert false
-      in
-      let prec = int_of_term prec and exp = int_of_term exp in
+      let prec = E.int_view prec and exp = E.int_view exp in
       let aux_func e =
         let res, _, _ = Fpa_rounding.float_of_rational prec exp mode e in
         res

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2801,3 +2801,15 @@ let reinit_cache () =
   clear_subst_cache ();
   Labels.clear labels;
   HC.reinit_cache ()
+
+let int_view t =
+  match term_view t with
+  | { f = Sy.Int n; _ } ->
+    let n = Hstring.view n in
+    begin match int_of_string n with
+      | n -> n
+      | exception Failure _ ->
+        Fmt.failwith "error when trying to convert %s to an int" n
+    end
+  | _ ->
+    Fmt.failwith "The given term %a is not an integer" print t

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -130,6 +130,14 @@ val term_view : t -> term_view
 val lit_view  : t -> lit_view
 val form_view : t -> form_view
 
+(** constant casts *)
+
+val int_view : t -> int
+(** Extracts the integer value of the expression, if there is one.
+
+    The returned value may be negative or null.
+
+    @raises Failure if the expression is not a constant integer. *)
 
 (** pretty printing *)
 

--- a/src/lib/structures/fpa_rounding.ml
+++ b/src/lib/structures/fpa_rounding.ml
@@ -269,12 +269,11 @@ let round_to_integer mode q =
 let make_adequate_app s l ty =
   match s with
   | Sy.Name (hs, Sy.Other) when Options.get_use_fpa() ->
-    let ei i = E.int (string_of_int i) in
     let float prec exp ?(mode = _NearestTiesToEven__rounding_mode) x =
-      Sy.(Op Float), [ei prec; ei exp; mode; x]
+      Sy.(Op Float), [E.int prec; E.int exp; mode; x]
     in
-    let float32 = float 24 149 in
-    let float64 = float 53 1074 in
+    let float32 = float "24" "149" in
+    let float64 = float "53" "1074" in
     let s, l  =
       match Hstring.view hs, l with
       (* Note: [prec], [exp], and [mode] are allowed to be quantified variables

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -47,7 +47,7 @@ type operator =
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
   (* FP *)
-  | Float of int * int (* precision|significant * exponential *)
+  | Float
   | Integer_round | Fixed
   | Sqrt_real | Sqrt_real_default | Sqrt_real_excess
   | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil
@@ -138,7 +138,7 @@ let compare_operators op1 op2 =
         let r = Int.compare i1 i2 in
         if r = 0 then Int.compare j1 j2 else r
       | _ , (Plus | Minus | Mult | Div | Modulo
-            | Concat | Extract _ | Get | Set | Fixed | Float _ | Reach
+            | Concat | Extract _ | Get | Set | Fixed | Float | Reach
             | Access _ | Record | Sqrt_real | Abs_int | Abs_real
             | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
@@ -291,7 +291,7 @@ let to_string ?(show_vars=true) x = match x with
   | Op Record -> "@Record"
   | Op Get -> "get"
   | Op Set -> "set"
-  | Op Float (prec, exp) -> Format.sprintf "float %d %d" prec exp
+  | Op Float -> "float"
   | Op Fixed -> "fixed"
   | Op Abs_int -> "abs_int"
   | Op Abs_real -> "abs_real"

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -47,7 +47,7 @@ type operator =
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
   (* FP *)
-  | Float of int * int (* precision|significant * exponential *)
+  | Float
   | Integer_round | Fixed
   | Sqrt_real | Sqrt_real_default | Sqrt_real_excess
   | Abs_int | Abs_real | Real_of_int | Int_floor | Int_ceil


### PR DESCRIPTION
Adding int parameters to `Sy.Float` in #596 involuntarily broke the floating-point prelude. This is because when we build the expressions, the parameters of the floating-point constructor may be variables, which then get instantiated by actual constants in a later phase.

This restores the old behavior, where we store the precision/exponent/mode arguments as expressions, and convert them into constants lazily post-instantiation.