### PR TITLE
[dolmen] Make a roundtrip through [Q] to normalize reals

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -804,7 +804,11 @@ let rec mk_expr ?(loc = Loc.dummy) ?(name_base = "")
           | B.True -> E.vrai
           | B.False -> E.faux
           | B.Integer s -> E.int s
-          | B.Decimal s -> E.real s
+          | B.Decimal s ->
+            (* We do a roundtrip through [Q.t] to ensure that multiple
+               representations of the same real (e.g. [2] and [0x1.0p1]) get
+               normalized to the same expression.  *)
+            E.real (s |> Q.of_string |> Q.to_string)
           | B.Bitvec s ->
             let ty = dty_to_ty term_ty in
             E.bitv s ty


### PR DESCRIPTION
When using the Dolmen frontend, we are not properly normalizing the representation of reals, which means that we can have multiple representations of the same underlying real value (e.g. [2] and [0x1.0p1]). This means that the Dolmen frontend misses some early optimization opportunities compared to the legacy frontend.

This was found using the `-d commands` option from #663.