### PR TITLE
[dolmen] Add support for n-ary "and" and "or" in pp_query

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1402,19 +1402,17 @@ let pp_query ~valid_mode t =
 
     | App (
         { term_descr = Cst { builtin = B.And; _ }; _ },
-        tyl, [x; y]
+        tyl, es
       ) when not bnot ->
-      let e1 = elim_toplevel_forall false x in
-      let e2 = elim_toplevel_forall false y in
-      DE.Term.apply_cst DE.Term.Const.and_ tyl [e1; e2]
+      let es = List.map (elim_toplevel_forall false) es in
+      DE.Term.apply_cst DE.Term.Const.and_ tyl es
 
     | App (
         { term_descr = Cst { builtin = B.Or;  _ }; _ },
-        tyl, [x; y]
+        tyl, es
       ) when bnot ->
-      let e1 = elim_toplevel_forall true x in
-      let e2 = elim_toplevel_forall true y in
-      DE.Term.apply_cst DE.Term.Const.and_ tyl [e1; e2]
+      let es = List.map (elim_toplevel_forall true) es in
+      DE.Term.apply_cst DE.Term.Const.and_ tyl es
 
     | App (
         { term_descr = Cst { builtin = B.Imply; _ }; _ },


### PR DESCRIPTION
The Dolmen builtins `B.And` and `B.Or` are n-ary.