### PR TITLE
Use implicit dependency to the alt-ergo binary for the tests

### DIFF
--- a/tools/gentest.ml
+++ b/tools/gentest.ml
@@ -270,7 +270,7 @@ let () =
       Sys.argv.(1)
     else "."
   in
-  let bin = "alt-ergo" in
+  let bin = "%{bin:alt-ergo}" in
   let timelimit = "--timelimit=2" in
   let solvers = [
     ("runtest-quick", "dolmen", [


### PR DESCRIPTION
(This is a better version of #676 that lets dune infer the dependency)

Currently the `gentest` script only adds the input file as a dependency for the test. This means that if the input file has not changed, dune will not re-run the test, which is clearly not what we want.

This is cause of issues because tests that shouldn't pass, look like they pass --- but they actually just aren't run! This affects the CI as well, because we keep a dune cache across CI runs.

This patch fixes the issue by adding an implicit dependency to the alt-ergo binary, forcing the tests to re-run whenever the binary changes (after recompilation).

Fixes #638