### PR TITLE
Add CI tests that we can correctly parse the prelude

### DIFF
--- a/src/preludes/cram.t/run.t
+++ b/src/preludes/cram.t/run.t
@@ -1,0 +1,5 @@
+  $ alt-ergo ../b-set-theory-prelude-2018-09-28.ae
+  $ alt-ergo ../b-set-theory-prelude-2020-02-28.ae
+  $ alt-ergo --use-fpa ../fpa-theory-2017-01-04-16h00.ae
+  $ alt-ergo --use-fpa ../fpa-theory-2019-06-14-11h00.ae
+  $ alt-ergo --use-fpa ../fpa-theory-2019-10-08-19h00.ae

--- a/src/preludes/dune
+++ b/src/preludes/dune
@@ -10,3 +10,7 @@
     (fpa-theory-2019-10-08-19h00.ae as preludes/fpa-theory-2019-10-08-19h00.ae)
   )
 )
+
+(cram
+ (alias runtest-ci)
+ (deps b-set-theory-prelude-2018-09-28.ae b-set-theory-prelude-2020-02-28.ae fpa-theory-2017-01-04-16h00.ae fpa-theory-2019-06-14-11h00.ae fpa-theory-2019-10-08-19h00.ae))


### PR DESCRIPTION
As discussed in #626 (note that these are not expected to pass until #626 is merged).

This does not yet add actual floating-point tests because I am not sure where to find such tests publicly. We probably can import why3-generated tests, which I will look into.