### PR TITLE
Incorporate the FPA prelude as a builtin

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -25,6 +25,7 @@ depends: [
   "seq"
   "fmt"
   "stdlib-shims"
+  "ppx_blob"
   "camlzip" {>= "1.07"}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -79,6 +79,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
   seq
   fmt
   stdlib-shims
+  ppx_blob
   (camlzip (>= 1.07))
   (odoc :with-doc)
  )

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -703,13 +703,13 @@ let parse_execution_opt =
       else
         let p' = Filename.concat Config.preludesdir p in
         if Sys.file_exists p' then begin
-          begin if String.starts_with ~prefix:"b-set-theory" p then
+          begin if Compat.String.starts_with ~prefix:"b-set-theory" p then
               Printer.print_wrn ~header:true
                 "Support for the B set theory is deprecated since version \
                  2.5.0 and may be removed in a future version. If you are \
                  actively using it, please make yourself known to the Alt-Ergo \
                  developers by writing to <alt-ergo@ocamlpro.com>."
-            else if String.starts_with ~prefix:"fpa-theory" p then
+            else if Compat.String.starts_with ~prefix:"fpa-theory" p then
               Printer.print_wrn ~header:true
                 "@[Support for the FPA theory has been integrated as a builtin \
                  theory prelude in version 2.5.0 and is enabled by default. \

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -325,7 +325,7 @@ let mk_execution_opt frontend input_format parse_only parsers
   let output_with_formatting = (not no_formatting_in_output) || pretty_output in
   let output_with_forced_flush =
     (not no_forced_flush_in_output) && (not pretty_output) in
-  set_infer_input_format input_format;
+  set_infer_input_format (Option.is_none input_format);
   let input_format = match input_format with
     | None -> Native
     | Some fmt -> fmt
@@ -400,7 +400,7 @@ let mk_output_opt
     interpretation use_underscore unsat_core output_format model_type models
   =
   let `Ok () = mk_models_opt models in
-  set_infer_output_format output_format;
+  set_infer_output_format (Option.is_none output_format);
   let output_format = match output_format with
     | None -> Native
     | Some fmt -> fmt
@@ -505,7 +505,8 @@ let mk_term_opt disable_ites inline_lets rewriting no_term_like_pp
   `Ok()
 
 let mk_theory_opt disable_adts () no_ac no_contracongru
-    no_fm no_nla no_tcp no_theory restricted tighten_vars _use_fpa
+    no_fm no_nla no_tcp no_theory restricted tighten_vars
+    _use_fpa theory_preludes
   =
   set_no_ac no_ac;
   set_no_fm no_fm;
@@ -516,6 +517,7 @@ let mk_theory_opt disable_adts () no_ac no_contracongru
   set_disable_adts disable_adts;
   set_tighten_vars tighten_vars;
   set_no_contracongru no_contracongru;
+  set_theory_preludes theory_preludes;
   `Ok()
 
 let halt_opt version_info where =
@@ -692,11 +694,51 @@ let parse_execution_opt =
          info ["add-parser"] ~docs ~doc) in
 
   let preludes =
+    let parse_prelude p =
+      if Sys.file_exists p then
+        if Sys.is_directory p then
+          Fmt.error "'%s' is a directory" p
+        else
+          Ok p
+      else
+        let p' = Filename.concat Config.preludesdir p in
+        if Sys.file_exists p' then begin
+          begin if String.starts_with ~prefix:"b-set-theory" p then
+              Printer.print_wrn ~header:true
+                "Support for the B set theory is deprecated since version \
+                 2.5.0 and may be removed in a future version. If you are \
+                 actively using it, please make yourself known to the Alt-Ergo \
+                 developers by writing to <alt-ergo@ocamlpro.com>."
+            else if String.starts_with ~prefix:"fpa-theory" p then
+              Printer.print_wrn ~header:true
+                "@[Support for the FPA theory has been integrated as a builtin \
+                 theory prelude in version 2.5.0 and is enabled by default. \
+                 This option is no longer needed, and the '%s'@ prelude will \
+                 be removed in a later version.@]" p
+          end;
+
+          if Sys.is_directory p' then
+            Fmt.error "'%s' is a directory" p
+          else
+            Ok p'
+        end else
+          Fmt.error "no '%s' file" p
+    in
+    let parse_preludes =
+      List.fold_left (fun r p ->
+          Result.bind r @@ fun ps ->
+          Result.map (fun p -> p :: ps) (parse_prelude p))
+        (Ok [])
+    in
     let doc =
       "Add a file that will be loaded as a prelude. The command is \
        cumulative, and the order of successive preludes is preserved." in
-    Arg.(value & opt_all string (get_preludes ()) &
-         info ["prelude"] ~docs ~doc) in
+    Term.(cli_parse_result' (
+        const parse_preludes $
+        Arg.(value & opt_all string (get_preludes ()) &
+             info ["prelude"] ~docs ~doc)
+      ))
+  in
 
   let no_locs_in_answers =
     let doc =
@@ -1220,10 +1262,77 @@ let parse_theory_opt =
     let deprecated = "this option is always enabled" in
     Arg.(value & flag & info ["use-fpa"] ~docs ~doc ~deprecated) in
 
+  let theories =
+    let theory_enum =
+      Preludes.all
+      |> List.map (fun t -> Format.asprintf "%a" Preludes.pp t, t)
+    in
+    let theory = Arg.enum theory_enum in
+    let enable_preludes =
+      let doc =
+        Format.asprintf "Enable theory preludes, multiple comma-separated values
+        are supported. $(docv) must be %s."
+          (Arg.doc_alts_enum theory_enum)
+      in
+      let docv = "THEORY" in
+      Arg.(
+        value & opt (list theory) [] & info ["enable-preludes"] ~docs ~doc ~docv
+      )
+    and disable_preludes =
+      let doc =
+        Format.asprintf "Disable theory preludes, multiple comma-separated
+        values are supported. THEORY must be %s."
+          (Arg.doc_alts_enum theory_enum)
+      in
+      let docv = "THEORY" in
+      Arg.(
+        value & opt (list theory) [] &
+        info ["disable-preludes"] ~docs ~doc ~docv
+      )
+    and disable_builtin_preludes =
+      let doc = "Disable all default theory preludes. Prefer using
+      $(i,--disable-preludes) to explicitly disable problematic theory preludes.
+      Select theory preludes can be re-enabled with $(i,--enable-preludes)." in
+      Arg.(
+        value & flag & info ["disable-default-preludes"] ~doc ~docs
+      )
+    in
+    let preludes enable_preludes disable_preludes disable_builtin_preludes =
+      let preludes =
+        if disable_builtin_preludes then
+          []
+        else
+          Preludes.default
+      in
+      let rec aux th en dis =
+        match en, dis with
+        | _ :: _, [] -> aux (List.rev_append en th) [] []
+        | e :: _, d :: _ when e = d ->
+          Fmt.error_msg "theory prelude '%a' cannot be both enabled and
+          disabled" Preludes.pp e
+        | e :: en, d :: _ when e < d -> aux (e :: th) en dis
+        | _ , d :: dis -> aux (List.filter ((<>) d) th) en dis
+        | [], [] -> Ok th
+      in
+      aux
+        preludes
+        (List.fast_sort compare enable_preludes)
+        (List.fast_sort compare disable_preludes)
+    in
+    Term.(
+      cli_parse_result (
+        const preludes
+        $ enable_preludes
+        $ disable_preludes
+        $ disable_builtin_preludes
+      )
+    )
+  in
+
   Term.(ret (const mk_theory_opt $
              disable_adts $ inequalities_plugin $ no_ac $ no_contracongru $
              no_fm $ no_nla $ no_tcp $ no_theory $ restricted $
-             tighten_vars $ use_fpa
+             tighten_vars $ use_fpa $ theories
             )
        )
 

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -163,7 +163,8 @@ let main () =
                 ~format:(Some (Filename.extension filename)))
         in
         let preludes = Options.get_preludes () in
-        Seq.append theory_preludes @@ I.parse_files ~filename ~preludes
+        Compat.Seq.append theory_preludes @@
+        I.parse_files ~filename ~preludes
       with
       | Util.Timeout ->
         FE.print_status (FE.Timeout None) 0;

--- a/src/bin/js/options_interface.ml
+++ b/src/bin/js/options_interface.ml
@@ -142,7 +142,8 @@ let set_options r =
   set_options_opt Options.set_answers_with_loc r.answers_with_loc;
   set_options_opt Options.set_input_format
     (get_input_format r.input_format);
-  Options.set_infer_input_format (get_input_format r.input_format);
+  Options.set_infer_input_format
+    (get_input_format r.input_format |> Option.is_none);
   set_options_opt Options.set_parse_only r.parse_only;
   set_options_opt Options.set_parsers r.parsers;
   set_options_opt Options.set_preludes r.preludes;
@@ -161,7 +162,8 @@ let set_options r =
 
   set_options_opt Options.set_output_format
     (get_output_format r.output_format);
-  Options.set_infer_output_format (get_input_format r.output_format);
+  Options.set_infer_output_format
+    (get_input_format r.output_format |> Option.is_none);
   set_options_opt Options.set_unsat_core r.unsat_core;
 
   set_options_opt Options.set_verbose r.verbose;

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -26,6 +26,9 @@
     fmt
   )
 
+  (preprocess (pps ppx_blob))
+  (preprocessor_deps (glob_files ../preludes/*.ae))
+
   ; .mli only modules *also* need to be in this field
   (modules_without_implementation matching_types sig sig_rel)
 
@@ -46,7 +49,7 @@
     ; util
     Config Emap Gc_debug Hconsing Hstring Iheap Lists Loc
     MyDynlink MyUnix Numbers
-    Options Timers Util Vec Version Steps Printer My_zip
+    Options Timers Util Vec Version Steps Printer My_zip Preludes
   )
 
  (js_of_ocaml

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -50,6 +50,7 @@
     Config Emap Gc_debug Hconsing Hstring Iheap Lists Loc
     MyDynlink MyUnix Numbers
     Options Timers Util Vec Version Steps Printer My_zip Preludes
+    Compat
   )
 
  (js_of_ocaml

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2503,7 +2503,7 @@ let assume_th_elt t th_elt dep =
     if axiom_kind == Util.Propagator then "Th propagator" else "Th CS"
   in
   match extends with
-  | Util.NIA | Util.NRA | Util.FPA ->
+  | Util.NIA | Util.NRA | Util.FPA | Util.RIA ->
     let th_form = separate_semantic_triggers ax_form in
     let th_elt = {th_elt with Expr.ax_form} in
     if get_debug_fpa () >= 2 then

--- a/src/lib/util/compat.ml
+++ b/src/lib/util/compat.ml
@@ -1,0 +1,18 @@
+module String = struct
+  open Stdlib.String
+
+  let starts_with ~prefix s =
+    length s >= length prefix &&
+    equal (sub s 0 (length prefix)) prefix
+end
+
+module Seq = struct
+  type 'a t = 'a Stdlib.Seq.t
+
+  open Stdlib.Seq
+
+  let rec append xs ys () =
+    match xs () with
+    | Nil -> ys ()
+    | Cons (x, xs) -> Cons (x, append xs ys)
+end

--- a/src/lib/util/compat.mli
+++ b/src/lib/util/compat.mli
@@ -1,0 +1,44 @@
+(**************************************************************************)
+(*                                                                        *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                 *)
+(*     Copyright (C) 2013-2023 --- OCamlPro SAS                           *)
+(*                                                                        *)
+(*     This file is distributed under the terms of OCamlPro               *)
+(*     Non-Commercial Purpose License, version 1.                         *)
+(*                                                                        *)
+(*     As an exception, Alt-Ergo Club members at the Gold level can       *)
+(*     use this file under the terms of the Apache Software License       *)
+(*     version 2.0.                                                       *)
+(*                                                                        *)
+(*     ---------------------------------------------------------------    *)
+(*                                                                        *)
+(*     The Alt-Ergo theorem prover                                        *)
+(*                                                                        *)
+(*     Sylvain Conchon, Evelyne Contejean, Francois Bobot                 *)
+(*     Mohamed Iguernelala, Stephane Lescuyer, Alain Mebsout              *)
+(*                                                                        *)
+(*     CNRS - INRIA - Universite Paris Sud                                *)
+(*                                                                        *)
+(*     Until 2013, some parts of this code were released under            *)
+(*     the Apache Software License version 2.0.                           *)
+(*                                                                        *)
+(*     ---------------------------------------------------------------    *)
+(*                                                                        *)
+(*     More details can be found in the directory licenses/               *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** This module enables some of the newer functions from OCaml's stdlib while
+    still supporting old versions of the compiler. *)
+
+module String : sig
+  (* @since 4.13.0 *)
+  val starts_with : prefix:string -> string -> bool
+end
+
+module Seq : sig
+  type 'a t = 'a Stdlib.Seq.t
+
+  (* @since 4.11.0 *)
+  val append : 'a t -> 'a t -> 'a t
+end

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -269,6 +269,7 @@ let infer_input_format = ref true
 let parse_only = ref false
 let parsers = ref []
 let preludes = ref []
+let theory_preludes = ref Preludes.default
 let type_only = ref false
 let type_smt2 = ref false
 
@@ -279,10 +280,11 @@ let set_output_with_formatting b = output_with_formatting := b
 let set_output_with_forced_flush b = output_with_forced_flush := b
 let set_frontend f = frontend := f
 let set_input_format f = input_format := f
-let set_infer_input_format f = infer_input_format := (Option.is_none f)
+let set_infer_input_format b = infer_input_format := b
 let set_parse_only b = parse_only := b
 let set_parsers p = parsers := p
 let set_preludes p = preludes := p
+let set_theory_preludes t = theory_preludes := t
 let set_type_only b = type_only := b
 let set_type_smt2 b = type_smt2 := b
 
@@ -297,6 +299,7 @@ let get_infer_input_format () = !infer_input_format
 let get_parse_only () = !parse_only
 let get_parsers () = !parsers
 let get_preludes () = !preludes
+let get_theory_preludes () = !theory_preludes
 let get_type_only () = !type_only
 let get_type_smt2 () = !type_smt2
 
@@ -353,7 +356,7 @@ let set_dump_models b = dump_models := b
 let set_interpretation_use_underscore b = interpretation_use_underscore := b
 let set_output_format b = output_format := b
 let set_model_type t = model_type := t
-let set_infer_output_format f = infer_output_format := Option.is_none f
+let set_infer_output_format b = infer_output_format := b
 let set_unsat_core b = unsat_core := b
 
 let equal_mode a b =

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -336,16 +336,19 @@ val set_output_with_formatting : bool -> unit
 val set_output_with_forced_flush : bool -> unit
 
 (** Set [infer_input_format] accessible with {!val:get_infer_input_format} *)
-val set_infer_input_format : 'a option -> unit
+val set_infer_input_format : bool -> unit
 
 (** Set [infer_output_format] accessible with {!val:get_infer_output_format} *)
-val set_infer_output_format : 'a option -> unit
+val set_infer_output_format : bool -> unit
 
 (** Set [parsers] accessible with {!val:get_parsers} *)
 val set_parsers : string list -> unit
 
 (** Set [preludes] accessible with {!val:get_preludes} *)
 val set_preludes : string list -> unit
+
+(** Set [theory_preludes] accessible with {!val:get_theory_preludes} *)
+val set_theory_preludes : Preludes.t list -> unit
 
 (** Set [disable_weaks] accessible with {!val:get_disable_weaks} *)
 val set_disable_weaks : bool -> unit
@@ -628,6 +631,9 @@ val get_parsers : unit -> string list
 (** List of files that have be loaded as preludes. *)
 val get_preludes : unit -> string list
 (** Default to [\[\]] *)
+
+(** List of theory preludes to load. *)
+val get_theory_preludes : unit -> Preludes.t list
 
 (** [true] if the program shall stop after typing. *)
 val get_type_only : unit -> bool

--- a/src/lib/util/preludes.ml
+++ b/src/lib/util/preludes.ml
@@ -28,92 +28,21 @@
 (*                                                                        *)
 (**************************************************************************)
 
-exception Timeout
-exception Unsolvable
+type t = Fpa | Ria | Nra
 
-exception Cmp of int
-exception Not_implemented of string
+let all = [ Fpa; Ria; Nra ]
 
-module MI : Map.S with type key = int
-module SI : Set.S with type elt = int
-module SS : Set.S with type elt = string
+let default = [ Fpa; Ria; Nra ]
 
-(** Different values for -case-split-policy option:
-    -after-theory-assume (default value): after assuming facts in
-    theory by the SAT
-    -before-matching: just before performing a matching round
-    -after-matching: just after performing a matching round **)
-type case_split_policy =
-  | AfterTheoryAssume (* default *)
-  | BeforeMatching
-  | AfterMatching
+let pp ppf = function
+  | Fpa -> Format.fprintf ppf "fpa"
+  | Ria -> Format.fprintf ppf "ria"
+  | Nra -> Format.fprintf ppf "nra"
 
+let filename =
+  Format.asprintf "<builtins>/%a.ae" pp
 
-type inst_kind = Normal | Forward | Backward
-
-type sat_solver =
-  | Tableaux
-  | Tableaux_CDCL
-  | CDCL
-  | CDCL_Tableaux
-
-type theories_extensions =
-  | Sum
-  | Adt
-  | Arrays
-  | Records
-  | Bitv
-  | LIA
-  | LRA
-  | NRA
-  | NIA
-  | FPA
-  | RIA
-
-type axiom_kind = Default | Propagator
-
-val th_ext_of_string : string -> theories_extensions option
-val string_of_th_ext : theories_extensions -> string
-
-(**
-   generic function for comparing algebraic data types.
-   [compare_algebraic a b f]
-   - Stdlib.compare a b is used if
-
-*)
-val [@inline always] compare_algebraic : 'a -> 'a -> (('a * 'a) -> int) -> int
-
-val [@inline always] cmp_lists: 'a list -> 'a list -> ('a -> 'a -> int) -> int
-
-type matching_env =
-  {
-    nb_triggers : int;
-    triggers_var : bool;
-    no_ematching: bool;
-    greedy : bool;
-    use_cs : bool;
-    backward : inst_kind
-  }
-
-(** Loops from 0 to [max] and returns
-    [(f max elt ... (f 1 elt (f 0 elt init)))...)].
-    Returns [init] if [max] < 0
-*)
-val loop:
-  f : (int -> 'a -> 'b -> 'b) ->
-  max : int ->
-  elt : 'a ->
-  init : 'b ->
-  'b
-
-val print_list:
-  sep:string ->
-  pp:(Format.formatter -> 'a -> unit) ->
-  Format.formatter -> 'a list -> unit
-
-val print_list_pp:
-  sep:(Format.formatter -> unit -> unit) ->
-  pp:(Format.formatter -> 'a -> unit) ->
-  Format.formatter -> 'a list -> unit
-
-val failwith: ('a, Format.formatter, unit, 'b) format4 -> 'a
+let content = function
+  | Fpa -> [%blob "src/preludes/fpa.ae"]
+  | Ria -> [%blob "src/preludes/ria.ae"]
+  | Nra -> [%blob "src/preludes/nra.ae"]

--- a/src/lib/util/util.ml
+++ b/src/lib/util/util.ml
@@ -82,6 +82,7 @@ type theories_extensions =
   | NRA
   | NIA
   | FPA
+  | RIA
 
 type axiom_kind = Default | Propagator
 
@@ -97,6 +98,7 @@ let th_ext_of_string ext =
   | "NRA" -> Some NRA
   | "NIA" -> Some NIA
   | "FPA" -> Some FPA
+  | "RIA" -> Some RIA
   |  _ -> None
 
 let string_of_th_ext ext =
@@ -111,6 +113,7 @@ let string_of_th_ext ext =
   | NRA -> "NRA"
   | NIA -> "NIA"
   | FPA -> "FPA"
+  | RIA -> "RIA"
 
 let [@inline always] compare_algebraic s1 s2 f_same_constrs_with_args =
   let r1 = Obj.repr s1 in

--- a/src/parsers/parsers.ml
+++ b/src/parsers/parsers.ml
@@ -154,5 +154,7 @@ let parse_problem_as_string ~content ~format =
     let lb = Lexing.from_string content in
     parse_file ?lang:format lb
   with
-  | Errors.Error e -> raise (Error e)
+  | Errors.Error e ->
+    Format.printf "%a" Errors.report e;
+    raise (Error e)
   | Parsing.Parse_error as e -> raise e

--- a/src/preludes/fpa.ae
+++ b/src/preludes/fpa.ae
@@ -1,0 +1,471 @@
+(******************************************************************************)
+(*                                                                            *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
+(*     Copyright (C) 2013-2017 --- OCamlPro SAS                               *)
+(*                                                                            *)
+(*     This file is distributed under the terms of the license indicated      *)
+(*     in the file 'License.OCamlPro'. If 'License.OCamlPro' is not           *)
+(*     present, please contact us to clarify licensing.                       *)
+(*                                                                            *)
+(******************************************************************************)
+
+theory Simple_FPA extends FPA =
+
+   (* what happends if we add versions for partially bounded float(x) ?
+      whould this be better ? *)
+
+   axiom rounding_operator_1 :
+     forall x : real.
+     forall i, j : real.
+     forall i2, j2 : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        x in [i, j],
+        i2 |-> float(m, p, mode, i),
+        j2 |-> float(m, p, mode, j)
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     i2 <= float(m, p, mode, x) <= j2
+
+
+   axiom integer_rounding_operator_1 :
+     forall x : real.
+     forall i, j : real.
+     forall i2, j2 : int.
+     forall mode : fpa_rounding_mode
+     [
+        integer_round(mode, x),
+        is_theory_constant(mode),
+        x in [i, j],
+        i2 |-> integer_round(mode, i),
+        j2 |-> integer_round(mode, j)
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     i2 <= integer_round(mode, x) <= j2
+
+
+  (* add the version with x in ? -> o(x) - x in ? *)
+  axiom rounding_operator_absolute_error_1_NearestTiesToEven :
+     forall x : real.
+     forall i, j, k : real.
+     forall exp_min, prec : int
+     [
+        float(prec, exp_min, NearestTiesToEven, x),
+        is_theory_constant(prec),
+        is_theory_constant(exp_min),
+        x in [i, j],
+        k |->
+           2 **. (
+            integer_log2(
+              max_real(
+                abs_real(i),
+                max_real(
+                  abs_real(j),
+                  2 **. (- exp_min + prec-1)
+                )
+               )
+             ) - prec (* we can improve by -1 for some rounding modes *)
+           )
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     - k <=  float(prec, exp_min, NearestTiesToEven, x) - x <= k
+
+
+  axiom rounding_operator_absolute_error_1_ALL :
+     forall x : real.
+     forall i, j, k : real.
+     forall mode : fpa_rounding_mode.
+     forall exp_min, prec : int
+     [
+        float(prec, exp_min, mode, x),
+        is_theory_constant(prec),
+        is_theory_constant(exp_min),
+        is_theory_constant(mode),
+        x in [i, j],
+        k |->
+           2 **. (
+            integer_log2(
+              max_real(
+                abs_real(i),
+                max_real(
+                  abs_real(j),
+                  2 **. (- exp_min + prec-1)
+                )
+               )
+             ) - prec + 1(* we can improve by -1 for some rounding modes *)
+           )
+     ]
+     {
+        i <= x,
+        x <= j
+     }.
+     - k <=  float(prec, exp_min, mode, x) - x <= k
+
+   axiom monotonicity_contrapositive_1 :
+      forall x, i, k : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in [?, i[,
+         k |-> float(prec, exp_min, Up, i)
+      ]
+      {
+         float(prec, exp_min, mode, x) < i
+      }.
+      (*float(prec, exp_min, mode, x) < i ->*)
+      x < k
+
+
+   axiom monotonicity_contrapositive_2 :
+      forall x, i, k : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in ]i, ?],
+         k |-> float(prec, exp_min, Down, i)
+      ]
+      {
+         float(prec, exp_min, mode, x) > i
+      }.
+      (*float(prec, exp_min, mode, x) > i ->*)
+      x > k
+
+   (* Remark: should add semantic trigger 'x <= y'
+      or maybe also 'float(m,p,md,x) > float(m,p,md,y)' in future
+      version *)
+   (* same as old monotonicity_contrapositive_3 *)
+   axiom float_is_monotonic:
+     forall m, p : int.
+     forall md : fpa_rounding_mode.
+     forall x, y : real
+     [
+         float(m,p,md,x), float(m,p,md,y),
+         is_theory_constant(m),
+         is_theory_constant(p),
+         is_theory_constant(md)
+     ].
+     x <= y -> float(m,p,md,x) <= float(m,p,md,y)
+
+
+   (* these two axioms are too expensive if put inside a theory *)
+   axiom monotonicity_contrapositive_4 :
+      forall x, y : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),float(prec, exp_min, mode, y),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < float(prec, exp_min, mode, y) ->
+      x < float(prec, exp_min, mode, y)
+
+   axiom monotonicity_contrapositive_5 :
+      forall x, y : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x), float(prec, exp_min, mode, y),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, x) < y
+
+
+   axiom contrapositive_enabeler_1 :
+      forall x, i : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in [?, i]
+      ]
+      { float(prec, exp_min, mode, x) <= i }.
+      float(prec, exp_min, mode, x) = i or float(prec, exp_min, mode, x) < i
+
+   axiom contrapositive_enabeler_2 :
+      forall x, i : real.
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, x),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode),
+         float(prec, exp_min, mode, x) in [i, ?]
+      ]
+      { float(prec, exp_min, mode, x) >= i }.
+      float(prec, exp_min, mode, x) = i or float(prec, exp_min, mode, x) > i
+
+
+   axiom gradual_underflow_1:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) > float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)) > 0.
+
+   axiom gradual_underflow_2:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) > - float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)) > 0.
+
+
+   axiom gradual_underflow_3:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) - float(prec, exp_min, mode, y)) < 0.
+
+   axiom gradual_underflow_4:
+      forall x, y : real. (* semantic triggers are missing! can we do better ? i.e. >= cst *)
+      forall mode : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode)
+      ].
+      float(prec, exp_min, mode, x) < - float(prec, exp_min, mode, y) ->
+      float(prec, exp_min, mode, float(prec, exp_min, mode, x) + float(prec, exp_min, mode, y)) < 0.
+
+
+   axiom float_of_float_same_formats:
+      forall x : real.
+      forall mode1, mode2 : fpa_rounding_mode.
+      forall exp_min, prec : int
+      [
+         float(prec, exp_min, mode1, float(prec, exp_min, mode2, x)),
+         is_theory_constant(prec),
+         is_theory_constant(exp_min),
+         is_theory_constant(mode1),
+         is_theory_constant(mode2)
+      ].
+      float(prec, exp_min, mode1, float(prec, exp_min, mode2, x)) =
+      float(prec, exp_min, mode2, x)
+
+   axiom float_of_float_different_formats:
+      forall x : real.
+      forall mode1, mode2 : fpa_rounding_mode.
+      forall exp_min1, prec1, exp_min2, prec2 : int
+      [
+         float(prec1, exp_min1, mode1, float(prec2, exp_min2, mode2, x)),
+         is_theory_constant(prec1),
+         is_theory_constant(exp_min1),
+         is_theory_constant(prec2),
+         is_theory_constant(exp_min2),
+         is_theory_constant(mode1),
+         is_theory_constant(mode2)
+      ].
+      prec2 <= prec1 ->
+      exp_min2 <= exp_min1 ->
+      float(prec1, exp_min1, mode1, float(prec2, exp_min2, mode2, x)) =
+      float(prec2, exp_min2, mode2, x)
+
+
+   axiom tighten_float_intervals_1__min_large : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in [i, ?],
+        k |-> float(m, p, Up, i)
+     ]
+     {
+        i <= float(m, p, mode, x)
+     }.
+     (*i < k -> not needed => subsumed *)
+     k <= float(m, p, mode, x)
+
+   axiom tighten_float_intervals__2__min_strict : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in ]i, ?],
+        k |-> float(m, p, Up, i)
+     ]
+     {
+        i < float(m, p, mode, x)
+     }. (* we can improve even if this condition is not true, with epsilon *)
+     (*i < k -> not needed => subsumed*)
+     k <= float(m, p, mode, x)
+
+   axiom tighten_float_intervals_3__max_large : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in [?, i],
+        k |-> float(m, p, Down, i)
+     ]
+     {
+        i >= float(m, p, mode, x)
+     }.
+     (*k < i -> not needed => subsumed*)
+     k >= float(m, p, mode, x)
+
+   axiom tighten_float_intervals__4__max_strict : (* add a semantic trigger on o(i) - i *)
+     forall x : real.
+     forall i, k : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in [?, i[,
+        k |-> float(m, p, Down, i)
+     ]
+     {
+        float(m, p, mode, x) < i
+     }. (* we can improve even if this condition is not true, with epsilon *)
+     (*k < i -> not needed => subsumed*)
+     float(m, p, mode, x) <= k
+
+
+   axiom float_of_minus_float:
+     forall x : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, - float(m, p, mode, x)),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode)
+     ].
+     float(m, p, mode, - float(m, p, mode, x)) = - float(m, p, mode, float(m, p, mode, x))
+     (* which can be directly simplified to - float(m, p, mode, x). Another axiom will do this *)
+     (* this axiom probably applies more generally to float(m, p, mode, - x) = - float(m, p, mode, x) *)
+
+
+   axiom float_of_int:
+     forall x : int.
+     forall k : real.
+     forall mode : fpa_rounding_mode.
+     forall exp_min, prec : int
+     [
+        float(prec, exp_min, mode, real_of_int(x)),
+        is_theory_constant(prec),
+        is_theory_constant(exp_min),
+        is_theory_constant(mode),
+        real_of_int(x) + (2 **. prec)  in [0., ?],
+        real_of_int(x) - (2 **. prec) in [?, 0.],
+        k |-> 2 **. prec
+     ]
+     {
+        -k <= real_of_int(x),
+        real_of_int(x) <= k
+     }.
+     float(prec, exp_min, mode, real_of_int(x)) = real_of_int(x)
+
+
+   axiom float_of_pos_pow_of_two:
+     forall x, y, i, k1, k2 : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x * float(m, p, mode, y)),
+        is_theory_constant(p),
+        is_theory_constant(m),
+        is_theory_constant(mode),
+        is_theory_constant(x),
+        x in [i , i],
+        k1 |-> abs_real(i),
+        k2 |-> 2 **. (integer_log2(abs_real(i)))
+     ].
+     k1 >= 1. ->
+     k1 = k2 -> (* is pow of 2 ?*)
+     float(m, p, mode, x * float(m, p, mode, y)) = x * float(m, p, mode, y)
+
+
+   axiom tighten_open_float_bounds :
+     forall x : real.
+     forall i, j, i2, j2 : real.
+     forall mode : fpa_rounding_mode.
+     forall p, m : int
+     [
+        float(m, p, mode, x),
+        is_theory_constant(m),
+        is_theory_constant(p),
+        is_theory_constant(mode),
+        float(m, p, mode, x) in ]i, j[,
+        i2 |-> float(m, p, Up, i + (2 **. (2 * (- p)))),
+        j2 |-> float(m, p, Down, j - (2 **. (2 * (- p))))
+        (* pow_real_int(2.,2 * (- p)) is smaller than any gap between two successive floats *)
+     ]
+     {
+        float(m, p, mode, x) > i,
+        float(m, p, mode, x) < j
+     }.
+     i = float(m, p, mode, i) ->
+     j = float(m, p, mode, j) ->
+     i2 <= float(m, p, mode, x) <= j2
+
+end

--- a/src/preludes/nra.ae
+++ b/src/preludes/nra.ae
@@ -1,0 +1,410 @@
+(******************************************************************************)
+(*                                                                            *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
+(*     Copyright (C) 2013-2017 --- OCamlPro SAS                               *)
+(*                                                                            *)
+(*     This file is distributed under the terms of the license indicated      *)
+(*     in the file 'License.OCamlPro'. If 'License.OCamlPro' is not           *)
+(*     present, please contact us to clarify licensing.                       *)
+(*                                                                            *)
+(******************************************************************************)
+
+theory Principal_Sqrt_real extends NRA = (* some axioms about sqrt: shoud add more *)
+
+axiom sqrt_bounds:
+      forall x, i, j : real
+      [sqrt_real(x), x in [i,j]]
+      (* x may be a constant. i.e. x = i = j and sqrt_real(x) is not exact *)
+      {i <= x, x <= j}.
+      sqrt_real_default(i) <= sqrt_real(x) <= sqrt_real_excess(j)
+
+axiom sqrt_real_is_positive:
+  forall x:real[sqrt_real(x)]. (* semantic triggers ? case-split ? *)
+     x >= 0. ->
+     sqrt_real(x) >= 0.
+
+axiom sqrt_real_is_positive_strict:
+  forall x:real[sqrt_real(x)]. (* semantic triggers ? case-split ? *)
+     x > 0. ->
+     sqrt_real(x) > 0.
+
+axiom square_of_sqrt_real:
+  forall x:real[sqrt_real(x)]. (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    sqrt_real(x) * sqrt_real(x) = x
+
+axiom sqrt_real_of_square:
+  forall x:real[sqrt_real(x * x)]. (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    sqrt_real(x * x) = x
+
+
+axiom sqrt_real_monotonicity:
+  forall x, y:real[sqrt_real(x), sqrt_real(y)].
+    (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    y >= 0. ->
+    x <= y ->
+    sqrt_real(x) <= sqrt_real(y)
+
+(* what about contrapositive of sqrt_real_monotonicity *)
+
+axiom sqrt_real_monotonicity_strict:
+  forall x, y:real[sqrt_real(x), sqrt_real(y)].
+    (* semantic triggers ? case-split ? *)
+    x >= 0. ->
+    y >= 0. ->
+    x < y ->
+    sqrt_real(x) < sqrt_real(y)
+
+(* what about contrapositive of sqrt_real_monotonicity_strict *)
+
+end
+
+theory Linearization extends NRA =
+
+   (* TODO: linearizations with strict inequalities are missing *)
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_1:
+         forall x, y: real.
+         forall a: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x >= 0. ->
+         x*a <= x*y
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_2:
+         forall x, y: real.
+         forall a: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x <= 0. ->
+         x*a >= x*y
+
+  (* needs more semantic triggers, case-split, and discarding of linear terms*)
+  axiom linearize_mult_3:
+         forall x, y: real.
+         forall b: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x >= 0. ->
+         x*y <= x*b
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_4:
+         forall x, y: real.
+         forall b: real
+         [
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x <= 0. ->
+         x*y >= x*b
+
+
+   (* commutativity of four axiomes above *)
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_5:
+         forall x, y: real.
+         forall a: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x >= 0. ->
+         a*x <= y*x
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_6:
+         forall x, y: real.
+         forall a: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [a,?]
+         ]
+         {a <= y}.
+         x <= 0. ->
+         a*x >= y*x
+
+  (* needs more semantic triggers, case-split, and discarding of linear terms*)
+  axiom linearize_mult_7:
+         forall x, y: real.
+         forall b: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x >= 0. ->
+         y*x <= b*x
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_mult_8:
+         forall x, y: real.
+         forall b: real
+         [
+            y*x,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+          |
+            x*y,
+            not_theory_constant(x),
+            not_theory_constant(y),
+            y in [?,b]
+         ]
+         {y <= b}.
+         x <= 0. ->
+         y*x >= b*x
+
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_1:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [c, ?]
+    ]
+    {a/b >= c}.
+    b > 0. ->
+    a >= b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_2:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [c, ?]
+    ]
+    {a/b >= c}.
+    b < 0. ->
+    a <= b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_3:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c]
+    ]
+    {a/b <= c}.
+    b > 0. ->
+    a <= b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_4:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c]
+    ]
+    {a/b <= c}.
+    b < 0. ->
+    a >= b * c
+
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_1:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in ]c, ?]
+    ]
+    {a/b > c}.
+    b > 0. ->
+    a > b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_2:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in ]c, ?]
+    ]
+    {a/b > c}.
+    b < 0. ->
+    a < b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_3:
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c[
+    ]
+    {a/b < c}.
+    b > 0. ->
+    a < b * c
+
+   (* needs more semantic triggers, case-split, and discarding of linear terms*)
+   axiom linearize_div_strict_4: (* add the same thing for equality ?? *)
+    forall a, b, c : real
+    [
+       a/b,
+       not_theory_constant(b),
+       a/b in [?, c[
+    ]
+    {a/b < c}.
+    b < 0. ->
+    a > b * c
+
+
+   axiom linearize_mult_zero_one_1:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]
+     {0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     x*y <= y
+
+   axiom linearize_mult_zero_one_2:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]{0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     y*x <= y
+
+   axiom linearize_mult_zero_one_3:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]{0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= x*y
+
+   axiom linearize_mult_zero_one_4:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        x in [0., 1.]
+     ]{0. <= x, x <= 1.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= y*x
+
+   axiom linearize_mult_zero_one_5:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     x*y <= y
+
+   axiom linearize_mult_zero_one_6:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y >= 0. ->
+     y*x <= y
+
+   axiom linearize_mult_zero_one_7:
+     forall x, y : real
+     [
+        x*y,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= x*y
+
+   axiom linearize_mult_zero_one_8:
+     forall x, y : real
+     [
+        y*x,
+        not_theory_constant(x),
+        not_theory_constant(y),
+        -x in [0., 1.]
+     ]{-1. <= x, x <= 0.}. (* needs cs on y an sem trigger on y *)
+     y <= 0. ->
+     y <= y*x
+
+end

--- a/src/preludes/ria.ae
+++ b/src/preludes/ria.ae
@@ -1,0 +1,177 @@
+(******************************************************************************)
+(*                                                                            *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                     *)
+(*     Copyright (C) 2013-2017 --- OCamlPro SAS                               *)
+(*                                                                            *)
+(*     This file is distributed under the terms of the license indicated      *)
+(*     in the file 'License.OCamlPro'. If 'License.OCamlPro' is not           *)
+(*     present, please contact us to clarify licensing.                       *)
+(*                                                                            *)
+(******************************************************************************)
+
+
+(*** Handling of real_of_int and real_is_int: ***)
+theory Real_of_Int extends RIA =
+   axiom rii : forall x : real [real_is_int(x)]. real_is_int(x) = (x = real_of_int(int_floor(x)))
+
+   axiom roi_add :
+     forall x, y : int [real_of_int(x+y)].
+       real_of_int(x + y) = real_of_int(x) + real_of_int(y)
+
+   axiom roi_sub :
+     forall x, y : int [real_of_int(x-y)].
+       real_of_int(x - y) = real_of_int(x) - real_of_int(y)
+
+   axiom roi_mult :
+     forall x, y : int [real_of_int(x*y)].
+       real_of_int(x * y) = real_of_int(x) * real_of_int(y)
+
+   axiom roi_monotonicity_1 :
+     forall x : int.
+     forall k : real.
+     forall i : int
+     [real_of_int(x), x in ]?, i], k |-> real_of_int(i)]
+     {x <= i}.
+     real_of_int(x) <= k
+
+   axiom roi_monotonicity_2 :
+     forall x : int.
+     forall k : real.
+     forall i : int
+     [real_of_int(x), x in [i, ?[, k |-> real_of_int(i)]
+     {i <= x}.
+     k <= real_of_int(x)
+
+   axiom real_of_int_to_int_1 :
+     forall x, k : int.
+     forall i : real
+     [real_of_int(x), real_of_int(x) in ]?, i], k |-> int_floor(i)]
+     {real_of_int(x) <= i}.
+     x <= k
+
+   axiom real_of_int_to_int_2 :
+     forall x, k : int.
+     forall i : real
+     [real_of_int(x), real_of_int(x) in [i, ?[, k |-> int_ceil(i)]
+     {i <= real_of_int(x)}.
+     k <= x
+
+   (* can add other axioms on strict ineqs on rationals ? *)
+
+end
+
+theory ABS extends RIA =
+
+   axiom abs_real_pos :
+     forall x : real
+     [
+        abs_real(x),
+        x in [0., ?[
+     ]
+     {x >= 0.}.
+     abs_real(x) = x
+
+  axiom abs_real_neg :
+     forall x : real
+     [
+        abs_real(x),
+        x in ]?, 0.]
+     ]
+     {x <= 0.}.
+     abs_real(x) = -x
+
+   case_split abs_real_cs:
+     forall x : real
+     [
+        abs_real(x),
+        x in [?i,?j],
+        0. in ]?i,?j[
+     ].
+     (* not of the form (a or not a) to avoid simplification of F.mk_or *)
+     x <= 0. or x >= 0.
+
+   axiom abs_real_interval_1 :
+     forall x : real
+     [
+        abs_real(x),
+        abs_real(x) in [?i, ?j],
+        0. in ]?i, ?j[
+     ].
+     0. <= abs_real(x)
+
+   axiom abs_real_interval_2 : (* should block this axiom once the deduction is made,
+         but this needs to have i and j on the left-hand-side of semantic triggers *)
+     forall i, j, k : real.
+     forall x : real
+     [
+        abs_real(x),
+        x in [i, j],
+        k |-> max_real (abs_real(i), abs_real(j))
+     ]
+     {i <= x, x <= j}.
+     abs_real(x) <= k
+
+   axiom abs_real_interval_3 : (* should block this axiom once the deduction is made,
+         but this needs to have i and j on the left-hand-side of semantic triggers *)
+     forall i : real.
+     forall x : real
+     [
+        abs_real(x),
+        abs_real(x) in [?, i]
+     ]
+     { abs_real(x) <= i }.
+     - i <= x <= i
+
+   axiom abs_real_from_square_large:
+     forall x, y : real[x*x,y*y]. (* semantic triggers mising *)
+       x*x <= y*y ->
+       abs_real(x) <= abs_real(y)
+
+   axiom abs_real_from_square_strict:
+     forall x, y : real[x*x,y*y]. (* semantic triggers mising *)
+       x*x < y*y ->
+       abs_real(x) < abs_real(y)
+
+
+   axiom abs_real_greater_than_real :
+     forall x : real
+     [
+        abs_real(x)
+     ].
+     x <= abs_real(x)
+
+
+  (* TODO: add semantic triggers not_theory_constant(x) on axioms of abs_int *)
+
+   axiom abs_int_pos :
+     forall x : int[abs_int(x) , x in [0, ?[ ]
+     {x >= 0}.
+     abs_int(x) = x
+
+  axiom abs_int_neg :
+     forall x : int[abs_int(x), x in ]?, 0]]
+     {x <= 0}.
+     abs_int(x) = -x
+
+   case_split abs_int_cs:
+     forall x : int [abs_int(x) , x in [?i,?j], 0 in ]?i,?j[].
+     (* not of the form (a or not a) to avoid simplification of F.mk_or *)
+     x <= 0 or x >= 0
+
+  axiom abs_int_interval_1 :
+     forall x : int [abs_int(x), abs_int(x) in [?i, ?j], 0 in ]?i, ?j[].
+     0 <= abs_int(x)
+
+  axiom abs_int_interval_2 :
+     forall i, j, k : int.
+     forall x : int [abs_int(x), x in [i, j], k |-> max_int (abs_int(i), abs_int(j))]
+     {i <= x , x <= j}.
+     abs_int(x) <= k
+
+  axiom abs_int_interval_3 :
+     forall i : int.
+     forall x : int [abs_int(x), abs_int(x) in [?, i]]
+     { abs_int(x) <= i }.
+     - i <= x <= i
+
+end


### PR DESCRIPTION
This patch adds support for "builtin" theory preludes, i.e. preludes
that are embedded in the Alt-Ergo binary (actually, library) rather than
being bundled as separate files.  The FPA prelude is moved from an
"old-style" prelude to such a bundled prelude -- in fact, to three
separate preludes (RIA, NRA, and FPA) to better reflect the fact that
some of the axioms within are not specific to floating point arithmetic
at all.

This new style of preludes reflects the idea that the fact that
floating-point support is implemented using a prelude is just that: an
implementation detail, and is otherwise irrelevant. It could as well be
a builtin theory, and there should be no difference to the end user.

The `--prelude` option is preserved, both for backwards compatibility
but also because the concept of user-defined preludes is useful. The new
builtin preludes are controlled with the `--enable-preludes`,
`--disable-preludes`, and `--disable-default-preludes` option.

Note that, keeping in sync with the remark above, we may want to call
these new options `--enable-theories` / `--disable-theories` (although
we can't really have `--disable-default-theories`), but if we do so, we
should consolidate somehow to expose consistent options with the
existing `--disable-adts` and co (I think having a single option to
enable/disable the theories selectively is better than adding
`--disable-fpa`, `--disable-ria` and `--disable-nra`, but I could be
convinced otherwise).

Note: This PR includes #647 and should not be merged as-is, but only after #647 are merged.
It also will not build on the CI, as it depends on Gbury/dolmen#160 being merged first.

The [last commit](https://github.com/OCamlPro/alt-ergo/commit/f90f9e94aaa71799152a87a52fcb90ca195dc9c6) can be reviewed independently, however, the API changes in Dolmen from that PR are fairly minor.