### PR TITLE
Add ppx_deriving dependency after 766d1234

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@ let
       ppx_blob
       dolmen_loop
       camlzip
+      ppx_deriving
     ];
   };
 

--- a/dune-project
+++ b/dune-project
@@ -88,6 +88,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
   (ppx_blob (>= 0.7.2))
   (camlzip (>= 1.07))
   (odoc :with-doc)
+  ppx_deriving
  )
  (conflicts
   (ppxlib (< 0.30.0))

--- a/shell.nix
+++ b/shell.nix
@@ -36,5 +36,6 @@ pkgs.mkShell {
     cmdliner
     ppx_blob
     odoc
+    ppx_deriving
   ];
 }


### PR DESCRIPTION
This patch adds an explicit dependency to ppx_deriving to alt-ergo-lib and to the nix config.