### PR TITLE
Do not discard `bvnot` applied to uninterpreted terms

### DIFF
--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -250,15 +250,13 @@ module Shostak(X : ALIEN) = struct
     let other ~neg t sz ctx =
       let r, ctx' = X.make t in
       let ctx = List.rev_append ctx' ctx in
-      match X.extract r with
-      | Some bv ->
-        if neg then
-          try negate_abstract bv, ctx with
-          | Failure _ ->
-            [ { bv = Other (X.term_embed (E.BV.bvnot t)); sz } ], ctx
-        else
-          bv, ctx
-      | None -> [ { bv = Other r; sz } ], ctx
+      let bv = embed r in
+      if neg then
+        try negate_abstract bv, ctx with
+        | Failure _ ->
+          [ { bv = Other (X.term_embed (E.BV.bvnot t)); sz } ], ctx
+      else
+        bv, ctx
 
     let extract_st i j ({ bv; sz } as st) =
       match bv with

--- a/tests/bitv/testfile-bvnot-term.dolmen.expected
+++ b/tests/bitv/testfile-bvnot-term.dolmen.expected
@@ -1,0 +1,2 @@
+
+unknown

--- a/tests/bitv/testfile-bvnot-term.dolmen.smt2
+++ b/tests/bitv/testfile-bvnot-term.dolmen.smt2
@@ -1,0 +1,7 @@
+(set-logic BV)
+
+(declare-const x (_ BitVec 4))
+(declare-const y (_ BitVec 4))
+(assert (= x (bvnot y)))
+(assert (distinct y x))
+(check-sat)


### PR DESCRIPTION
In PR #745 we correctly handled the case where uninterpreted terms appear deep within a bit-vector terms, but we accidentally missed the case where the whole bit-vector is itself an uninterpreted term, leading to unsoundness (see the attached test).

This patch fixes the code to properly deal with `bvnot` applied to an uninterpreted term.

#800 will make the issue obsolete but in the meantime we should still fix it.