### PR TITLE
Fix the cram tests

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -25,7 +25,7 @@ depends: [
   "seq"
   "fmt"
   "stdlib-shims"
-  "ppx_blob"
+  "ppx_blob" {>= "0.3"}
   "camlzip" {>= "1.07"}
   "odoc" {with-doc}
 ]

--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -25,7 +25,7 @@ depends: [
   "seq"
   "fmt"
   "stdlib-shims"
-  "ppx_blob" {>= "0.3"}
+  "ppx_blob" {>= "0.7.2"}
   "camlzip" {>= "1.07"}
   "odoc" {with-doc}
 ]

--- a/dune
+++ b/dune
@@ -1,0 +1,1 @@
+(data_only_dirs examples)

--- a/dune-project
+++ b/dune-project
@@ -85,7 +85,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
   seq
   fmt
   stdlib-shims
-  (ppx_blob (>= 0.3))
+  (ppx_blob (>= 0.7.2))
   (camlzip (>= 1.07))
   (odoc :with-doc)
  )

--- a/dune-project
+++ b/dune-project
@@ -85,7 +85,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
   seq
   fmt
   stdlib-shims
-  ppx_blob
+  (ppx_blob (>= 0.3))
   (camlzip (>= 1.07))
   (odoc :with-doc)
  )

--- a/src/plugins/AB-Why3/preludes/cram.t/run.t
+++ b/src/plugins/AB-Why3/preludes/cram.t/run.t
@@ -1,3 +1,3 @@
-  $ dune exec -- alt-ergo ../b-set-theory-prelude-2018-09-28.ae
-  $ dune exec -- alt-ergo ../b-set-theory-prelude-2020-02-28.ae
+  $ alt-ergo ../b-set-theory-prelude-2018-09-28.ae
+  $ alt-ergo ../b-set-theory-prelude-2020-02-28.ae
 

--- a/src/plugins/AB-Why3/preludes/cram.t/run.t
+++ b/src/plugins/AB-Why3/preludes/cram.t/run.t
@@ -1,3 +1,3 @@
-  $ alt-ergo ../b-set-theory-prelude-2018-09-28.ae
-  $ alt-ergo ../b-set-theory-prelude-2020-02-28.ae
+  $ dune exec -- alt-ergo ../b-set-theory-prelude-2018-09-28.ae
+  $ dune exec -- alt-ergo ../b-set-theory-prelude-2020-02-28.ae
 

--- a/src/plugins/AB-Why3/preludes/dune
+++ b/src/plugins/AB-Why3/preludes/dune
@@ -8,7 +8,7 @@
 )
 
 (cram
- (package alt-ergo)
+ (package alt-ergo-plugin-ab-why3)
  (alias runtest-ci)
  (deps
    %{bin:alt-ergo}

--- a/src/plugins/AB-Why3/preludes/dune
+++ b/src/plugins/AB-Why3/preludes/dune
@@ -8,5 +8,11 @@
 )
 
 (cram
+ (package alt-ergo)
  (alias runtest-ci)
- (deps b-set-theory-prelude-2018-09-28.ae b-set-theory-prelude-2020-02-28.ae))
+ (deps
+   %{bin:alt-ergo}
+   b-set-theory-prelude-2018-09-28.ae
+   b-set-theory-prelude-2020-02-28.ae
+ )
+)

--- a/src/preludes/dune
+++ b/src/preludes/dune
@@ -9,5 +9,12 @@
 )
 
 (cram
+ (package alt-ergo)
  (alias runtest-ci)
- (deps fpa-theory-2017-01-04-16h00.ae fpa-theory-2019-06-14-11h00.ae fpa-theory-2019-10-08-19h00.ae))
+ (deps
+   %{bin:alt-ergo}
+   fpa-theory-2017-01-04-16h00.ae
+   fpa-theory-2019-06-14-11h00.ae
+   fpa-theory-2019-10-08-19h00.ae
+ )
+)


### PR DESCRIPTION
The opam CI failed because `alt-ergo` binary is not available for the some cram tests located in `src/lib/`. You can see it with:
```sh
dune clean && dune build -p alt-ergo-lib @runtest
```
All the cram tests in `src/lib/` depend on the binary and should be a part of the `alt-ergo` package or depend on it.

Alas, we have to backport this fix for the release 2.5.0 :(

- I also set the minimum version for `ppx_blob` to the version `0.7.2`. The lower versions are not compatible with dune and the opam CI failed or recent OCaml compilers.

- I prevent dune to build examples.