### PR TITLE
Fix model generation for records

### DIFF
--- a/src/lib/frontend/models.mli
+++ b/src/lib/frontend/models.mli
@@ -28,6 +28,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+module MS : Map.S with type key = string
+
 (** {1 Models module} *)
 
 (** Print the given counterexample on the given formatter with the
@@ -42,4 +44,5 @@ val output_concrete_model :
   functions:ModelMap.t ->
   constants:ModelMap.t ->
   arrays:ModelMap.t ->
+  records:string MS.t MS.t ->
   unit

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -330,10 +330,10 @@ struct
   let is_solvable_theory_symbol sb ty =
     X1.is_mine_symb sb ty ||
     not (Options.get_restricted ()) &&
-    (X2.is_mine_symb sb ty ||
-     X3.is_mine_symb sb ty ||
-     X4.is_mine_symb sb ty ||
-     X5.is_mine_symb sb ty)
+    ((*X2.is_mine_symb sb ty || *)
+      X3.is_mine_symb sb ty ||
+      X4.is_mine_symb sb ty ||
+      X5.is_mine_symb sb ty)
 
 
   let is_a_leaf r = match r.v with

--- a/tests/models/record/record1.models.expected
+++ b/tests/models/record/record1.models.expected
@@ -1,0 +1,5 @@
+
+unknown
+(
+  (define-fun a () Pair (pair 5 0))
+)

--- a/tests/models/record/record1.models.smt2
+++ b/tests/models/record/record1.models.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+(set-option :produce-models true)
+(declare-datatype Pair
+((pair (first Int) (second Int))))
+(declare-const a Pair)
+(assert (= (first a) 5))
+(check-sat)
+(get-model)


### PR DESCRIPTION
Before this PR, it seems the model generation for records didn't work on `next`. The reason is simple. If we want to produce a value for a declared record, we need to accumulate all the accesses to this record. For instance, the following input file:
```
(set-logic ALL)
(set-option :produce-models true)
(declare-datatype Pair
((pair (first Int) (second Int))))
(declare-const a Pair)
(assert (= (first a) 5))
(check-sat)
(get-model)
```
didn't produce a correct model. It assigned `0` for any field of type `Int`.

Note: for functional arrays, we can use the `ModelMap.t` structure to accumulate the `store` instructions as functional arrays can be seen as a map. We cannot do the same thing for records since each destructor of the record can return a different type. 