### PR TITLE
Keep trailing whitespaces in cram tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ insert_final_newline = true
 
 [Makefile]
 indent_style = tab
+
+[*.t]
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
We keep trailing whitespaces in cram tests