### PR TITLE
[bitv] Do not use structural comparison when equality is enough

### DIFF
--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -671,7 +671,7 @@ module Shostak(X : ALIEN) = struct
     (* [partition eq l] returns a list of pairs [(a, bs)] where [bs] contains
        all the [b] such that [(a, b)] occurs in the original list.
 
-       When applied to oriented systems of equatoins returned by [sys_solve],
+       When applied to oriented systems of equations returned by [sys_solve],
        this merges together all the equalities involving the same [simple_term]
        on the left. *)
     let partition eq l =

--- a/src/lib/util/lists.ml
+++ b/src/lib/util/lists.ml
@@ -77,3 +77,10 @@ let rec compare cmp l1 l2 =
     if c <> 0 then c
     else
       compare cmp tl1 tl2
+
+(* List.equal in OCaml 4.12+ *)
+let rec equal eq l1 l2 =
+  match l1, l2 with
+  | [], [] -> true
+  | hd1 :: tl1, hd2 :: tl2 when eq hd1 hd2 -> equal eq tl1 tl2
+  | _ -> false

--- a/src/lib/util/lists.mli
+++ b/src/lib/util/lists.mli
@@ -57,3 +57,6 @@ val find_opt : ('a -> bool) -> 'a list -> 'a option
 val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
 (** [compare cmp l1 l2] compares the lists [l1] and [l2] using the comparison
     function [cmp] on elements. *)
+
+val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+(** This is [List.equal] from the OCaml 4.12+ *)

--- a/src/lib/util/lists.mli
+++ b/src/lib/util/lists.mli
@@ -59,4 +59,8 @@ val compare : ('a -> 'a -> int) -> 'a list -> 'a list -> int
     function [cmp] on elements. *)
 
 val equal : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
-(** This is [List.equal] from the OCaml 4.12+ *)
+(** [equal eq l1 l2] holds when the two input lists have the same length and for
+    each pair of elements [ai], [bi] at the same position in [l1] and [l2]
+    respectively, we have [eq ai bi].
+
+    This is a backport of List.equal from OCaml 4.12.0 *)


### PR DESCRIPTION
This replaces uses of the (potentially expensive) structural comparison functions in the bitv module with cheaper comparisons using equality, which can make use of the hash-consing of terms.