### PR TITLE
Replace dummy values in Model by abstract values

### DIFF
--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -11,8 +11,7 @@ appropriate here.
   
   unknown
   (
-    (define-fun a1 () (Array Int Int)
-     (store ((as const (Array Int Int)) 0) 0 0))
+    (define-fun a1 () (Array Int Int) (store (as @a1 (Array Int Int)) 0 0))
     (define-fun x () Int 0)
     (define-fun y () Int 0)
   )

--- a/tests/issues/555.models.expected
+++ b/tests/issues/555.models.expected
@@ -1,8 +1,7 @@
 
 unknown
 (
-  (define-fun a1 () (Array Int Int)
-   (store ((as const (Array Int Int)) 0) 0 0))
+  (define-fun a1 () (Array Int Int) (store (as @a1 (Array Int Int)) 0 0))
   (define-fun x () Int 0)
   (define-fun y () Int 0)
 )

--- a/tests/models/records/record1.models.expected
+++ b/tests/models/records/record1.models.expected
@@ -1,5 +1,5 @@
 
 unknown
 (
-  (define-fun a () Pair (pair 5 0))
+  (define-fun a () Pair (pair 5 (as @!k3 Int)))
 )


### PR DESCRIPTION
This PR uses abstract values of the SMTLIB standard instead of printing dummy values. 

Notice I use `Hstring.fresh_string` to produce fresh names. For instance, the test 
```
(set-logic ALL)
(set-option :produce-models true)
(declare-datatype Pair
((pair (first Int) (second Int))))
(declare-const a Pair)
(assert (= (first a) 5))
(check-sat)
(get-model)
```
will produce the model
```
(
  (define-fun a () Pair (pair 5 (as @!k3 Int)))
)
```
I checked that `@!...` are valid identifiers in SMT-LIB.