### PR TITLE
Restore record printing functionality

### DIFF
--- a/src/lib/frontend/models.ml
+++ b/src/lib/frontend/models.ml
@@ -416,7 +416,13 @@ module SmtlibCounterExample = struct
            else
              reps_aux representants
          in
-         print_fun_def fmt f xs_ty_named ty rep;
+         (* Only print declared (but not defined!) function symbols -- note
+            that we still need to *handle* other symbols without printing them
+            because they could be record accessors that must be added to the
+            `records` reference *)
+         match f with
+         | Sy.Name (_, _, false) -> print_fun_def fmt f xs_ty_named ty rep
+         | _ -> ()
       ) fprofs;
     !records
 end

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -1026,7 +1026,9 @@ let compute_concrete_model ({ make; _ } as env) =
   ME.fold
     (fun t _mk ((fprofs, cprofs, carrays, mrepr) as acc) ->
        let { E.f; xs; ty; _ } = E.term_view t in
-       if X.is_solvable_theory_symbol f ty
+       (* Keep record constructors because models.ml expects them to be there *)
+       if (X.is_solvable_theory_symbol f ty
+           && not (Shostak.Records.is_mine_symb f ty))
        || E.is_fresh t || E.is_fresh_skolem t
        || E.equal t E.vrai || E.equal t E.faux
        then

--- a/tests/models/records/record1.models.expected
+++ b/tests/models/records/record1.models.expected
@@ -1,0 +1,5 @@
+
+unknown
+(
+  (define-fun a () Pair (pair 5 0))
+)

--- a/tests/models/records/record1.models.smt2
+++ b/tests/models/records/record1.models.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+(set-option :produce-models true)
+(declare-datatype Pair
+((pair (first Int) (second Int))))
+(declare-const a Pair)
+(assert (= (first a) 5))
+(check-sat)
+(get-model)


### PR DESCRIPTION
This got lost somewhere along the way as the conditions for model generation changed.

Note that it is a bit weird that the accumulation of record accesses happens in `models.ml` while the accumulation of array accesses happens in `uf.ml`.  We should pick a single one for both (probably in `models` but even better would be to expose the appropriate APIs so that each theory can build its own model values), but for now this patch should wrangle the `if`s properly and restore the existing functionality.

This is an alternate version of #792 that uses the existing functionality in `models.ml` to collect record field information.