### PR TITLE
Remove pinning of dolmen to git version

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -45,8 +45,5 @@ jobs:
       # And then, install external (no need for depext with opam 2.1) and libs deps.
       - run: opam switch create . ocaml-system --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 
-      - name: Temporary fix
-        run: opam pin https://github.com/Gbury/dolmen.git
-
       # Install the project packages
       - run: opam install .

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Install deps
         run: opam exec -- make test-deps js-deps
 
-      - name: Temporary fix
-        run: opam pin https://github.com/Gbury/dolmen.git
-
       # compile Alt-Ergo with Js_of_ocaml
       - name: Make alt-ergo.js
         run: opam exec -- make js-node

--- a/.github/workflows/build_make.yml
+++ b/.github/workflows/build_make.yml
@@ -50,9 +50,6 @@ jobs:
       - name: opam install deps
         run: opam exec -- make deps js-deps
 
-      - name: Temporary fix
-        run: opam pin https://github.com/Gbury/dolmen.git
-
       # make use `dune build` which update .opam file if the dune-project is updated
       - name: Make
         run: opam exec -- make


### PR DESCRIPTION
This was done because we needed support for mutually recursive definitions, but that is present in dolmen 0.8.1 which is the currently released version.

On the other hand, the dev version of Dolmen has introduced backwards-incompatible API changes (see #629), so we can't use it anymore.

This removes the "Temporary fix" in the GitHub Actions and uses the publicly released dolmen version everywhere.