### PR TITLE
Remove plateform-dependent message in the cram test

### DIFF
--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -1,7 +1,7 @@
   $ export BUILD_PATH_PREFIX_MAP="SRC=$(dirname $(dirname $(dirname $(dirname $(which alt-ergo))))):$BUILD_PATH_PREFIX_MAP"
-  $ echo '(check-sat)' | alt-ergo --inequalities-plugin does-not-exist -i smtlib2 -o smtlib2
+  $ echo '(check-sat)' | alt-ergo --inequalities-plugin does-not-exist -i smtlib2 -o smtlib2 2> >(sed -E 's/\(\\".*\\"\)//' 1>&2)
   alt-ergo: ; Fatal Error: [Dynlink] Loading the 'inequalities' reasoner (FM module) plugin in "does-not-exist" failed!
-            >> Failure message: error loading shared library: Dynlink.Error (Dynlink.Cannot_open_dll "Failure(\"$TESTCASE_ROOT/does-not-exist: cannot open shared object file: No such file or directory\")")
+            >> Failure message: error loading shared library: Dynlink.Error (Dynlink.Cannot_open_dll "Failure")
   [125]
 
 Now we will have some tests for the models. Note that it is okay if the format
@@ -9,7 +9,7 @@ changes slightly, you should be concerned with ensuring the semantic is
 appropriate here.
 
   $ alt-ergo --frontend dolmen --produce-models model555.smt2 --no-forced-flush-in-output 2>/dev/null
-  
+
   unknown
   (
     (define-fun a1 () (Array Int Int)
@@ -18,31 +18,35 @@ appropriate here.
     (define-fun y () Int 0)
   )
 
+
 Now we will test some semantic triggers.
 
   $ alt-ergo --frontend legacy -o smtlib2 semantic_triggers.ae 2>/dev/null
-  
+
   unknown
-  
+
   unsat
-  
+
   unsat
+
   $ alt-ergo --frontend dolmen -o smtlib2 semantic_triggers.ae 2>/dev/null
-  
+
   unknown
-  
+
   unsat
-  
+
   unsat
+
 
 And some SMT2 action.
 
   $ alt-ergo --frontend dolmen -o smtlib2 --prelude prelude.ae postlude.smt2 2>/dev/null
-  
+
   unknown
-  
+
   unsat
-  
+
   unknown
-  
+
   unsat
+

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -27,7 +27,6 @@ Now we will test some semantic triggers.
   unsat
   
   unsat
-
   $ alt-ergo --frontend dolmen -o smtlib2 semantic_triggers.ae 2>/dev/null
   
   unknown
@@ -35,7 +34,6 @@ Now we will test some semantic triggers.
   unsat
   
   unsat
-
 
 And some SMT2 action.
 

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -1,8 +1,7 @@
   $ export BUILD_PATH_PREFIX_MAP="SRC=$(dirname $(dirname $(dirname $(dirname $(which alt-ergo))))):$BUILD_PATH_PREFIX_MAP"
-  $ echo '(check-sat)' | alt-ergo --inequalities-plugin does-not-exist -i smtlib2 -o smtlib2 2> >(sed -E 's/\(\\".*\\"\)//' 1>&2)
+  $ echo '(check-sat)' | alt-ergo --inequalities-plugin does-not-exist -i smtlib2 -o smtlib2 2>&1 >/dev/null | sed -E 's/\(\\".*\\"\)//'
   alt-ergo: ; Fatal Error: [Dynlink] Loading the 'inequalities' reasoner (FM module) plugin in "does-not-exist" failed!
             >> Failure message: error loading shared library: Dynlink.Error (Dynlink.Cannot_open_dll "Failure")
-  [125]
 
 Now we will have some tests for the models. Note that it is okay if the format
 changes slightly, you should be concerned with ensuring the semantic is

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -9,7 +9,7 @@ changes slightly, you should be concerned with ensuring the semantic is
 appropriate here.
 
   $ alt-ergo --frontend dolmen --produce-models model555.smt2 --no-forced-flush-in-output 2>/dev/null
-
+  
   unknown
   (
     (define-fun a1 () (Array Int Int)
@@ -21,30 +21,30 @@ appropriate here.
 Now we will test some semantic triggers.
 
   $ alt-ergo --frontend legacy -o smtlib2 semantic_triggers.ae 2>/dev/null
-
+  
   unknown
-
+  
   unsat
-
+  
   unsat
 
   $ alt-ergo --frontend dolmen -o smtlib2 semantic_triggers.ae 2>/dev/null
-
+  
   unknown
-
+  
   unsat
-
+  
   unsat
 
 
 And some SMT2 action.
 
   $ alt-ergo --frontend dolmen -o smtlib2 --prelude prelude.ae postlude.smt2 2>/dev/null
-
+  
   unknown
-
+  
   unsat
-
+  
   unknown
-
+  
   unsat

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -18,7 +18,6 @@ appropriate here.
     (define-fun y () Int 0)
   )
 
-
 Now we will test some semantic triggers.
 
   $ alt-ergo --frontend legacy -o smtlib2 semantic_triggers.ae 2>/dev/null
@@ -49,4 +48,3 @@ And some SMT2 action.
   unknown
 
   unsat
-


### PR DESCRIPTION
Fix the issue #740 