### PR TITLE
Compatibility with new Dolmen constructs

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -472,7 +472,7 @@ let main () =
               { solver_ctx with ctx = cnf @ solver_ctx.ctx }
             ) st
         end
-      | {id = _; contents = `Solve _; loc }
+      | {id = _; contents = `Solve _; loc ; attrs }
         when (
           match (State.get State.logic_file st).lang with
           | Some (Smtlib2 _) -> true
@@ -490,7 +490,7 @@ let main () =
             Typer_Pipe.{
               id = DStd.Id.mk DStd.Namespace.term goal_name;
               contents = `Goal DStd.Expr.Term.(of_cst Const._false);
-              loc;
+              loc; attrs;
             }
         in
         let cnf = List.rev rev_cnf in


### PR DESCRIPTION
Now that Gbury/dolmen#162 and Gbury/dolmen#166 have been merged the build is broken. This patch removes the old In_interval constructor. It was not working properly anyways. Support for the new Semantic_trigger constructor that replaces it in dolmen will land in #681.

In addition, this patch is adapted to propagate attributes from the typed statements. This will help determine theory and case-split information in #662.