### PR TITLE
[models] Actually print values, not terms

### DIFF
--- a/src/lib/structures/ty.mli
+++ b/src/lib/structures/ty.mli
@@ -130,6 +130,9 @@ val equal : t -> t -> bool
 val compare : t -> t -> int
 (** Comparison function *)
 
+val pp_smtlib : Format.formatter -> t -> unit
+(** Printing function for types in smtlib2 format. *)
+
 val print : Format.formatter -> t -> unit
 (** Printing function for types (does not print
     the type of each fields for records). *)

--- a/tests/issues/555.models.expected
+++ b/tests/issues/555.models.expected
@@ -1,7 +1,8 @@
 
 unknown
 (
+  (define-fun a1 () (Array Int Int)
+   (store ((as const (Array Int Int)) 0) 0 0))
   (define-fun x () Int 0)
   (define-fun y () Int 0)
-  (define-fun a1 () (Array Int Int) (store (as @a1 (Array Int Int)) 0 0))
 )

--- a/tests/models/uf/uf2.models.expected
+++ b/tests/models/uf/uf2.models.expected
@@ -1,7 +1,7 @@
 
 unknown
 (
-  (define-fun f ((arg_0 Int)) Int (ite (= arg_0 a) 2 0))
+  (define-fun f ((arg_0 Int)) Int (ite (= arg_0 0) 2 0))
   (define-fun a () Int 0)
   (define-fun b () Int (- 2))
 )


### PR DESCRIPTION
This patch makes it so that the model values that we print are actually values, not terms (i.e. they do not contain variables).  This is achieved by aggressively substituting variable definitions when printing.

The patch is a bit more involved than I'd have liked, because we can't simply substitute semantic values into terms, so the guts of the model printing had to be changed a little.

The code now works in two pass. In the first pass, we build a hash table from symbols (constants and arrays) to their respective definitions using the new `value_defn` mini-language, which we then use for printing. The substitution is performed on-the-fly in the second pass, which actually prints, using the hash table that was built in the first pass.