### PR TITLE
[refactor] Always represent classes as sets

### DIFF
--- a/src/lib/reasoners/arrays_rel.ml
+++ b/src/lib/reasoners/arrays_rel.ml
@@ -229,8 +229,8 @@ let update_env are_eq are_dist dep env acc gi si p p_ded n n_ded =
   ---------------------------------------------------------------------*)
 let get_of_set are_eq are_dist gtype (env,acc) class_of =
   let {g=get; gt=gtab; gi=gi; gty=gty} = gtype in
-  L.fold_left
-    (fun (env,acc) set ->
+  E.Set.fold
+    (fun set (env,acc) ->
        if Tmap.splited get set env.seen then (env,acc)
        else
          let env = {env with seen = Tmap.update get set env.seen} in
@@ -253,16 +253,16 @@ let get_of_set are_eq are_dist gtype (env,acc) class_of =
            update_env
              are_eq are_dist dep env acc gi si p p_ded n n_ded
          | _ -> (env,acc)
-    ) (env,acc) (class_of gtab)
+    ) (class_of gtab) (env,acc)
 
 (*----------------------------------------------------------------------
   set(-,-,-) modulo egalite
   ---------------------------------------------------------------------*)
 let get_from_set _are_eq _are_dist stype (env,acc) class_of =
   let sets =
-    L.fold_left
-      (fun acc t -> S.union acc (TBS.find t env.tbset))
-      (S.singleton stype) (class_of stype.st)
+    E.Set.fold
+      (fun t acc -> S.union acc (TBS.find t env.tbset))
+      (class_of stype.st) (S.singleton stype)
   in
 
   S.fold (fun { s = set; si = si; sv = sv; _ } (env,acc) ->
@@ -285,9 +285,9 @@ let get_and_set are_eq are_dist gtype (env,acc) class_of =
   let {g=get; gt=gtab; gi=gi; gty=gty} = gtype in
 
   let suff_sets =
-    L.fold_left
-      (fun acc t -> S.union acc (TBS.find t env.tbset))
-      S.empty (class_of gtab)
+    E.Set.fold
+      (fun t acc -> S.union acc (TBS.find t env.tbset))
+      (class_of gtab) S.empty
   in
   S.fold
     (fun  {s=set; st=stab; si=si; sv=sv; _ } (env,acc) ->

--- a/src/lib/reasoners/ccx.ml
+++ b/src/lib/reasoners/ccx.ml
@@ -71,7 +71,7 @@ module type S = sig
     (r Xliteral.view * bool * Th_util.lit_origin) list * t
   val query :  t -> E.t -> Th_util.answer
   val new_terms : t -> Expr.Set.t
-  val class_of : t -> Expr.t -> Expr.t list
+  val class_of : t -> Expr.t -> Expr.Set.t
   val are_equal : t -> Expr.t -> Expr.t -> init_terms:bool -> Th_util.answer
   val are_distinct : t -> Expr.t -> Expr.t -> Th_util.answer
   val cl_extract : t -> Expr.Set.t list
@@ -341,7 +341,7 @@ module Main : S = struct
       match E.term_view t1 with
       | { E.f = f1; xs = [x]; _ } ->
         let ty_x = Expr.type_info x in
-        List.iter
+        E.Set.iter
           (fun t2 ->
              match E.term_view t2 with
              | { E.f = f2 ; xs = [y]; _ } when Sy.equal f1 f2 ->

--- a/src/lib/reasoners/ccx.mli
+++ b/src/lib/reasoners/ccx.mli
@@ -63,7 +63,7 @@ module type S = sig
     (r Xliteral.view * bool * Th_util.lit_origin) list * t
   val query :  t -> Expr.t -> Th_util.answer
   val new_terms : t -> Expr.Set.t
-  val class_of : t -> Expr.t -> Expr.t list
+  val class_of : t -> Expr.t -> Expr.Set.t
   val are_equal : t -> Expr.t -> Expr.t -> init_terms:bool -> Th_util.answer
   val are_distinct : t -> Expr.t -> Expr.t -> Th_util.answer
   val cl_extract : t -> Expr.Set.t list

--- a/src/lib/reasoners/matching.mli
+++ b/src/lib/reasoners/matching.mli
@@ -60,7 +60,7 @@ module type Arg = sig
   type t
   val term_repr : t -> Expr.t -> init_term:bool -> Expr.t
   val are_equal : t -> Expr.t -> Expr.t -> init_terms:bool -> Th_util.answer
-  val class_of : t -> Expr.t -> Expr.t list
+  val class_of : t -> Expr.t -> Expr.Set.t
 end
 
 

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -900,8 +900,6 @@ let term_repr uf t =
   try SE.min_elt st
   with Not_found -> t
 
-let class_of env t = SE.elements (class_of env t)
-
 let empty () =
   let env = {
     make  = ME.empty;

--- a/src/lib/reasoners/uf.mli
+++ b/src/lib/reasoners/uf.mli
@@ -55,7 +55,7 @@ val are_equal : t -> Expr.t -> Expr.t -> added_terms:bool -> Th_util.answer
 val are_distinct : t -> Expr.t -> Expr.t -> Th_util.answer
 val already_distinct : t -> r list -> bool
 
-val class_of : t -> Expr.t -> Expr.t list
+val class_of : t -> Expr.t -> Expr.Set.t
 val rclass_of : t -> r -> Expr.Set.t
 
 val cl_extract : t -> Expr.Set.t list


### PR DESCRIPTION
Most representations of UF classes uses Expr.Set.t, but `class_of` specifically converts the class to a list. There doesn't seem to be any real reason for that, and it simply causes a bit of memory overhead by creating the list instead of iterating over the expression set directly.

This patch is a first step towards abstracting the representation of UF classes by using a common type for all their representations. It is not entirely trivial to abstract the representation, because of cyclic dependencies with `Explanation.Inconsistent`.