### PR TITLE
Support of get-info SMT2 command

### DIFF
--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -32,6 +32,21 @@ open Commands
 open Format
 open Options
 
+let timeout_reason_to_string = function
+  | Sat_solver_sig.Assume -> "Assume"
+  | ProofSearch -> "ProofSearch"
+  | ModelGen -> "ModelGen"
+
+let unknown_reason_to_string = function
+  | Sat_solver_sig.Incomplete -> "Incomplete"
+  | Memout -> "Memout"
+  | Timeout t -> Format.sprintf "Timeout:%s" (timeout_reason_to_string t)
+
+let unknown_reason_opt_to_string =
+  function
+  | None -> "Decided"
+  | Some r -> unknown_reason_to_string r
+
 module E = Expr
 module Ex = Explanation
 module type S = sig
@@ -154,27 +169,20 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     if Options.get_unsat_core () then Ex.singleton (Ex.RootDep {name;f;loc})
     else Ex.empty
 
-  let timeout_reason_to_string = function
-    | None -> "(?)"
-    | Some SAT.NoTimeout -> "NoTimeout"
-    | Some SAT.Assume -> "Assume"
-    | Some SAT.ProofSearch -> "ProofSearch"
-    | Some SAT.ModelGen -> "ModelGen"
-
-  let print_model env timeout =
+  let print_model env unknown_reason_opt =
     if Options.(get_interpretation () && get_dump_models ()) then begin
-      let s = timeout_reason_to_string timeout in
+      let s = unknown_reason_opt_to_string unknown_reason_opt in
       match SAT.get_model env with
       | None ->
         Printer.print_fmt (Options.Output.get_fmt_diagnostic ())
           "@[<v 0>It seems that no model has been computed so \
            far. You may need to change your model generation strategy \
-           or to increase your timeouts. Returned timeout reason = %s@]" s
+           or to increase your timeouts. Returned unknown reason = %s@]" s
 
       | Some (lazy model) ->
         Printer.print_fmt
           (Options.Output.get_fmt_diagnostic ())
-          "@[<v 0>; Returned timeout reason = %s@]" s;
+          "@[<v 0>; Returned unknown reason = %s@]" s;
         Models.output_concrete_model (Options.Output.get_fmt_models ()) model
     end
 
@@ -270,7 +278,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
       (* This case should mainly occur when a query has a non-unsat result,
          so we want to print the status in this case. *)
       print_status (Sat (d,t)) (Steps.get_steps ());
-      print_model env (Some SAT.NoTimeout);
+      print_model env None;
       env, `Sat t, dep
     | SAT.Unsat dep' ->
       (* This case should mainly occur when a new assumption results in an unsat
@@ -280,14 +288,16 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
       if get_debug_unsat_core () then check_produced_unsat_core dep;
       (* print_status (Inconsistent d) (Steps.get_steps ()); *)
       env , `Unsat, dep
-    | SAT.I_dont_know {env = t; timeout} ->
+    | SAT.I_dont_know t ->
       (* TODO: always print Unknown for why3 ? *)
+      let ur = SAT.get_unknown_reason t in
       let status =
-        if timeout != NoTimeout then (Timeout (Some d))
-        else (Unknown (d, t))
+        match ur with
+        | Some (Sat_solver_sig.Timeout _) -> Timeout (Some d)
+        | _ -> Unknown (d, t)
       in
       print_status status (Steps.get_steps ());
-      print_model t (Some timeout);
+      print_model t ur;
       (* TODO: Is it an appropriate behaviour? *)
       (*       if timeout != NoTimeout then raise Util.Timeout; *)
       env, `Unknown t, dep

--- a/src/lib/frontend/frontend.mli
+++ b/src/lib/frontend/frontend.mli
@@ -63,3 +63,5 @@ module type S = sig
 end
 
 module Make (SAT: Sat_solver_sig.S) : S with type sat_env = SAT.t
+
+val unknown_reason_to_string : Sat_solver_sig.unknown_reason -> string

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -31,18 +31,25 @@
 (* We put an ml file for the module type, to avoid issues when
    building the lib *)
 
+type timeout_reason =
+  | Assume
+  | ProofSearch
+  | ModelGen
+
+type unknown_reason =
+  | Incomplete
+  | Memout
+  | Timeout of timeout_reason
+
+(* TODO: use an ADT and add Timeout when library starts acting like a
+   library. *)
+
 module type S = sig
   type t
 
-  type timeout_reason =
-    | NoTimeout
-    | Assume
-    | ProofSearch
-    | ModelGen
-
   exception Sat of t
   exception Unsat of Explanation.t
-  exception I_dont_know of { env : t; timeout : timeout_reason }
+  exception I_dont_know of t
 
   (* the empty sat-solver context *)
   val empty : unit -> t
@@ -82,6 +89,9 @@ module type S = sig
   (** [get_model t] produces the current model. *)
   val get_model: t -> Models.t Lazy.t option
 
+  (** [get_unknown_reason t] returns the reason Alt-Ergo raised
+      [I_dont_know] if it did. If it did not, returns None. *)
+  val get_unknown_reason : t -> unknown_reason option
 end
 
 

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -41,9 +41,6 @@ type unknown_reason =
   | Memout
   | Timeout of timeout_reason
 
-(* TODO: use an ADT and add Timeout when library starts acting like a
-   library. *)
-
 module type S = sig
   type t
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -28,18 +28,22 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type timeout_reason =
+  | Assume
+  | ProofSearch
+  | ModelGen
+
+type unknown_reason =
+  | Incomplete
+  | Memout
+  | Timeout of timeout_reason
+
 module type S = sig
   type t
 
-  type timeout_reason =
-    | NoTimeout
-    | Assume
-    | ProofSearch
-    | ModelGen
-
   exception Sat of t
   exception Unsat of Explanation.t
-  exception I_dont_know of { env : t; timeout : timeout_reason }
+  exception I_dont_know of t
 
   (** the empty sat-solver context *)
   val empty : unit -> t
@@ -83,6 +87,9 @@ module type S = sig
   (** [get_model t] produces the current model. *)
   val get_model: t -> Models.t Lazy.t option
 
+  (** [get_unknown_reason t] returns the reason Alt-Ergo raised
+      [I_dont_know] if it did. If it did not, returns None. *)
+  val get_unknown_reason : t -> unknown_reason option
 end
 
 

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -104,7 +104,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   exception Unsat of Explanation.t
   exception I_dont_know of t
 
-  let i_dont_know env ur = 
+  let i_dont_know env ur =
     raise (I_dont_know {env with unknown_reason = Some ur})
 
   exception IUnsat of t * Explanation.t

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -62,6 +62,9 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     guards : guards;
     last_saved_model : Models.t Lazy.t option ref;
     model_gen_phase : bool ref;
+    unknown_reason : Sat_solver_sig.unknown_reason option;
+    (** The reason why satml raised [I_dont_know] if it does; [None] by
+        default. *)
   }
 
   let empty_guards () = {
@@ -91,20 +94,18 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       add_inst = (fun _ -> true);
       last_saved_model = ref None;
       model_gen_phase = ref false;
+      unknown_reason = None;
     }
 
   let empty_with_inst add_inst =
     { (empty ()) with add_inst = add_inst }
 
-  type timeout_reason =
-    | NoTimeout
-    | Assume
-    | ProofSearch
-    | ModelGen
-
   exception Sat of t
   exception Unsat of Explanation.t
-  exception I_dont_know of { env : t; timeout : timeout_reason }
+  exception I_dont_know of t
+
+  let i_dont_know env ur = 
+    raise (I_dont_know {env with unknown_reason = Some ur})
 
   exception IUnsat of t * Explanation.t
 
@@ -1005,15 +1006,14 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
     end
 
-  let update_model_and_return_unknown env compute_model ~timeout =
+  let update_model_and_return_unknown env compute_model ~unknown_reason =
     try
       let env = may_update_last_saved_model env compute_model in
       Options.Time.unset_timeout ();
-      raise (I_dont_know {env; timeout })
+      i_dont_know env unknown_reason
     with Util.Timeout when !(env.model_gen_phase) ->
       (* In this case, timeout reason becomes 'ModelGen' *)
-      raise (I_dont_know {env; timeout = ModelGen })
-
+      i_dont_know env (Timeout ModelGen)
 
   let model_gen_on_timeout env =
     let i = Options.get_interpretation () in
@@ -1022,7 +1022,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
        !(env.model_gen_phase) ||  (* we timeouted in model-gen-phase *)
        Stdlib.(=) ti 0. (* no time allocated for extra model search *)
     then
-      raise (I_dont_know {env; timeout = ProofSearch})
+      i_dont_know env (Timeout ProofSearch)
     else
       begin
         (* Beware: models generated on timeout of ProofSearch phase may
@@ -1032,7 +1032,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
         Options.Time.unset_timeout ();
         Options.Time.set_timeout ti;
         update_model_and_return_unknown
-          env i ~timeout:ProofSearch (* may becomes ModelGen *)
+          env i ~unknown_reason:(Timeout ProofSearch) (* may becomes ModelGen *)
       end
 
   let rec unsat_rec env ~first_call:_ : unit =
@@ -1079,7 +1079,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
         if not updated then
           update_model_and_return_unknown
             env (Options.get_last_interpretation ())
-            ~timeout:NoTimeout; (* may becomes ModelGen *)
+            ~unknown_reason:Incomplete; (* may becomes ModelGen *)
         unsat_rec env ~first_call:false
 
       with
@@ -1214,7 +1214,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
          | Util.Timeout ->
            (* don't attempt to compute a model if timeout before
               calling unsat function *)
-           raise (I_dont_know {env; timeout = Assume})
+           i_dont_know env (Timeout Assume)
 
   (* instrumentation of relevant exported functions for profiling *)
   let assume t ff dep =
@@ -1246,6 +1246,8 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     env
 
   let get_model env = !(env.last_saved_model)
+
+  let get_unknown_reason env = env.unknown_reason
 
   let reinit_ctx () =
     Steps.reinit_steps ();

--- a/src/lib/util/printer.mli
+++ b/src/lib/util/printer.mli
@@ -175,9 +175,9 @@ val print_status_preprocess :
   float option ->
   int option -> unit
 
-(** Print smtlib error message on the error formatter accessible with
-    {!val:Options.get_fmt_err} and set by default to stderr.
-    The err formatter is flushed after the print if flushed is set *)
+(** Print smtlib error message on the regular formatter, accessible with
+    {!val:Options.get_fmt_regular} and set by default to stdout.
+    The regular formatter is flushed after the print if flushed is set. *)
 val print_smtlib_err :
   ?flushed:bool ->
   ('a, Format.formatter, unit) format -> 'a

--- a/tests/everything/testfile-smt-instr-get-info.dolmen.expected
+++ b/tests/everything/testfile-smt-instr-get-info.dolmen.expected
@@ -1,11 +1,13 @@
 (error "Invalid (get-info :reason-unknown)")
 
 unknown
-(:all-statistics unsupported)
-(:assertion-stack-levels unsupported)
+unsupported
+
+unsupported
+
 (:authors "Alt-Ergo developers")
 (:error-behavior immediate-exit)
 (:name "Alt-Ergo")
-(:reason-unknown incomplete)
+(:reason-unknown Incomplete)
 (:version dev)
-(error "unknown option ':foo'")
+unsupported

--- a/tests/everything/testfile-smt-instr-get-info.dolmen.expected
+++ b/tests/everything/testfile-smt-instr-get-info.dolmen.expected
@@ -1,0 +1,11 @@
+(error "Invalid (get-info :reason-unknown)")
+
+unknown
+(:all-statistics unsupported)
+(:assertion-stack-levels unsupported)
+(:authors "Alt-Ergo developers")
+(:error-behavior immediate-exit)
+(:name "Alt-Ergo")
+(:reason-unknown incomplete)
+(:version dev)
+(error "unknown option ':foo'")

--- a/tests/everything/testfile-smt-instr-get-info.dolmen.smt2
+++ b/tests/everything/testfile-smt-instr-get-info.dolmen.smt2
@@ -1,0 +1,17 @@
+(set-logic ALL)
+
+(declare-const x Int)
+(declare-const y Int)
+
+(assert (= (* x x) 4))
+
+(get-info :reason-unknown)
+(check-sat)
+(get-info :all-statistics)
+(get-info :assertion-stack-levels)
+(get-info :authors)
+(get-info :error-behavior)
+(get-info :name)
+(get-info :reason-unknown)
+(get-info :version)
+(get-info :foo)


### PR DESCRIPTION
Adds support for the `(get-info)` command, based on https://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf#page=58