### PR TITLE
Make Dolmen ignore the "shawoding" warning

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -295,6 +295,7 @@ let main () =
         |> disable "unused-type-var"
         |> disable "unused-term-var"
         |> disable "extra-dstr"
+        |> disable "shadowing"
       )
     in
     let dir = Filename.dirname path in


### PR DESCRIPTION
Many files from the SMT-LIB benchmarks have (intentional or not) shadowing.
Allowing the warning pollutes the output.