### PR TITLE
Test AE on 4.08.1 and 4.14.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 env:
-  OCAML_DEFAULT_VERSION: 4.08.0
+  OCAML_DEFAULT_VERSION: 4.08.1
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -26,7 +26,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - 4.08.0
+          - 4.08.1
           - 4.14.1
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 env:
-  OCAML_DEFAULT_VERSION: 4.10.1
+  OCAML_DEFAULT_VERSION: 4.08.0
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -26,7 +26,8 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-compiler:
-          - 4.10.1
+          - 4.08.0
+          - 4.14.2
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           - ubuntu-latest
         ocaml-compiler:
           - 4.08.0
-          - 4.14.2
+          - 4.14.1
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
         ocaml-compiler:
           - 4.08.1
           - 4.14.1
+          - 5.0.0
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 ## unreleased
-### deprecated
-* printing underscore instead of fresh value in model
+### Deprecated
+* printing underscore instead of fresh value in model (PR #805)
+
+### Build
+* use OCaml 4.08.1 as the minimal supported version (PR #803)
 
 ## v2.5.0
 

--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -14,7 +14,7 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.1"}
   "dune" {>= "3.0"}
   "dune-build-info"
   "dolmen" {>= "0.9"}

--- a/alt-ergo-parsers.opam
+++ b/alt-ergo-parsers.opam
@@ -14,7 +14,7 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.1"}
   "dune" {>= "3.0"}
   "alt-ergo-lib" {= version}
   "psmt2-frontend" {>= "0.4"}

--- a/alt-ergo.opam
+++ b/alt-ergo.opam
@@ -12,7 +12,7 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.1"}
   "dune" {>= "3.0"}
   "alt-ergo-lib" {= version}
   "alt-ergo-parsers" {= version}

--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@ Alt-Ergo is an automatic theorem prover of mathematical formulas. It was develop
 
 See more details on https://alt-ergo.ocamlpro.com/")
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.08.1))
   dune
   (alt-ergo-lib (= :version))
   (alt-ergo-parsers (= :version))
@@ -51,7 +51,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
  (license "LicenseRef-OcamlPro-Non-Commercial")
 
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.08.1))
   dune
   (alt-ergo-lib (= :version))
   (psmt2-frontend (>= 0.4))
@@ -74,7 +74,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
  (license "LicenseRef-OcamlPro-Non-Commercial")
 
  (depends
-  (ocaml (>= 4.08.0))
+  (ocaml (>= 4.08.1))
   dune
   dune-build-info
   (dolmen (>= 0.9))

--- a/test.smt2
+++ b/test.smt2
@@ -1,5 +1,0 @@
-(set-logic ALL)
-(set-option :produce-models true)
-(declare-fun a (Int) Int)
-(check-sat)
-(get-model)

--- a/test.smt2
+++ b/test.smt2
@@ -1,0 +1,5 @@
+(set-logic ALL)
+(set-option :produce-models true)
+(declare-fun a (Int) Int)
+(check-sat)
+(get-model)


### PR DESCRIPTION
As I explained on Zulip, we don't test AE with ocaml 4.08.1 but still we publish AE on opam with this minimal version. This PR modifies a bit the CI in such way we test AE on both 4.08.1 and 4.14.1.