### PR TITLE
Deprecate the option --use-underscore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ## unreleased
+### deprecated
+* printing underscore instead of fresh value in model
 
 ## v2.5.0
 

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -1025,10 +1025,14 @@ let parse_output_opt =
 
   let use_underscore =
     let doc = "Output \"_\" instead of fresh value in interpretation" in
+    let deprecated =
+      "this option will be removed as it does not produce a \
+       SMTLIB-compliant output."
+    in
     let docv = "VAL" in
     Arg.(value & flag & info
            ["interpretation-use-underscore";"use-underscore"]
-           ~docv ~docs:s_models ~doc) in
+           ~docv ~docs:s_models ~doc ~deprecated) in
 
   let unsat_core =
     let doc = "Experimental support for computing and printing unsat-cores." in


### PR DESCRIPTION
This PR deprecates the option `--use-underscore` as this option doesn't produce a SMTLIB-compliant output model.
After merging #804, it will be easy to distinguish between values constraint by the context and free values, so we don't need to output underscores to make it clear.