### PR TITLE
Add a lock file for the alt-ergo-lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,9 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 	echo "}" >> archi.dot
 	dot -Tpdf archi.dot > archi.pdf
 
+lock:
+	opam lock ./alt-ergo-lib.opam -w
+
 dev-switch:
 	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 

--- a/Makefile
+++ b/Makefile
@@ -234,10 +234,10 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 	echo "}" >> archi.dot
 	dot -Tpdf archi.dot > archi.pdf
 
-lock:
+lock: clean lib
 	opam lock ./alt-ergo-lib.opam -w
 	# Remove OCaml compiler constraints
-	sed -i '/\"ocaml/d' ./alt-ergo-lib.opam.locked
+	sed -i '/"ocaml"\|"ocaml-base-compiler"\|"ocaml-system"\|"ocaml-config"/d' ./alt-ergo-lib.opam.locked
 
 dev-switch:
 	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,8 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 
 lock:
 	opam lock ./alt-ergo-lib.opam -w
-	sed -i '/ocaml/d' ./alt-ergo-lib.opam.locked
+	# Remove OCaml compiler constraints
+	sed -i '/\"ocaml/d' ./alt-ergo-lib.opam.locked
 
 dev-switch:
 	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ test-deps:
 dune-deps:
 	dune-deps . | dot -Tpng -o docs/deps.png
 
-.PHONY: archi deps test-deps dune-deps dev-switch
+.PHONY: archi deps test-deps dune-deps dev-switch lock
 
 # ===============
 # PUBLIC RELEASES

--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 
 lock:
 	opam lock ./alt-ergo-lib.opam -w
+	sed -i '/ocaml/d' ./alt-ergo-lib.opam.locked
 
 dev-switch:
 	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,8 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 	echo "}" >> archi.dot
 	dot -Tpdf archi.dot > archi.pdf
 
-lock: clean lib
+lock:
+	dune build ./alt-ergo-lib.opam
 	opam lock ./alt-ergo-lib.opam -w
 	# Remove OCaml compiler constraints
 	sed -i '/"ocaml"\|"ocaml-base-compiler"\|"ocaml-system"\|"ocaml-config"/d' ./alt-ergo-lib.opam.locked

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -43,6 +43,9 @@ depends: [
   "menhirLib" {= "20230608"}
   "menhirSdk" {= "20230608"}
   "num" {= "1.4"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
+  "ocamlbuild" {= "0.14.2"}
+  "ocamlfind" {= "1.9.6"}
   "ocplib-endian" {= "1.2"}
   "ocplib-simplex" {= "0.5"}
   "pp_loc" {= "2.1.0"}

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -7,16 +7,14 @@ This is the core library used in the Alt-Ergo SMT solver.
 
 Alt-Ergo is an automatic theorem prover of mathematical formulas. It was developed at LRI, and is now maintained at OCamlPro.
 
-See more details on http://alt-ergo.ocamlpro.com/"""
 maintainer: "Alt-Ergo developers"
 authors: "Alt-Ergo developers"
 license: ["LicenseRef-OCamlpro-Non-Commercial" "Apache-2.0"]
 tags: "org:OCamlPro"
-homepage: "https://alt-ergo.ocamlpro.com/"
-doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
   "base-bigarray" {= "base"}
+  "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "camlzip" {= "1.11"}
@@ -24,35 +22,36 @@ depends: [
   "conf-gmp" {= "4"}
   "conf-pkg-config" {= "3"}
   "conf-zlib" {= "1"}
+  "cppo" {= "1.6.9"}
+  "csexp" {= "1.5.2"}
   "dolmen" {= "0.9"}
   "dolmen_loop" {= "0.9"}
   "dolmen_type" {= "0.9"}
   "dune" {= "3.10.0"}
   "dune-build-info" {= "3.10.0"}
+  "dune-configurator" {= "3.10.0"}
   "fmt" {= "0.9.0"}
   "gen" {= "1.1"}
   "logs" {= "0.7.0"}
+  "lwt" {= "5.6.1"}
   "menhir" {= "20230608"}
   "menhirLib" {= "20230608"}
   "menhirSdk" {= "20230608"}
   "num" {= "1.4"}
-  "ocaml" {= "4.10.1"}
-  "ocaml-base-compiler" {= "4.10.1"}
-  "ocaml-compiler-libs" {= "v0.12.4"}
-  "ocaml-config" {= "1"}
-  "ocamlbuild" {= "0.14.2"}
-  "ocamlfind" {= "1.9.6"}
+  "ocplib-endian" {= "1.2"}
   "ocplib-simplex" {= "0.5"}
   "pp_loc" {= "2.1.0"}
   "ppx_blob" {= "0.7.2"}
   "ppx_derivers" {= "1.2.1"}
   "ppxlib" {= "0.30.0"}
+  "sedlex" {= "3.2"}
   "seq" {= "base"}
-  "sexplib0" {= "v0.16.0"}
+  "sexplib0" {= "v0.15.1"}
   "spelll" {= "0.4"}
   "stdlib-shims" {= "0.3.0"}
   "topkg" {= "1.0.7"}
   "uutf" {= "1.0.3"}
+  "yojson" {= "2.1.0"}
   "zarith" {= "1.13"}
 ]
 build: [

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+name: "alt-ergo-lib"
+version: "dev"
+synopsis: "The Alt-Ergo SMT prover library"
+description: """\
+This is the core library used in the Alt-Ergo SMT solver.
+
+Alt-Ergo is an automatic theorem prover of mathematical formulas. It was developed at LRI, and is now maintained at OCamlPro.
+
+See more details on http://alt-ergo.ocamlpro.com/"""
+maintainer: "Alt-Ergo developers"
+authors: "Alt-Ergo developers"
+license: ["LicenseRef-OCamlpro-Non-Commercial" "Apache-2.0"]
+tags: "org:OCamlPro"
+homepage: "https://alt-ergo.ocamlpro.com/"
+doc: "https://ocamlpro.github.io/alt-ergo"
+bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
+depends: [
+  "base-bigarray" {= "base"}
+  "base-threads" {= "base"}
+  "base-unix" {= "base"}
+  "camlzip" {= "1.11"}
+  "cmdliner" {= "1.2.0"}
+  "conf-gmp" {= "4"}
+  "conf-pkg-config" {= "3"}
+  "conf-zlib" {= "1"}
+  "dolmen" {= "0.9"}
+  "dolmen_loop" {= "0.9"}
+  "dolmen_type" {= "0.9"}
+  "dune" {= "3.10.0"}
+  "dune-build-info" {= "3.10.0"}
+  "fmt" {= "0.9.0"}
+  "gen" {= "1.1"}
+  "logs" {= "0.7.0"}
+  "menhir" {= "20230608"}
+  "menhirLib" {= "20230608"}
+  "menhirSdk" {= "20230608"}
+  "num" {= "1.4"}
+  "ocaml" {= "4.10.1"}
+  "ocaml-base-compiler" {= "4.10.1"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
+  "ocaml-config" {= "1"}
+  "ocamlbuild" {= "0.14.2"}
+  "ocamlfind" {= "1.9.6"}
+  "ocplib-simplex" {= "0.5"}
+  "pp_loc" {= "2.1.0"}
+  "ppx_blob" {= "0.7.2"}
+  "ppx_derivers" {= "1.2.1"}
+  "ppxlib" {= "0.30.0"}
+  "seq" {= "base"}
+  "sexplib0" {= "v0.16.0"}
+  "spelll" {= "0.4"}
+  "stdlib-shims" {= "0.3.0"}
+  "topkg" {= "1.0.7"}
+  "uutf" {= "1.0.3"}
+  "zarith" {= "1.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -7,10 +7,13 @@ This is the core library used in the Alt-Ergo SMT solver.
 
 Alt-Ergo is an automatic theorem prover of mathematical formulas. It was developed at LRI, and is now maintained at OCamlPro.
 
+See more details on http://alt-ergo.ocamlpro.com/"""
 maintainer: "Alt-Ergo developers"
 authors: "Alt-Ergo developers"
 license: ["LicenseRef-OCamlpro-Non-Commercial" "Apache-2.0"]
 tags: "org:OCamlPro"
+homepage: "https://alt-ergo.ocamlpro.com/"
+doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
   "base-bigarray" {= "base"}
@@ -32,6 +35,8 @@ depends: [
   "dune-configurator" {= "3.10.0"}
   "fmt" {= "0.9.0"}
   "gen" {= "1.1"}
+  "js_of_ocaml" {= "5.4.0"}
+  "js_of_ocaml-compiler" {= "5.4.0"}
   "logs" {= "0.7.0"}
   "lwt" {= "5.6.1"}
   "menhir" {= "20230608"}


### PR DESCRIPTION
This PR add a lock file for the alt-ergo-lib in order to improve the reproducibility of the building process.
I also add a target `lock` in the makefile to update the lock file. 