### PR TITLE
BV Theory: Handling of zero extend

### DIFF
--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -139,7 +139,8 @@ module Shostak(X : ALIEN) = struct
 
   let is_mine_symb sy _ =
     match sy with
-    | Sy.Bitv _ | Sy.Op (Concat | Extract _ | BV2Nat | BVnot)  -> true
+    | Sy.Bitv _
+    | Sy.Op (Concat | Extract _ | BV2Nat | BVnot | BVZeroExtend _)  -> true
     | _ -> false
 
   let embed r =
@@ -212,6 +213,8 @@ module Shostak(X : ALIEN) = struct
         { descr = Vextract (t', i, j); size }
       | { f = Op BVnot; xs = [ t ]; ty = Tbitv size; _ } ->
         { descr = Vnot t; size }
+      | { f = Op BVZeroExtend n; xs = [ t ]; ty = Tbitv size; _ } when n > 0 ->
+        { descr = Vconcat (E.BV.bvzero n, t); size = n + size }
       | { ty = Tbitv size; _ } ->
         { descr = Vother t; size }
       | _ -> assert false

--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -213,6 +213,8 @@ module Shostak(X : ALIEN) = struct
         { descr = Vextract (t', i, j); size }
       | { f = Op BVnot; xs = [ t ]; ty = Tbitv size; _ } ->
         { descr = Vnot t; size }
+      | { f = Op BVZeroExtend n; xs = [ t ]; ty = Tbitv size; _ } when n = 0 ->
+        { descr = Vother t; size }
       | { f = Op BVZeroExtend n; xs = [ t ]; ty = Tbitv size; _ } when n > 0 ->
         { descr = Vconcat (E.BV.bvzero n, t); size = n + size }
       | { ty = Tbitv size; _ } ->

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -46,7 +46,7 @@ type operator =
   (* BV *)
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
-  | BVnot | BVand | BVor | Int2BV of int | BV2Nat
+  | BVnot | BVand | BVor | Int2BV of int | BV2Nat | BVZeroExtend of int
   (* FP *)
   | Float
   | Integer_round | Fixed
@@ -142,14 +142,15 @@ let compare_operators op1 op2 =
       | Extract (i1, j1), Extract (i2, j2) ->
         let r = Int.compare i1 i2 in
         if r = 0 then Int.compare j1 j2 else r
-      | Int2BV n1, Int2BV n2 -> Int.compare n1 n2
+      | Int2BV n1, Int2BV n2
+      | BVZeroExtend n1, BVZeroExtend n2 -> Int.compare n1 n2
       | _ , (Plus | Minus | Mult | Div | Modulo | Real_is_int
             | Concat | Extract _ | Get | Set | Fixed | Float | Reach
             | Access _ | Record | Sqrt_real | Abs_int | Abs_real
             | Real_of_int | Int_floor | Int_ceil | Sqrt_real_default
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
             | Integer_log2 | Pow | Integer_round
-            | BVnot | BVand | BVor | Int2BV _ | BV2Nat
+            | BVnot | BVand | BVor | Int2BV _ | BV2Nat | BVZeroExtend _
             | Not_theory_constant | Is_theory_constant | Linear_dependency
             | Constr _ | Destruct _ | Tite) -> assert false
     )
@@ -327,6 +328,7 @@ let to_string ?(show_vars=true) x = match x with
   | Op BVor -> "bvor"
   | Op Int2BV n -> Format.sprintf "int2bv[%d]" n
   | Op BV2Nat -> "bv2nat"
+  | Op BVZeroExtend n -> Format.sprintf "zero_extend %i" n
   | Op Tite -> "ite"
   | Op Reach -> assert false
   | True -> "true"

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -46,7 +46,7 @@ type operator =
   (* BV *)
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
-  | BVnot | BVand | BVor | Int2BV of int | BV2Nat
+  | BVnot | BVand | BVor | Int2BV of int | BV2Nat | BVZeroExtend of int
   (* FP *)
   | Float
   | Integer_round | Fixed

--- a/tests/bitv/testfile-bvze.dolmen.expected
+++ b/tests/bitv/testfile-bvze.dolmen.expected
@@ -1,0 +1,6 @@
+
+unsat
+
+unknown
+
+unknown

--- a/tests/bitv/testfile-bvze.dolmen.smt2
+++ b/tests/bitv/testfile-bvze.dolmen.smt2
@@ -1,0 +1,16 @@
+(set-logic BV)
+
+(push 1)
+(assert (= ((_ zero_extend 8) #b11111111) #b1000000011111111))
+(check-sat)
+(pop 1)
+
+(push 1)
+(assert (= ((_ zero_extend 8) #b11111111) #b0000000011111111))
+(check-sat)
+(pop 1)
+
+(push 1)
+(assert (= ((_ zero_extend 0) #b11111111) #b11111111))
+(check-sat)
+(pop 1)


### PR DESCRIPTION
This MR adds to the alt-ergo bit vector theory processor the zero_extend primitive

https://smtlib.cs.uiowa.edu/logics-all.shtml