### PR TITLE
Add a debugging option to display the commands sent to the solver

### DIFF
--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -189,12 +189,13 @@ module Debug = struct
     | Unsat_core
     | Use
     | Warnings
+    | Commands
 
   let all = [
     Debug; Ac; Adt; Arith; Arrays; Bitv; Sum; Ite;
     Cc; Combine; Constr; Explanation; Fm; Fpa; Gc;
     Interpretation; Matching; Sat; Split; Triggers;
-    Types; Typing; Uf; Unsat_core; Use; Warnings
+    Types; Typing; Uf; Unsat_core; Use; Warnings; Commands
   ]
 
   let show = function
@@ -224,6 +225,7 @@ module Debug = struct
     | Unsat_core -> "unsat-core"
     | Use -> "use"
     | Warnings -> "warnings"
+    | Commands -> "commands"
 
   let mk ~verbosity flags =
     List.concat flags
@@ -254,6 +256,7 @@ module Debug = struct
         | Unsat_core -> Options.set_debug_unsat_core true
         | Use -> Options.set_debug_use true
         | Warnings -> Options.set_debug_warnings true
+        | Commands -> Options.set_debug_commands true
       )
 
   let light_flag_term, medium_flag_term, full_flag_term =

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -66,6 +66,11 @@ let main () =
   let module FE = Frontend.Make (SAT) in
 
   let solve all_context (cnf, goal_name) =
+    if Options.get_debug_commands () then
+      Printer.print_dbg "@[<v 2>goal %s:@ %a@]@."
+        ~module_name:"Solving_loop" ~function_name:"solve"
+        goal_name
+        Fmt.(list ~sep:sp Commands.print) cnf;
     let used_context = FE.choose_used_context all_context ~goal_name in
     let consistent_dep_stack = Stack.create () in
     Signals_profiling.init_profiling ();

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -163,6 +163,7 @@ let debug_uf = ref false
 let debug_unsat_core = ref false
 let debug_use = ref false
 let debug_warnings = ref false
+let debug_commands = ref false
 let rule = ref (-1)
 
 let set_debug b = debug := b
@@ -191,6 +192,7 @@ let set_debug_uf b = debug_uf := b
 let set_debug_unsat_core b = debug_unsat_core := b
 let set_debug_use b = debug_use := b
 let set_debug_warnings b = debug_warnings := b
+let set_debug_commands b = debug_commands := b
 let set_rule b = rule := b
 
 let get_debug () = !debug
@@ -219,6 +221,7 @@ let get_debug_uf () = !debug_uf
 let get_debug_unsat_core () = !debug_unsat_core
 let get_debug_use () = !debug_use
 let get_debug_warnings () = !debug_warnings
+let get_debug_commands () = !debug_commands
 let get_rule () = !rule
 
 (** Case split options *)

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -170,6 +170,9 @@ val set_debug_use : bool -> unit
 (** Set [debug_warnings] accessible with {!val:get_debug_warnings} *)
 val set_debug_warnings : bool -> unit
 
+(** Set [debug_commands] accessible with {!val:get_debug_commands} *)
+val set_debug_commands : bool -> unit
+
 (** Set [profiling] accessible with {!val:get_profiling} *)
 val set_profiling : bool -> float -> unit
 
@@ -458,6 +461,10 @@ val get_debug : unit -> bool
 
 (** Get the debugging flag of warnings. *)
 val get_debug_warnings : unit -> bool
+
+(** Get the debugging flag of commands. If enabled, Alt-Ergo will display all
+    the commands that are sent to the solver. *)
+val get_debug_commands : unit -> bool
 
 (** Get the debugging flag of cc. *)
 val get_debug_cc : unit -> bool


### PR DESCRIPTION
Use `-d commands` to display the commnds before sending them to the solver.  This is useful to debug parsing issues and differences between frontends.