### PR TITLE
[WIP] Removing exceptions from the Sat solver API

### DIFF
--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -383,16 +383,17 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
             print_status (Unsat (d, dep)) (Steps.get_steps ());
             (env, `Unsat, dep)
           | `Sat t ->
-            (* This case should mainly occur when a query has a non-unsat result,
-               so we want to print the status in this case. *)
+            (* This case should mainly occur when a query has a non-unsat
+               result, so we want to print the status in this case. *)
             print_status (Sat (d,t)) (Steps.get_steps ());
             res
           | `Unknown t ->
             (* In this case, it's not clear whether we want to print the status.
-               Instead, it'd be better to accumulate in `consistent` a 3-case adt
-               and not a simple bool. *)
+               Instead, it'd be better to accumulate in `consistent` a 3-case
+               adt and not a simple bool. *)
             print_status (Unknown (d, t)) (Steps.get_steps ());
-            (*if get_model () then SAT.print_model ~header:true (get_fmt_mdl ()) t;*)
+            (* if get_model () then
+                 SAT.print_model ~header:true (get_fmt_mdl ()) t; *)
             res
         end
       | ThAssume th_elt ->

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -120,7 +120,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
       let env =
         List.fold_left
           (fun env f ->
-             match
+             process_sat_res @@
                SAT.assume env
                  {E.ff=f;
                   origin_name = "";
@@ -135,11 +135,6 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
                   from_terms = [];
                   theory_elim = true;
                  } Ex.empty
-             with
-             | Done e -> e
-             | Sat t -> raise (SAT t)
-             | Unsat e -> raise (UNSAT e)
-             | I_dont_know t -> raise (I_DONT_KNOW t)
           ) (SAT.empty ()) pb
       in
       ignore (SAT.unsat

--- a/src/lib/frontend/frontend.mli
+++ b/src/lib/frontend/frontend.mli
@@ -39,6 +39,8 @@ module type S = sig
     | `Unsat
   ]
 
+  type t = sat_env * res * Explanation.t
+
   type status =
     | Unsat of Commands.sat_tdecl * Explanation.t
     | Inconsistent of Commands.sat_tdecl
@@ -47,13 +49,34 @@ module type S = sig
     | Timeout of Commands.sat_tdecl option
     | Preprocess
 
+  (** The signature of function manipulating the frontend environment. *)
+  type 'input process_decl_base =
+    used_context ->
+    (res * Explanation.t) Stack.t ->
+    Loc.t ->
+    t ->
+    'input ->
+    t
+
+  val push : int process_decl_base
+
+  val pop : int process_decl_base
+
+  val assume : (string * Expr.t * bool) process_decl_base
+
+  val pred_def : (Expr.t * string) process_decl_base
+
+  val query : (string * Expr.t * Ty.goal_sort) process_decl_base
+
+  val assume_th_elt : Expr.th_elt process_decl_base
+
   val process_decl:
     (status -> int -> unit) ->
     used_context ->
     (res * Explanation.t) Stack.t ->
-    sat_env * res * Explanation.t ->
+    t ->
     Commands.sat_tdecl ->
-    sat_env * res * Explanation.t
+    t
 
   val print_status : status -> int -> unit
 

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -34,12 +34,6 @@
 module type S = sig
   type t
 
-  type res =
-    | Done of t
-    | Sat of t
-    | Unsat of Explanation.t
-    | I_dont_know of t
-
   (* the empty sat-solver context *)
   val empty : unit -> t
   val empty_with_inst : (Expr.t -> bool) -> t
@@ -56,19 +50,26 @@ module type S = sig
       will be propagated to false (at level 0) *)
   val pop : t -> int -> t
 
-  (* [assume env f] assume a new formula [f] in [env]. Raises Unsat if
-     [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> res
+  (* [assume env f] assume a new formula [f] in [env]. Returns [Unsat] if
+      [f] is unsatisfiable in [env]. *)
+  val assume :
+    t ->
+    Expr.gformula ->
+    Explanation.t ->
+    [`Unknown of t | `Unsat of Explanation.t]
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> res
+  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
 
   (* [pred_def env f] assume a new predicate definition [f] in [env]. *)
-  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> res
+  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
 
   (* [unsat env f size] checks the unsatisfiability of [f] in
-     [env]. Raises I_dont_know when the proof tree's height reaches
-     [size]. Raises Sat if [f] is satisfiable in [env] *)
-  val unsat : t -> Expr.gformula -> res
+     [env]. Returns I_dont_know when the proof tree's height reaches
+     [size]. Returns Sat if [f] is satisfiable in [env] *)
+  val unsat :
+    t ->
+    Expr.gformula ->
+    [`Unknown of t | `Sat of t | `Unsat of Explanation.t]
 
   val reset_refs : unit -> unit
 

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -34,9 +34,11 @@
 module type S = sig
   type t
 
-  exception Sat of t
-  exception Unsat of Explanation.t
-  exception I_dont_know of t
+  type res =
+    | Done of t
+    | Sat of t
+    | Unsat of Explanation.t
+    | I_dont_know of t
 
   (* the empty sat-solver context *)
   val empty : unit -> t
@@ -56,17 +58,17 @@ module type S = sig
 
   (* [assume env f] assume a new formula [f] in [env]. Raises Unsat if
      [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> t
+  val assume : t -> Expr.gformula -> Explanation.t -> res
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> res
 
   (* [pred_def env f] assume a new predicate definition [f] in [env]. *)
-  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
+  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> res
 
   (* [unsat env f size] checks the unsatisfiability of [f] in
      [env]. Raises I_dont_know when the proof tree's height reaches
      [size]. Raises Sat if [f] is satisfiable in [env] *)
-  val unsat : t -> Expr.gformula -> Explanation.t
+  val unsat : t -> Expr.gformula -> res
 
   val reset_refs : unit -> unit
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -31,9 +31,11 @@
 module type S = sig
   type t
 
-  exception Sat of t
-  exception Unsat of Explanation.t
-  exception I_dont_know of t
+  type res =
+    | Done of t
+    | Sat of t
+    | Unsat of Explanation.t
+    | I_dont_know of t
 
   (** the empty sat-solver context *)
   val empty : unit -> t
@@ -53,19 +55,19 @@ module type S = sig
 
   (** [assume env f] assume a new formula [f] in [env]. Raises Unsat if
       [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> t
+  val assume : t -> Expr.gformula -> Explanation.t -> res
 
   (** [assume env f exp] assume a new formula [f] with the explanation [exp]
       in the theories environment of [env]. *)
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> res
 
   (** [pred_def env f] assume a new predicate definition [f] in [env]. *)
-  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
+  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> res
 
   (** [unsat env f size] checks the unsatisfiability of [f] in
       [env]. Raises I_dont_know when the proof tree's height reaches
       [size]. Raises Sat if [f] is satisfiable in [env] *)
-  val unsat : t -> Expr.gformula -> Explanation.t
+  val unsat : t -> Expr.gformula -> res
 
   (** [print_model header fmt env] print propositional model and theory model
       on the corresponding fmt. *)

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -31,12 +31,6 @@
 module type S = sig
   type t
 
-  type res =
-    | Done of t
-    | Sat of t
-    | Unsat of Explanation.t
-    | I_dont_know of t
-
   (** the empty sat-solver context *)
   val empty : unit -> t
   val empty_with_inst : (Expr.t -> bool) -> t
@@ -53,21 +47,28 @@ module type S = sig
       will be propagated to false (at level 0) *)
   val pop : t -> int -> t
 
-  (** [assume env f] assume a new formula [f] in [env]. Raises Unsat if
-      [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> res
+  (** [assume env f] assume a new formula [f] in [env]. Returns [Unsat] if
+      [f] is unsatisfiable in [env]. *)
+  val assume :
+    t ->
+    Expr.gformula ->
+    Explanation.t ->
+    [`Unknown of t | `Unsat of Explanation.t]
 
   (** [assume env f exp] assume a new formula [f] with the explanation [exp]
       in the theories environment of [env]. *)
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> res
+  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
 
   (** [pred_def env f] assume a new predicate definition [f] in [env]. *)
-  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> res
+  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
 
   (** [unsat env f size] checks the unsatisfiability of [f] in
-      [env]. Raises I_dont_know when the proof tree's height reaches
-      [size]. Raises Sat if [f] is satisfiable in [env] *)
-  val unsat : t -> Expr.gformula -> res
+      [env]. Returns I_dont_know when the proof tree's height reaches
+      [size]. Returns Sat if [f] is satisfiable in [env] *)
+  val unsat :
+    t ->
+    Expr.gformula ->
+    [`Unknown of t | `Sat of t | `Unsat of Explanation.t]
 
   (** [print_model header fmt env] print propositional model and theory model
       on the corresponding fmt. *)

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -92,8 +92,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let empty_with_inst add_inst =
     { (empty ()) with add_inst = add_inst }
 
-  (* Leaving this exception in case we actually raise Sat one day.
-     Remember to update `safe_call` by catching this exception if you do. *)
   exception Sat of t [@@warning "-38"]
   exception Unsat of Explanation.t
   exception I_dont_know of t


### PR DESCRIPTION
This PR removes the Sat, Unsat and I_dont_know exceptions raised by the library. It now returns an ADT which is either Done, Sat, Unsat or I_dont_know.
Alt-ergo has the exact same behavior than before, but it is not a bit cleaner. 

This PR also removes a `raise Exit` lost in the middle of the library.