### PR TITLE
Better pre-commit hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/rsc/extra/pre-commit--git-hook
+++ b/rsc/extra/pre-commit--git-hook
@@ -1,14 +1,32 @@
 #!/bin/sh
 
-git_repo=`git rev-parse --show-toplevel`
-cd $git_repo/rsc/extra
-
-res=`./check_style.sh`
-echo $res
-
-if [ "$res" = "All files have correct style" ] ; then
-	./check_indentation.sh
-	exit $?
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
 else
-  exit 1
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
 fi
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Reindent files using ocp-indent
+errors=0
+files=$(git diff --cached --name-only --diff-filter=ACMR -z HEAD | grep -Ez '\.ml[ily]?$' | xargs -0)
+for f in $files; do
+	cmp -s <(git show ":$f") <(git show ":$f" | ocp-indent)
+	if [[ $? -ne 0 ]]; then
+		echo "$f: indentation errors."
+		ocp-indent -i "$f"
+		git diff -- "$f"
+		errors=$((errors+1))
+	fi
+done
+
+if [[ $errors -ne 0 ]]; then
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against --


### PR DESCRIPTION
The current pre-commit hook in rsc/extra/pre-commit--git-hook is fairly frustrating to use for multiple reasons:

 - It always checks *all* the files in the repository, making it slow;
 - It prints messages even when everything is fine (if I remember correctly, not been using it for a long time)
 - It always check against the working copy, not the index, meaning that trying to commit twice (without adding the changes in between) always work.

This patch provides an alternative implementation of a pre-commit hook that:

 - Only checks the files that will be modified by the tentative commit
 - Is silent when all checks pass
 - Checks against the index, ensuring that it will never let you commit ill-indented files (well, unless you use `--no-verify` of course).

For indentation errors, if there are any, the script re-indents the corresponding file(s) using `ocp-indent`, and tells you about the changes. You must add (or not) the corresponding changes manually. This is required to be compatible with workflows based on partial commits (using `git add -p`).

For whitespace errors, the script simply checks them, and does not let you commit if there are any, because that is provided for free by `git`. Whitespace errors are easy to avoid with proper editor configuration, and as an alternative a `.editorconfig` file is provided to help with editor configuration.