### PR TITLE
Documentation of the ite relations

### DIFF
--- a/src/lib/reasoners/ite_rel.ml
+++ b/src/lib/reasoners/ite_rel.ml
@@ -56,12 +56,12 @@ module TB =
 
 (* The present theory simplifies the ite t of the form
     ite(pred, t1, t2)
-   where pred is an assumed predicate by adding the equation
+   where pred is an assumed predicate by introducing the equation
    t = t1 or t = t2 according to the truth value of pred. *)
 
 type t = {
   pending_deds      : Ex.t ME2.t;
-  (* Map of pending deducations to their explanation. A deduction is just
+  (* Map of pending deductions to their explanation. A deduction is just
      an equation of the form t = b where t is an ite and b is one of its
      branches. *)
 

--- a/src/lib/reasoners/ite_rel.ml
+++ b/src/lib/reasoners/ite_rel.ml
@@ -97,7 +97,7 @@ let add_to_guarded p s t mp =
   let st = try ME.find p mp with Not_found -> SE2.empty in
   ME.add p (SE2.add (s, t) st) mp
 
-(* Check if the condition of the ite t is an assumed predicate. If do so,
+(* Check if the condition of the ite t is an assumed predicate. If so,
    select the appropriate branch b of the ite and produce the deduction t = b.
    Otherwise save the if and else branches of t in order to retrieve them
    quickly in the assume function. *)

--- a/src/lib/reasoners/ite_rel.ml
+++ b/src/lib/reasoners/ite_rel.ml
@@ -54,28 +54,37 @@ module TB =
         if c <> 0 then c else Stdlib.compare b1 b2
     end)
 
-(* The present theory simplifies the ite t of the form
+(* The present theory simplifies the ite terms t of the form
     ite(pred, t1, t2)
    where pred is an assumed predicate by introducing the equation
    t = t1 or t = t2 according to the truth value of pred. *)
 
 type t = {
   pending_deds      : Ex.t ME2.t;
-  (* Map of pending deductions to their explanation. A deduction is just
-     an equation of the form t = b where t is an ite and b is one of its
-     branches. *)
+  (* Map of pending deductions to their explanation. A deduction is an equation
+     of the form t = b where t is an ite term and b is one of its branches.
+     A deduction is added to pending_deds if the condition of the ite term
+     is entailed by the current state of the solver. If so, the appropriate
+     branch is selected according to the truth value of the condition. *)
 
   guarded_pos_deds  : SE2.t ME.t;
-  (* Map of the conditions to the if branches. *)
+  (* Map of the condition of ite terms to its if branch.
+     This map contains only condition that was not entailed yet by the
+     current state of the solver during the registration of the ite term. *)
 
   guarded_neg_deds  : SE2.t ME.t;
-  (* Map of the conditions to the else branches. *)
+  (* Map of the condition of ite terms to its else branch.
+     This map contains only condition whose the negation was not entailed yet
+     by the current state of the solver during the registration of the ite
+     term. *)
 
   assumed_pos_preds : Ex.t ME.t;
-  (* Map of all the predicates assumed true to their explanation. *)
+  (* Map of all the predicates entailed by the current state of the solver to
+     their explanation. *)
 
   assumed_neg_preds : Ex.t ME.t;
-  (* Map of all the predicates assumed false to their explanation. *)
+  (* Map of all the predicates whose the negation is entailed by the current
+     state of the solver to their explanation. *)
 }
 
 let empty _ = {
@@ -97,10 +106,10 @@ let add_to_guarded p s t mp =
   let st = try ME.find p mp with Not_found -> SE2.empty in
   ME.add p (SE2.add (s, t) st) mp
 
-(* Check if the condition of the ite t is an assumed predicate. If so,
-   select the appropriate branch b of the ite and produce the deduction t = b.
-   Otherwise save the if and else branches of t in order to retrieve them
-   quickly in the assume function. *)
+(* Check if the condition of the ite t is a predicate entailed by the current
+   state of the solver. If so, select the appropriate branch b of the ite and
+   produce the deduction t = b. Otherwise save the if and else branches of t
+   in order to retrieve them quickly in the assume function. *)
 let add_aux env t =
   if Options.get_disable_ites () then env
   else


### PR DESCRIPTION
This PR add a documentation of the implementation of `ite_rel`.
As Basile explained this theory simplify an ite `t` of the form `ite(cond, b1, b2)` and whose the condition `cond` is assumed in the current context by adding equation `t = b1` or `t = b2` according to the truth value of `cond`.

I noticed that `ite_rel` does this simplification only for predicate condition. I don't know if there is actually other cases. 