### PR TITLE
The file dune.inc is linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-# Declare files that will always have LF line endings on checkout.
+# Declare files will always have LF line endings on checkout.
 configure eol=lf
+
+tests/dune.inc linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Declare files will always have LF line endings on checkout.
 configure eol=lf
 
+# Hide the file in statistics and pull request diffs.
 tests/dune.inc linguist-generated


### PR DESCRIPTION
This PR hides the file `tests/dune.inc` in statistics and diff as it is generated by `gentest.ml` and modifying only one test produces a huge diff on this file.