### PR TITLE
Make fpa_rounding_mode an ADT again

### DIFF
--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2815,7 +2815,9 @@ let const_view t =
       | exception Failure _ ->
         Fmt.failwith "error when trying to convert %s to an int" n
     end
-  | { f = Op RoundingMode m; _ } -> RoundingMode m
+  | { f = Op (Constr c); ty; _ }
+    when Ty.equal ty Fpa_rounding.fpa_rounding_mode ->
+    RoundingMode (Fpa_rounding.rounding_mode_of_hs c)
   | _ -> Fmt.failwith "unsupported constant: %a" print t
 
 let int_view t =

--- a/src/lib/structures/fpa_rounding.ml
+++ b/src/lib/structures/fpa_rounding.ml
@@ -65,7 +65,32 @@ let pp_rounding_mode ppf m =
   | Nd -> "Nd"
   | Nu -> "Nu"
 
-let fpa_rounding_mode = Ty.Text ([], Hs.make "fpa_rounding_mode")
+let fpa_rounding_mode, rounding_mode_of_hs =
+  let cstrs =
+    [ (* standards *)
+      NearestTiesToEven;
+      ToZero;
+      Up;
+      Down;
+      NearestTiesToAway;
+      (* non standards *)
+      Aw;
+      Od;
+      No;
+      Nz;
+      Nd;
+      Nu ]
+  in
+  let h_cstrs =
+    List.map (fun c -> Hs.make (Format.asprintf "%a" pp_rounding_mode c)) cstrs
+  in
+  let ty = Ty.Tsum (Hs.make "fpa_rounding_mode", h_cstrs) in
+  let table =
+    let table = Hashtbl.create 17 in
+    List.iter2 (Hashtbl.add table) h_cstrs cstrs;
+    table
+  in
+  ty, Hashtbl.find table
 
 (** Helper functions **)
 

--- a/src/lib/structures/fpa_rounding.mli
+++ b/src/lib/structures/fpa_rounding.mli
@@ -45,9 +45,9 @@ type rounding_mode =
   | Nd (* nd in Gappa: to nearest, tie breaking toward minus infinity *)
   | Nu (* nu in Gappa: to nearest, tie breaking toward plus infinity *)
 
-val pp_rounding_mode : Format.formatter -> rounding_mode -> unit
-
 val fpa_rounding_mode : Ty.t
+
+val rounding_mode_of_hs : Hstring.t -> rounding_mode
 
 (** Integer part of binary logarithm for NON-ZERO POSITIVE number **)
 val integer_log_2 : Numbers.Q.t -> int

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -48,7 +48,7 @@ type operator =
   | Extract of int * int (* lower bound * upper bound *)
   (* FP *)
   | Float
-  | RoundingMode of Fpa_rounding.rounding_mode | Integer_round | Fixed
+  | Integer_round | Fixed
   | Sqrt_real | Sqrt_real_default | Sqrt_real_excess
   | Abs_int | Abs_real | Real_of_int | Real_is_int
   | Int_floor | Int_ceil | Integer_log2
@@ -139,14 +139,12 @@ let compare_operators op1 op2 =
       | Extract (i1, j1), Extract (i2, j2) ->
         let r = Int.compare i1 i2 in
         if r = 0 then Int.compare j1 j2 else r
-      | RoundingMode m1, RoundingMode m2 ->
-        Stdlib.compare m1 m2
       | _ , (Plus | Minus | Mult | Div | Modulo | Real_is_int
             | Concat | Extract _ | Get | Set | Fixed | Float | Reach
             | Access _ | Record | Sqrt_real | Abs_int | Abs_real
             | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
-            | Integer_log2 | Pow | Integer_round | RoundingMode _
+            | Integer_log2 | Pow | Integer_round
             | Not_theory_constant | Is_theory_constant | Linear_dependency
             | Constr _ | Destruct _ | Tite) -> assert false
     )
@@ -297,7 +295,6 @@ let to_string ?(show_vars=true) x = match x with
   | Op Get -> "get"
   | Op Set -> "set"
   | Op Float -> "float"
-  | Op RoundingMode m -> Format.asprintf "%a" Fpa_rounding.pp_rounding_mode m
   | Op Fixed -> "fixed"
   | Op Abs_int -> "abs_int"
   | Op Abs_real -> "abs_real"

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -48,7 +48,7 @@ type operator =
   | Extract of int * int (* lower bound * upper bound *)
   (* FP *)
   | Float
-  | RoundingMode of Fpa_rounding.rounding_mode | Integer_round | Fixed
+  | Integer_round | Fixed
   | Sqrt_real | Sqrt_real_default | Sqrt_real_excess
   | Abs_int | Abs_real | Real_of_int | Real_is_int
   | Int_floor | Int_ceil | Integer_log2


### PR DESCRIPTION
In #647 the fpa_rounding_mode was converted from an ADT to a builtin type.  This broke the use of [is_theory_constant] on the fpa_rounding_mode type, because it is no longer a theory constant (it previously was a theory constant for the ADT theory, but being a builtin it no longer has an associated theory).

This patch makes the fpa_rounding_mode type an ADT again.