### PR TITLE
[bitv] Actually apply the C-substitution

### DIFF
--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -819,7 +819,7 @@ module Shostak(X : ALIEN) = struct
               in
               if Lists.compare cmp _bw bw = 0
               then slice_rec ((t,vls')::bw) _fw
-              else slice_rec [] (bw@((t,vls'):: _fw))
+              else slice_rec [] (_bw@((t,vls'):: _fw))
             end
       in slice_rec [] parts
 


### PR DESCRIPTION
In `equations_slice` we apply the C-substitution to the equations that we have already treated and then re-process these equations *while ignoring the substitution*. This patch fixes it by feeding back the *post-substitution* equations to the recursive call when a substitution actually took place.