### PR TITLE
Run tests with dolmen by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,11 +122,11 @@ gentest: $(wildcard tests/**/*)
 
 # Run non-regression tests.
 runtest: gentest bin
-	dune build @runtest-quick
+	dune build @runtest @runtest-quick
 
 # Run non-regression tests for the CI.
 runtest-ci: gentest bin
-	dune build @runtest-ci
+	dune build @runtest @runtest-quick @runtest-ci
 
 # Promote new outputs of the tests.
 promote:


### PR DESCRIPTION
We plan on making dolmen the default frontend in the near future, so it onyl makes sense that we actually start testing dolmen more.

This also simplifies slightly the handling of the 'dolmen' modifier, since it only means that we must exclude the 'legacy' case now.

This also simplifies the test generation a bit by including the runtest and runtest-quick targets on the CI, which means we don't need duplicates for `tableaux` and `tableaux_ci`, etc anymore.

Note: the CI is expected to fail due to #734 