### PR TITLE
Add basic support for the SMT-LIB BV and QF_BV logics

### DIFF
--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2831,3 +2831,235 @@ let rounding_mode_view t =
   match const_view t with
   | RoundingMode m -> m
   | _ -> Fmt.failwith "The given term %a is not a rounding mode" print t
+
+(****************************************************************************)
+(*                     Helpers to build typed terms                         *)
+(****************************************************************************)
+
+(** Constructors from the smtlib core theory.
+    https://smtlib.cs.uiowa.edu/theories-Core.shtml *)
+module Core = struct
+  let not = neg
+  let eq = mk_eq ~iff:false
+  let xor = mk_xor
+  let and_ s t = mk_and s t false
+  let or_ s t = mk_or s t false
+  let ite c t e = mk_ite c t e
+end
+
+(** Constructors from the smtlib theory of integers.
+    https://smtlib.cs.uiowa.edu/theories-Ints.shtml *)
+module Ints = struct
+  let of_Z n = int (Z.to_string n)
+
+  let ( ~$ ) = of_Z
+
+  let of_int n = int (string_of_int n)
+
+  let ( ~$$ ) = of_int
+
+  let ( + ) x y = mk_term (Op Plus) [ x; y ] Tint
+
+  let ( - ) x y = mk_term (Op Minus) [ x; y ] Tint
+
+  let ( ~- ) x = ~$$0 - x
+
+  let ( * ) x y = mk_term (Op Mult) [ x; y ] Tint
+
+  let ( / ) x y = mk_term (Op Div) [ x; y ] Tint
+
+  let ( mod ) x y = mk_term (Op Modulo) [ x; y ] Tint
+
+  let abs x = mk_term (Op Abs_int) [ x ] Tint
+
+  let ( ** ) x y = mk_term (Op Pow) [ x; y ] Tint
+
+  let ( <= ) x y = mk_builtin ~is_pos:true LE [x; y]
+
+  let ( >= ) x y = y <= x
+
+  let ( < ) x y = x <= y - ~$$1
+
+  let ( > ) x y = y < x
+end
+
+(** Constructors from the smtlib theory of fixed-size bit-vectors and the QF_BV
+    logic.
+
+    https://smtlib.cs.uiowa.edu/theories-FixedSizeBitVectors.shtml
+    https://smtlib.cs.uiowa.edu/logics-all.shtml#QF_BV *)
+module BV = struct
+  open Core
+
+  (* Constant symbols for all zeros and all ones *)
+  let bvzero m = bitv (String.make m '0') (Tbitv m)
+  let bvones m = bitv (String.make m '1') (Tbitv m)
+
+  (* Helpers *)
+  let b = function
+    | 0 -> bvzero 1
+    | 1 -> bvones 1
+    | _ -> assert false
+
+  let is x bit = eq x (b bit)
+  let size e = match type_info e with Tbitv m -> m | _ -> assert false
+  let size2 s t =
+    let m = size s in
+    assert (size t = m);
+    m
+
+  let int2bv n t = mk_term (Op (Int2BV n)) [t] (Tbitv n)
+  let bv2nat t = mk_term (Op BV2Nat) [t] Tint
+
+  (* Function symbols for concatenation *)
+  let concat s t =
+    let n = size s and m = size t in
+    mk_term (Op Concat) [s; t] (Tbitv (n + m))
+
+  (* Function symbols for extraction *)
+  let extract i j s =
+    mk_term
+      (Sy.Op (Sy.Extract (j, i))) [s] (Ty.Tbitv (i - j + 1))
+
+  (* Other operations *)
+  let rec repeat i t =
+    assert (i >= 1);
+    if i = 1 then t else concat t (repeat (i - 1) t)
+
+  let zero_extend i t =
+    if i = 0 then t else concat (bvzero i) t
+
+  let sign_extend i t =
+    if i = 0 then t else
+      let m = size t in
+      concat (repeat i (extract (m - 1) (m - 1) t)) t
+
+  let rotate_left i t =
+    let m = size t in
+    if m = 1 then t
+    else
+      let i = i mod m in
+      if i = 0 then t
+      else
+        concat (extract (m - i - 1) 0 t) (extract (m - 1) (m - i) t)
+
+  let rotate_right i t =
+    let m = size t in
+    if m = 1 then t
+    else
+      let i = i mod m in
+      if i = 0 then t
+      else
+        concat (extract (i - 1) 0 t) (extract (m - 1) i t)
+
+  (* Bit-wise operations *)
+  let bvnot s = mk_term (Op BVnot) [s] (type_info s)
+  let bvand s t = mk_term (Op BVand) [s; t] (type_info s)
+  let bvor s t = mk_term (Op BVor) [s; t] (type_info s)
+  let bvnand s t = bvnot (bvand s t)
+  let bvnor s t = bvnot (bvor s t)
+  let bvxor s t = bvor (bvand s (bvnot t)) (bvand (bvnot s) t)
+  let bvxnor s t = bvor (bvand s t) (bvand (bvnot s) (bvnot t))
+  let bvcomp s t =
+    let rec bvcomp m s t =
+      assert (m >= 1);
+      if m = 1 then
+        bvxnor s t
+      else
+        bvand
+          (bvxnor (extract (m - 1) (m - 1) s) (extract (m - 1) (m - 1) t))
+          (bvcomp (m - 1) (extract (m - 2) 0 s) (extract (m - 2) 0 t))
+    in
+    bvcomp (size2 s t) s t
+
+  (* Arithmetic operations *)
+  let bvneg s =
+    let m = size s in
+    int2bv m Ints.(~$Z.(pow ~$2 m) - bv2nat s)
+  let bvadd s t = int2bv (size s) Ints.(bv2nat s + bv2nat t)
+  let bvsub s t = bvadd s (bvneg t)
+  let bvmul s t = int2bv (size s) Ints.(bv2nat s * bv2nat t)
+  let bvudiv s t =
+    let m = size2 s t in
+    ite (eq (bv2nat t) Ints.(~$$0))
+      (bvones m)
+      (int2bv m Ints.(bv2nat s / bv2nat t))
+  let bvurem s t =
+    let m = size2 s t in
+    ite (eq (bv2nat t) Ints.(~$$0))
+      s
+      (int2bv m Ints.(bv2nat s mod bv2nat t))
+  let bvsdiv s t =
+    let m = size2 s t in
+    let msb_s = extract (m - 1) (m - 1) s in
+    let msb_t = extract (m - 1) (m - 1) t in
+    ite (and_ (is msb_s 0) (is msb_t 0))
+      (bvudiv s t)
+    @@ ite (and_ (is msb_s 1) (is msb_t 0))
+      (bvneg (bvudiv (bvneg s) t))
+    @@ ite (and_ (is msb_s 0) (is msb_t 1))
+      (bvneg (bvudiv s (bvneg t)))
+      (bvudiv (bvneg s) (bvneg t))
+  let bvsrem s t =
+    let m = size2 s t in
+    let msb_s = extract (m - 1) (m - 1) s in
+    let msb_t = extract (m - 1) (m - 1) t in
+    ite (and_ (is msb_s 0) (is msb_t 0))
+      (bvurem s t)
+    @@ ite (and_ (is msb_s 1) (is msb_t 0))
+      (bvneg (bvurem (bvneg s) t))
+    @@ ite (and_ (is msb_s 0) (is msb_t 1))
+      (bvurem s (bvneg t))
+      (bvneg (bvurem (bvneg s) (bvneg t)))
+  let bvsmod s t =
+    let m = size2 s t in
+    let msb_s = extract (m - 1) (m - 1) s in
+    let msb_t = extract (m - 1) (m - 1) t in
+    let abs_s = ite (is msb_s 0) s (bvneg s) in
+    let abs_t = ite (is msb_t 0) t (bvneg t) in
+    let u = bvurem abs_s abs_t in
+    ite (eq (bv2nat u) Ints.(~$$0))
+      u
+    @@ ite (and_ (is msb_s 0) (is msb_t 0))
+      u
+    @@ ite (and_ (is msb_s 1) (is msb_t 0))
+      (bvadd (bvneg u) t)
+    @@ ite (and_ (is msb_s 0) (is msb_t 1))
+      (bvadd u t)
+      (bvneg u)
+
+  (* Shift operations *)
+  let bvshl s t = int2bv (size2 s t) Ints.(bv2nat s * (~$$2 ** bv2nat t))
+  let bvlshr s t = int2bv (size2 s t) Ints.(bv2nat s / (~$$2 ** bv2nat t))
+  let bvashr s t =
+    let m = size2 s t in
+    ite (is (extract (m - 1) (m - 1) s) 0)
+      (bvlshr s t)
+      (bvnot (bvlshr (bvnot s) t))
+
+  (* Comparisons *)
+  let bvult s t = Ints.(bv2nat s < bv2nat t)
+  let bvule s t = Ints.(bv2nat s <= bv2nat t)
+  let bvugt s t = bvult t s
+  let bvuge s t = bvule t s
+  let bvslt s t =
+    let m = size2 s t in
+    or_
+      (and_
+         (is (extract (m - 1) (m - 1) s) 1)
+         (is (extract (m - 1) (m - 1) t) 0))
+      (and_
+         (eq (extract (m - 1) (m - 1) s) (extract (m - 1) (m - 1) t))
+         (bvult s t))
+  let bvsle s t =
+    let m = size2 s t in
+    or_
+      (and_
+         (is (extract (m - 1) (m - 1) s) 1)
+         (is (extract (m - 1) (m - 1) t) 0))
+      (and_
+         (eq (extract (m - 1) (m - 1) s) (extract (m - 1) (m - 1) t))
+         (bvule s t))
+  let bvsgt s t = bvslt t s
+  let bvsge s t = bvsle t s
+end

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -334,3 +334,111 @@ val save_cache: unit -> unit
 
 val reinit_cache: unit -> unit
 (** Reinitializes the module's cache *)
+
+(** Constructors from the smtlib core theory.
+    https://smtlib.cs.uiowa.edu/theories-Core.shtml *)
+module Core : sig
+  val not : t -> t
+
+  val eq : t -> t -> t
+
+  val xor : t -> t -> t
+
+  val and_ : t -> t -> t
+
+  val or_ : t -> t -> t
+
+  val ite : t -> t -> t -> t
+end
+
+(** Constructors from the smtlib theory of integers.
+    https://smtlib.cs.uiowa.edu/theories-Ints.shtml *)
+module Ints : sig
+  (* Conversion from ZArith *)
+  val of_Z : Z.t -> t
+  val ( ~$ ) : Z.t -> t
+
+  (* Conversion from int *)
+  val of_int : int -> t
+  val ( ~$$ ) : int -> t
+
+  (* Arithmetic operations *)
+  val ( + ) : t -> t -> t
+  val ( - ) : t -> t -> t
+  val ( ~- ) : t -> t
+  val ( * ) : t -> t -> t
+  val ( / ) : t -> t -> t
+  val ( mod ) : t -> t -> t
+
+  (* Absolute value *)
+  val abs : t -> t
+
+  (* Exponentiation *)
+  val ( ** ) : t -> t -> t
+
+  (* Comparisons *)
+  val ( <= ) : t -> t -> t
+  val ( >= ) : t -> t -> t
+  val ( < ) : t -> t -> t
+  val ( > ) : t -> t -> t
+end
+
+(** Constructors from the smtlib theory of fixed-size bit-vectors and the QF_BV
+    logic.
+
+    https://smtlib.cs.uiowa.edu/theories-FixedSizeBitVectors.shtml
+    https://smtlib.cs.uiowa.edu/logics-all.shtml#QF_BV *)
+module BV : sig
+  (* Conversion from and to integers *)
+  val int2bv : int -> t -> t
+  val bv2nat : t -> t
+
+  (* Constant symbols with all zeros and all ones *)
+  val bvzero: int -> t
+  val bvones : int -> t
+
+  (* Vector-level operations *)
+  val concat : t -> t -> t
+  val extract : int -> int -> t -> t
+  val repeat : int -> t -> t
+  val zero_extend : int -> t -> t
+  val sign_extend : int -> t -> t
+  val rotate_left : int -> t -> t
+  val rotate_right : int -> t -> t
+
+  (* Bit-wise operations *)
+  val bvnot : t -> t
+  val bvand : t -> t -> t
+  val bvor : t -> t -> t
+  val bvnand : t -> t -> t
+  val bvnor : t -> t -> t
+  val bvxor : t -> t -> t
+  val bvxnor : t -> t -> t
+  val bvcomp : t -> t -> t
+
+  (* Arithmetic operations *)
+  val bvneg : t -> t
+  val bvadd : t -> t -> t
+  val bvsub : t -> t -> t
+  val bvmul : t -> t -> t
+  val bvudiv : t -> t -> t
+  val bvurem : t -> t -> t
+  val bvsdiv : t -> t -> t
+  val bvsrem : t -> t -> t
+  val bvsmod : t -> t -> t
+
+  (* Comparison predicates *)
+  val bvult : t -> t -> t
+  val bvule : t -> t -> t
+  val bvugt : t -> t -> t
+  val bvuge : t -> t -> t
+  val bvslt : t -> t -> t
+  val bvsle : t -> t -> t
+  val bvsgt : t -> t -> t
+  val bvsge : t -> t -> t
+
+  (* Shift operations *)
+  val bvshl : t -> t -> t
+  val bvlshr : t -> t -> t
+  val bvashr : t -> t -> t
+end

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -46,6 +46,7 @@ type operator =
   (* BV *)
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
+  | BVnot | BVand | BVor | Int2BV of int | BV2Nat
   (* FP *)
   | Float
   | Integer_round | Fixed
@@ -139,12 +140,14 @@ let compare_operators op1 op2 =
       | Extract (i1, j1), Extract (i2, j2) ->
         let r = Int.compare i1 i2 in
         if r = 0 then Int.compare j1 j2 else r
+      | Int2BV n1, Int2BV n2 -> Int.compare n1 n2
       | _ , (Plus | Minus | Mult | Div | Modulo | Real_is_int
             | Concat | Extract _ | Get | Set | Fixed | Float | Reach
             | Access _ | Record | Sqrt_real | Abs_int | Abs_real
             | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
             | Integer_log2 | Pow | Integer_round
+            | BVnot | BVand | BVor | Int2BV _ | BV2Nat
             | Not_theory_constant | Is_theory_constant | Linear_dependency
             | Constr _ | Destruct _ | Tite) -> assert false
     )
@@ -317,6 +320,11 @@ let to_string ?(show_vars=true) x = match x with
   | Op Linear_dependency -> "linear_dependency"
   | Op Concat -> "@"
   | Op Extract (i, j) -> Format.sprintf "^{%d; %d}" i j
+  | Op BVnot -> "bvnot"
+  | Op BVand -> "bvand"
+  | Op BVor -> "bvor"
+  | Op Int2BV n -> Format.sprintf "int2bv[%d]" n
+  | Op BV2Nat -> "bv2nat"
   | Op Tite -> "ite"
   | Op Reach -> assert false
   | True -> "true"

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -46,6 +46,7 @@ type operator =
   (* BV *)
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
+  | BVnot | BVand | BVor | Int2BV of int | BV2Nat
   (* FP *)
   | Float
   | Integer_round | Fixed


### PR DESCRIPTION
This is the first part in a reloaded version of #669.  It only includes parsing and typechecking support for the bit-vector primitives: bvnot, bvand, bvor, bv2nat and nat2bv (called int2bv because it also accepts negative inputs) are treated as uninterpreted functions; the other operators defined in the SMT-LIB are defined in terms of these primitives and of the existing `concat` and `extract` operators.

The support for the bit-vector functions will be improved in separate PRs focusing on the bv2nat/nat2bv interaction, so that we are at least able to solve simple arithmetic goals. In the future, we might want to consider additional strategies (e.g. bitblasting), but that is out of scope for now.

Following the discussion in #669, including the apparent restrictions around the building of "ite" in the theory and the lack of infrastructure for actually doing simplifications there (at least for now), the definition of most functions are moved back to `Expr.ml`. The PR also includes a few helper functions to help write the definition of the bitvector operators more concisely, which should help ensuring that they are correct.