### PR TITLE
Ensure that internal AC symbols do not end up in models

### DIFF
--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -327,13 +327,24 @@ struct
       false
     | _ -> assert false
 
+  (* This is [true] if, and only if, the symbol is an internal symbol
+     introduced by AC(X) for nesting purposes. These symbols are syntactic
+     artifacts and are always equal to the original function, hence they are
+     treated as solvable and ignored in models. *)
+  let is_internal_ac_symbol = function
+    | Symbols.Name (name, _, _) ->
+      Compat.String.starts_with ~prefix:"@" (Hstring.view name)
+    | _ -> false
+
+
   let is_solvable_theory_symbol sb ty =
     X1.is_mine_symb sb ty ||
     not (Options.get_restricted ()) &&
     (X2.is_mine_symb sb ty ||
      X3.is_mine_symb sb ty ||
      X4.is_mine_symb sb ty ||
-     X5.is_mine_symb sb ty)
+     X5.is_mine_symb sb ty ||
+     is_internal_ac_symbol sb)
 
 
   let is_a_leaf r = match r.v with

--- a/tests/cram.t/ac-at-sy.ae
+++ b/tests/cram.t/ac-at-sy.ae
@@ -1,0 +1,4 @@
+logic ac f : int, int -> int
+logic ac g : int, int -> int
+axiom ax : f(g(0, 0), 0) = 0
+check_sat g : true

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -87,3 +87,13 @@ And now some cases where it should work (using either `--produce-models` or
   unknown
   (
   )
+
+Test that internal AC symbols (@g, ...) do not end up in models.
+
+  $ alt-ergo --dump-models -o smtlib2 ac-at-sy.ae 2>/dev/null
+  (
+    (define-fun f ((arg_0 Int) (arg_1 Int)) Int 0)
+    (define-fun g ((arg_0 Int) (arg_1 Int)) Int 0)
+  )
+  
+  unknown


### PR DESCRIPTION
The AC(X) algorithm uses special symbols as an indirection (I believe to help enforce a terminating rewrite order) for AC symbols appearing within other AC symbols. These internal symbols start with `@` which is otherwise not a valid first character for a symbol name (but see #807). They should not appear in models.