### PR TITLE
[frontend:legacy] Explicitely disable polymorphic enums

### DIFF
--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -147,7 +147,7 @@ module Types = struct
       let ty = Ty.text ty_vars id in
       ty, { env with to_ty = MString.add id ty env.to_ty }
     | Enum lc ->
-      if Stdlib.(ty_vars <> []) then
+      if not (Lists.is_empty ty_vars) then
         Errors.typing_error (PolymorphicEnum id) loc;
       let ty = Ty.tsum id lc in
       ty, { env with to_ty = MString.add id ty env.to_ty }

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -147,6 +147,8 @@ module Types = struct
       let ty = Ty.text ty_vars id in
       ty, { env with to_ty = MString.add id ty env.to_ty }
     | Enum lc ->
+      if Stdlib.(ty_vars <> []) then
+        Errors.typing_error (PolymorphicEnum id) loc;
       let ty = Ty.tsum id lc in
       ty, { env with to_ty = MString.add id ty env.to_ty }
     | Record (record_constr, lbs) ->

--- a/src/lib/structures/errors.ml
+++ b/src/lib/structures/errors.ml
@@ -75,6 +75,7 @@ type typing_error =
   | NotAdtConstr of string * Ty.t
   | BadPopCommand of {pushed : int; to_pop : int}
   | ShouldBePositive of int
+  | PolymorphicEnum of string
 
 type run_error =
   | Invalid_steps_count of int
@@ -216,6 +217,10 @@ let report_typing_error fmt = function
   | ShouldBePositive n ->
     fprintf fmt
       "This integer : %d should be positive" n
+
+  | PolymorphicEnum n ->
+    fprintf fmt
+      "Polymorphic enum definition for %s is not supported" n
 
 let report_run_error fmt = function
   | Invalid_steps_count i ->

--- a/src/lib/structures/errors.mli
+++ b/src/lib/structures/errors.mli
@@ -81,6 +81,7 @@ type typing_error =
   | NotAdtConstr of string * Ty.t
   | BadPopCommand of {pushed : int; to_pop : int}
   | ShouldBePositive of int
+  | PolymorphicEnum of string
 
 (** Errors that can be raised at solving*)
 type run_error =


### PR DESCRIPTION
Polymorphic enums are not supported by the legacy typechecker (enums aka sum types are always monomorphic), but they fail with a cryptic error message (see #517).

The dolmen frontend deals with this properly, and we plan on deprecating the legacy typechecker in the future, so it's probably not worth fixing -- but at the very least we should have a more informative error message.

Fixes #517