### PR TITLE
Ensure that definitions have the same ordering with dolmen

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1939,6 +1939,8 @@ let make dloc_file acc stmt =
                here. *)
             assert false
         ) defs;
+      let append xs = List.append xs acc in
+      append @@
       List.filter_map (fun (def : Typer_Pipe.def) ->
           match def with
           | `Term_def ( _, ({ path; tags; _ } as tcst), tyvars, terml, body) ->
@@ -2018,7 +2020,7 @@ let make dloc_file acc stmt =
                polymorphic partially-defined bulitin and should not end up
                here. *)
             assert false
-        ) defs |> List.rev_append acc
+        ) defs
 
     | {contents = `Decls [td]; _ } ->
       begin match td with


### PR DESCRIPTION
The dolmen frontend is adding declarations to the end of the command queue instead of to the front, causing the final command list to be all shuffled. This is the cause of at least some of the regressions with the dolmen frontend, since the solver now processes things in a different order.

This patch ensures that the definitions are added with the correct ordering, so that the command queue should be the same with both frontends, barring additional bugs. This was tested with `-d commands` on a few benchmarks locally, where it produced the exact same output with both frontends.

The patch also refactors slightly the [handle_smtt] method in the solving loop: as part of the debugging for this, I realized that we can never end up with `Hyp` constructors with local/global hypotheses names there, because one difference between the Dolmen and legacy frontend is that the legacy frontend extracts the hypotheses from the goal during typechecking (so prior to cnf-conversion) while the Dolmen frontend extracts the hypotheses from the goal during cnf-conversion (i.e. when we encounter a `Solve`).