### PR TITLE
Expose the bv2nat and int2bv primitives

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -567,7 +567,7 @@ let main () =
       let g =
         Parser.parse_logic ~preludes logic_file
       in
-      let st = State.set Typer.additional_builtins D_cnf.fpa_builtins st in
+      let st = State.set Typer.additional_builtins D_cnf.builtins st in
       let all_used_context = FE.init_all_used_context () in
       let finally = finally ~handle_exn in
       let st =

--- a/src/lib/frontend/d_cnf.mli
+++ b/src/lib/frontend/d_cnf.mli
@@ -43,7 +43,7 @@ val make :
     type-checked statement [stmt] and appends them to [acc].
 *)
 
-val fpa_builtins :
+val builtins :
   Dolmen_loop.State.t ->
   D_loop.Typer.lang ->
   Dolmen_loop.Typer.T.builtin_symbols


### PR DESCRIPTION
This patch exposes the bv2nat and int2bv primitives as symbols available to the user. Even though these symbols are not part of the official smtlib theories, they are useful for mixed bitvector/integer specifications that are likely to occur in the context of program verification, and they are also supported by other solvers such as Z3 and CVC5.