### PR TITLE
Fix error handling of dolmen

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -257,6 +257,9 @@ let main () =
     | Errors.Error e ->
       Printer.print_err "%a" Errors.report e;
       exit 1
+    | D_loop.DolmenError (i, descr) ->
+      Printer.print_err "Dolmen failed %s (code %i)" descr i;
+      exit 1
     | _ as exn -> Printexc.raise_with_backtrace exn bt
   in
   let finally ~handle_exn st e =

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -258,7 +258,7 @@ let main () =
       Printer.print_err "%a" Errors.report e;
       exit 1
     | D_loop.DolmenError (i, descr) ->
-      Printer.print_err "Dolmen failed %s (code %i)" descr i;
+      Printer.print_err "Failure %s (code %i)" descr i;
       exit 1
     | _ as exn -> Printexc.raise_with_backtrace exn bt
   in

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -257,9 +257,6 @@ let main () =
     | Errors.Error e ->
       Printer.print_err "%a" Errors.report e;
       exit 1
-    | D_loop.DolmenError (i, descr) ->
-      Printer.print_err "Failure %s (code %i)" descr i;
-      exit 1
     | _ as exn -> Printexc.raise_with_backtrace exn bt
   in
   let finally ~handle_exn st e =

--- a/src/lib/frontend/d_loop.ml
+++ b/src/lib/frontend/d_loop.ml
@@ -28,10 +28,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-exception DolmenError of int * string
-(** An error raised by Dolmen; corresponds to the error code and a short
-    description of the error. *)
-
 module DStd = Dolmen.Std
 module Dl = Dolmen_loop
 
@@ -44,7 +40,7 @@ module State = struct
     let loc = Dolmen.Std.Misc.opt_map loc Dolmen.Std.Loc.full_loc in
     let aux _ =
       let code, descr = Dl.(Code.descr Dl.Report.Error.(code error)) in
-      raise (DolmenError (code, descr))
+      raise (Errors.(error (Dolmen_error (code, descr))))
     in
     match get report_style st with
     | Minimal ->

--- a/src/lib/frontend/d_loop.ml
+++ b/src/lib/frontend/d_loop.ml
@@ -29,6 +29,8 @@
 (**************************************************************************)
 
 exception DolmenError of int * string
+(** An error raised by Dolmen; corresponds to the error code and a short
+    description of the error. *)
 
 module DStd = Dolmen.Std
 module Dl = Dolmen_loop

--- a/src/lib/structures/errors.ml
+++ b/src/lib/structures/errors.ml
@@ -92,6 +92,7 @@ type error =
   | Typing_error of Loc.t * typing_error
   | Run_error of run_error
   | Warning_as_error
+  | Dolmen_error of (int * string)
 
 exception Error of error
 
@@ -256,4 +257,7 @@ let report fmt = function
   | Run_error e ->
     Options.pp_comment fmt "Fatal Error: ";
     report_run_error fmt e
+  | Dolmen_error (code, descr) ->
+    Options.pp_comment fmt
+      (Format.sprintf "Error %s (code %i)" descr code);
   | Warning_as_error -> ()

--- a/src/lib/structures/errors.mli
+++ b/src/lib/structures/errors.mli
@@ -100,6 +100,8 @@ type error =
   | Typing_error of Loc.t * typing_error (** Error used at typing *)
   | Run_error of run_error (** Error used during solving *)
   | Warning_as_error
+  | Dolmen_error of (int * string)
+  (** Error code + description raised by dolmen. *)
 
 (** {2 Exceptions } *)
 


### PR DESCRIPTION
When dolmen fails, its default behavior is to call `exit` with a custom exit code. This MR overrides the `error` function of the dolmen loop so that alt-ergo keeps control over the exit code.