### PR TITLE
Add dependency to the alt-ergo binary for the tests

### DIFF
--- a/tools/gentest.ml
+++ b/tools/gentest.ml
@@ -149,7 +149,7 @@ end = struct
 @[<v 1>\
 (rule@,\
 (target %a)@,\
-(deps (:input %s))@,\
+(deps (:input %s) %%{bin:alt-ergo})@,\
 (package alt-ergo)@,\
 @[<v 1>(action@,\
 @[<v 1>(no-infer@,\


### PR DESCRIPTION
Currently the `gentest` script only adds the input file as a dependency for the test. This means that if the input file has not changed, dune will not re-run the test, which is clearly not what we want.

This is cause of issues because tests that shouldn't pass, look like they pass --- but they actually just aren't run! This affects the CI as well, because we keep a dune cache across CI runs.

This patch fixes the issue by adding a dependency to the alt-ergo binary, forcing the tests to re-run whenever the binary changes (after recompilation).

Fixes #638