### PR TITLE
Result conflict and ppxlib

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -26,8 +26,12 @@ depends: [
   "fmt" {>= "0.9.0"}
   "stdlib-shims"
   "ppx_blob" {>= "0.7.2"}
+  "ppxlib" {>= "0.30.0"}
   "camlzip" {>= "1.07"}
   "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -86,8 +86,12 @@ See more details on http://alt-ergo.ocamlpro.com/"
   (fmt (>= 0.9.0))
   stdlib-shims
   (ppx_blob (>= 0.7.2))
+  (ppxlib (>= 0.30.0))
   (camlzip (>= 1.07))
   (odoc :with-doc)
+ )
+ (conflicts
+  (result (< 1.5))
  )
 )
 


### PR DESCRIPTION
We have to use ppxlib >= 0.30.0 and prevent conflict with result < 1.5.