### PR TITLE
Clear preludes in options when `--disable-default-preludes` is set

### DIFF
--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -1303,7 +1303,7 @@ let parse_theory_opt =
     let preludes enable_preludes disable_preludes disable_builtin_preludes =
       let preludes =
         if disable_builtin_preludes then
-          []
+          (Options.set_preludes []; [])
         else
           Preludes.default
       in


### PR DESCRIPTION
Otherwise the option is pointless since they are loaded anyways, at least with the dolmen frontend.