### PR TITLE
Proper C-bitvector substitutions

### DIFF
--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -566,9 +566,11 @@ module Shostak(X : ALIEN) = struct
 
     let apply_subs subs sys =
       let rec f_aux = function
-        |[] -> assert false
-        |v::r -> try let (v1,v2) = List.assoc v subs in v1::v2::(f_aux r)
-          with _ -> v::(f_aux r)
+        |[] -> []
+        |v::r ->
+          match List.assoc v subs with
+          | (v1, v2) -> v1 :: v2 :: f_aux r
+          | exception Not_found -> v :: f_aux r
       in List.map (fun (t,vls) ->(t,List.map f_aux vls))sys
 
     let equations_slice parts =

--- a/tests/issues/649/649.ae
+++ b/tests/issues/649/649.ae
@@ -1,0 +1,5 @@
+logic x: bitv[2]
+
+goal g:
+  forall y: bitv[4].
+    (y^{3,3} @ y^{3,3}) @ y = ([|00|] @ x) @ [|00|]

--- a/tests/issues/649/649.expected
+++ b/tests/issues/649/649.expected
@@ -1,0 +1,2 @@
+
+unknown

--- a/tests/issues/649/dolmen/649.expected
+++ b/tests/issues/649/dolmen/649.expected
@@ -1,0 +1,2 @@
+
+unknown

--- a/tests/issues/649/dolmen/649.smt2
+++ b/tests/issues/649/dolmen/649.smt2
@@ -1,0 +1,10 @@
+(set-logic BV)
+(declare-const x (_ BitVec 2))
+(assert (
+    exists
+      ((y (_ BitVec 4)))
+      (distinct
+        (concat (concat ((_ extract 3 3) y) ((_ extract 3 3) y)) y)
+        (concat (concat (_ bv0 2) x) (_ bv0 2))
+)))
+(check-sat)


### PR DESCRIPTION
When solving bitvector equalities, if there is a C-substitution that is found, applying that substitution will always result in an assertion failure, because we are iterating over a list recursively and have an unconditional `assert false` in the empty case.

I believe that returning an empty list here is the correct thing, and makes the function an actual substitution.

Note that in many cases we don't hit the assertion failure because if there is no substitution at all, the `apply_subs` function is not called in `equations_slice` (if I had to wager a guess, I would say that the `assert false` in `apply_subs` came from trying to ensure that the `subs` was not empty -- except it was not applied to the right variable).

Fixes #649