### PR TITLE
Use ZArith-based representations for numbers and bitvectors

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -950,11 +950,7 @@ let rec mk_expr
           | B.True -> E.vrai
           | B.False -> E.faux
           | B.Integer s -> E.int s
-          | B.Decimal s ->
-            (* We do a roundtrip through [Q.t] to ensure that multiple
-               representations of the same real (e.g. [2] and [0x1.0p1]) get
-               normalized to the same expression.  *)
-            E.real (s |> Q.of_string |> Q.to_string)
+          | B.Decimal s -> E.real s
           | B.Bitvec s ->
             let ty = dty_to_ty term_ty in
             E.bitv s ty

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -964,7 +964,7 @@ let real r =
     mk_term (Sy.Op Sy.Minus) [ positive_real "0"; positive_real pi ] Ty.Treal
   | _ -> positive_real r
 
-let bitv bt ty = mk_term (Sy.Bitv bt) [] ty
+let bitv bt ty = mk_term (Sy.bitv bt) [] ty
 
 let pred t = mk_term (Sy.Op Sy.Minus) [t;int "1"] Ty.Tint
 
@@ -2813,11 +2813,10 @@ type const =
 let const_view t =
   match term_view t with
   | { f = Int n; _ } ->
-    let n = Hstring.view n in
-    begin match int_of_string n with
+    begin match Z.to_int n with
       | n -> Int n
-      | exception Failure _ ->
-        Fmt.failwith "error when trying to convert %s to an int" n
+      | exception Z.Overflow ->
+        Fmt.failwith "error when trying to convert %a to an int" Z.pp_print n
     end
   | { f = Op (Constr c); ty; _ }
     when Ty.equal ty Fpa_rounding.fpa_rounding_mode ->

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -85,9 +85,9 @@ type t =
   | False
   | Void
   | Name of Hstring.t * name_kind * bool
-  | Int of Hstring.t
-  | Real of Hstring.t
-  | Bitv of string
+  | Int of Z.t
+  | Real of Q.t
+  | Bitv of int * Z.t
   | Op of operator
   | Lit of lit
   | Form of form
@@ -100,6 +100,7 @@ val name : ?kind:name_kind -> ?defined:bool -> string -> t
 val var : Var.t -> t
 val underscore : t
 val int : string -> t
+val bitv : string -> t
 val real : string -> t
 val constr : string -> t
 val destruct : guarded:bool -> string -> t

--- a/src/lib/util/compat.ml
+++ b/src/lib/util/compat.ml
@@ -4,6 +4,13 @@ module String = struct
   let starts_with ~prefix s =
     length s >= length prefix &&
     equal (sub s 0 (length prefix)) prefix
+
+  let fold_left f x a =
+    let r = ref x in
+    for i = 0 to length a - 1 do
+      r := f !r (unsafe_get a i)
+    done;
+    !r
 end
 
 module Seq = struct

--- a/src/lib/util/compat.mli
+++ b/src/lib/util/compat.mli
@@ -34,6 +34,9 @@
 module String : sig
   (* @since 4.13.0 *)
   val starts_with : prefix:string -> string -> bool
+
+  (* @since 4.13.0 *)
+  val fold_left : ('acc -> char -> 'acc) -> 'acc -> string -> 'acc
 end
 
 module Seq : sig

--- a/src/lib/util/numbers.mli
+++ b/src/lib/util/numbers.mli
@@ -86,7 +86,7 @@ end
 
 (** Rationals implementation. **)
 module Q : sig
-  type t
+  type t = Q.t
 
   exception Not_a_float
 


### PR DESCRIPTION
Alt-Ergo uses strings to represent terms containing numbers and/or bitvectors. In addition to a (slight) overhead, it also caused issues in the past with different string representations of the same value being considered distinct.

This patch uses Z.t (Q.t for reals) to represent integers, bitvectors and reals instead of strings.

Fixes #668