### PR TITLE
Increase minimal version of Zarith

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -21,16 +21,16 @@ depends: [
   "dolmen_type" {>= "0.9"}
   "dolmen_loop" {>= "0.9"}
   "ocplib-simplex" {>= "0.5"}
-  "zarith" {>= "1.4"}
+  "zarith" {>= "1.11"}
   "seq"
   "fmt" {>= "0.9.0"}
   "stdlib-shims"
   "ppx_blob" {>= "0.7.2"}
-  "ppxlib" {>= "0.30.0"}
   "camlzip" {>= "1.07"}
   "odoc" {with-doc}
 ]
 conflicts: [
+  "ppxlib" {< "0.30.0"}
   "result" {< "1.5"}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -81,16 +81,16 @@ See more details on http://alt-ergo.ocamlpro.com/"
   (dolmen_type (>= 0.9))
   (dolmen_loop (>= 0.9))
   (ocplib-simplex (>= 0.5))
-  (zarith (>= 1.4))
+  (zarith (>= 1.11))
   seq
   (fmt (>= 0.9.0))
   stdlib-shims
   (ppx_blob (>= 0.7.2))
-  (ppxlib (>= 0.30.0))
   (camlzip (>= 1.07))
   (odoc :with-doc)
  )
  (conflicts
+  (ppxlib (< 0.30.0))
   (result (< 1.5))
  )
 )


### PR DESCRIPTION
We have to increase the minimal version of `Zarith`. Indeed, the function `Q.of_string` does not support decimal notation before `Zarith > 1.11`. See https://github.com/ocaml/Zarith/pull/65

This issue cannot be detected by the opam repository CI as the command `dune build @runtest-ci` isn't running by this CI and the issue occurs only using both a switch with lower bounds and the frontend dolmen.

I run tests locally and it should work now.

To prevent such situations from recurring, I suggest to use the alias `runtest` to run all the tests and `runtest-something` to run locally quick tests.

As soon as opam 2.2 is stable, I will modify the CI in order to check lower bounds.

I also add `ppxlib < 0.30.0` as a conflict instead of a dependency.

We have to backport this PR again...