### PR TITLE
Make hypotheses with `Sat` goal_sort be global

### DIFF
--- a/src/lib/structures/ty.ml
+++ b/src/lib/structures/ty.ml
@@ -704,7 +704,7 @@ let fresh_hypothesis_name =
   fun sort ->
     incr cpt;
     match sort with
-    | Thm -> "@H"^(string_of_int !cpt)
+    | Thm | Sat -> "@H"^(string_of_int !cpt)
     | _ -> "@L"^(string_of_int !cpt)
 
 let is_local_hyp s =


### PR DESCRIPTION
The Thm/Sat distinction is used for model generation (and for printing purposes only, as far as I can tell). The global/local distinction is related to the behavior of the `check` and `cut` commands, and from that point of view, Thm and Sat should behave identically.