### PR TITLE
Allow dynamic selection of the SAT solver with `set-option`

### DIFF
--- a/examples/lib_usage.ml
+++ b/examples/lib_usage.ml
@@ -90,7 +90,7 @@ module FE = Frontend.Make(SAT)
 let () =
   List.iter
     (fun (pb, _goal_name) ->
-       let ctxt = FE.init_all_used_context () in
+       let ctxt = Frontend.init_all_used_context () in
        let acc0 = SAT.empty (), `Unknown (SAT.empty ()), Explanation.empty in
        let s = Stack.create () in
        let _env, consistent, _ex =

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -1008,9 +1008,6 @@ let parse_output_opt =
           set_cdcl_tableaux_inst false;
           set_cdcl_tableaux_th false
       end;
-      set_tableaux_cdcl (match sat_solver with
-          | Tableaux_CDCL -> true
-          | _ -> false);
       ()
     in
     Term.(

--- a/src/bin/js/options_interface.ml
+++ b/src/bin/js/options_interface.ml
@@ -190,7 +190,6 @@ let set_options r =
     (get_no_decisions_on r.no_decisions_on);
   set_options_opt Options.set_no_sat_learning r.no_sat_learning;
   set_options_opt Options.set_sat_solver (get_sat_solver r.sat_solver);
-  set_options_opt Options.set_tableaux_cdcl r.tableaux_cdcl;
 
   set_options_opt Options.set_disable_ites r.disable_ites;
   set_options_opt Options.set_inline_lets r.inline_lets;

--- a/src/bin/js/worker_interface.ml
+++ b/src/bin/js/worker_interface.ml
@@ -261,7 +261,6 @@ type options = {
   no_decisions_on : (string list) option;
   no_sat_learning : bool option;
   sat_solver : sat_solver option;
-  tableaux_cdcl : bool option;
 
   disable_ites : bool option;
   inline_lets : bool option;
@@ -365,7 +364,6 @@ let init_options () = {
   no_decisions_on = None;
   no_sat_learning = None;
   sat_solver = None;
-  tableaux_cdcl = None;
 
   disable_ites = None;
   inline_lets = None;
@@ -515,11 +513,10 @@ let opt6_encoding =
   conv
     (fun opt6 -> opt6)
     (fun opt6 -> opt6)
-    (obj10
+    (obj9
        (opt "no_decisions_on" (list string))
        (opt "no_sat_learning" bool)
        (opt "sat_solver" sat_solver_encoding)
-       (opt "tableaux_cdcl" bool)
        (opt "disable_ites" bool)
        (opt "inline_lets" bool)
        (opt "rewriting" bool)
@@ -645,7 +642,6 @@ let options_to_json opt =
     (opt.no_decisions_on,
      opt.no_sat_learning,
      opt.sat_solver,
-     opt.tableaux_cdcl,
      opt. disable_ites,
      opt.inline_lets,
      opt.rewriting,
@@ -763,7 +759,6 @@ let options_from_json options =
     let (no_decisions_on,
          no_sat_learning,
          sat_solver,
-         tableaux_cdcl,
          disable_ites,
          inline_lets,
          rewriting,
@@ -851,7 +846,6 @@ let options_from_json options =
       no_decisions_on;
       no_sat_learning;
       sat_solver;
-      tableaux_cdcl;
       disable_ites;
       inline_lets;
       rewriting;

--- a/src/bin/js/worker_interface.mli
+++ b/src/bin/js/worker_interface.mli
@@ -144,7 +144,6 @@ type options = {
   no_decisions_on : (string list) option;
   no_sat_learning : bool option;
   sat_solver : sat_solver option;
-  tableaux_cdcl : bool option;
 
   disable_ites : bool option;
   inline_lets : bool option;

--- a/src/bin/js/worker_js.ml
+++ b/src/bin/js/worker_js.ml
@@ -110,18 +110,18 @@ let main worker_id content =
     let get_status_and_print status n =
       returned_status :=
         begin match status with
-          | FE.Unsat _ -> Worker_interface.Unsat n
-          | FE.Inconsistent _ -> Worker_interface.Inconsistent n
-          | FE.Sat _ -> Worker_interface.Sat n
-          | FE.Unknown _ -> Worker_interface.Unknown n
-          | FE.Timeout _ -> Worker_interface.LimitReached "timeout"
-          | FE.Preprocess -> Worker_interface.Unknown n
+          | Frontend.Unsat _ -> Worker_interface.Unsat n
+          | Inconsistent _ -> Worker_interface.Inconsistent n
+          | Sat _ -> Worker_interface.Sat n
+          | Unknown _ -> Worker_interface.Unknown n
+          | Timeout _ -> Worker_interface.LimitReached "timeout"
+          | Preprocess -> Worker_interface.Unknown n
         end;
-      FE.print_status status n
+      Frontend.print_status status n
     in
 
     let solve all_context (cnf, goal_name) =
-      let used_context = FE.choose_used_context all_context ~goal_name in
+      let used_context = Frontend.choose_used_context all_context ~goal_name in
       let consistent_dep_stack = Stack.create () in
       SAT.reset_refs ();
       let env = SAT.empty_with_inst add_inst in
@@ -182,7 +182,7 @@ let main worker_id content =
         Printer.print_err "%a" Errors.report e;
         raise Exit
     in
-    let all_used_context = FE.init_all_used_context () in
+    let all_used_context = Frontend.init_all_used_context () in
     let assertion_stack = Stack.create () in
     let typing_loop state p =
       try

--- a/src/lib/frontend/frontend.mli
+++ b/src/lib/frontend/frontend.mli
@@ -28,10 +28,24 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type used_context
+
+val init_all_used_context : unit -> used_context
+val choose_used_context : used_context -> goal_name:string -> used_context
+
+type 'a status =
+  | Unsat of Commands.sat_tdecl * Explanation.t
+  | Inconsistent of Commands.sat_tdecl
+  | Sat of Commands.sat_tdecl * 'a
+  | Unknown of Commands.sat_tdecl * 'a
+  | Timeout of Commands.sat_tdecl option
+  | Preprocess
+
+val print_status : 'a status -> int -> unit
+
 module type S = sig
 
   type sat_env
-  type used_context
 
   type res = [
     | `Sat of sat_env
@@ -39,27 +53,13 @@ module type S = sig
     | `Unsat
   ]
 
-  type status =
-    | Unsat of Commands.sat_tdecl * Explanation.t
-    | Inconsistent of Commands.sat_tdecl
-    | Sat of Commands.sat_tdecl * sat_env
-    | Unknown of Commands.sat_tdecl * sat_env
-    | Timeout of Commands.sat_tdecl option
-    | Preprocess
-
   val process_decl:
-    (status -> int -> unit) ->
+    (sat_env status -> int -> unit) ->
     used_context ->
     (res * Explanation.t) Stack.t ->
     sat_env * res * Explanation.t ->
     Commands.sat_tdecl ->
     sat_env * res * Explanation.t
-
-  val print_status : status -> int -> unit
-
-  val init_all_used_context : unit -> used_context
-  val choose_used_context : used_context -> goal_name:string -> used_context
-
 end
 
 module Make (SAT: Sat_solver_sig.S) : S with type sat_env = SAT.t

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -469,7 +469,6 @@ let no_decisions_on = ref Util.SS.empty
 let no_sat_learning = ref false
 let sat_plugin = ref ""
 let sat_solver = ref Util.CDCL_Tableaux
-let tableaux_cdcl = ref false
 
 let set_arith_matching b = arith_matching := b
 let set_bottom_classes b = bottom_classes := b
@@ -486,7 +485,6 @@ let set_no_decisions_on s = no_decisions_on := s
 let set_no_sat_learning b = no_sat_learning := b
 let set_sat_plugin p = sat_plugin := p
 let set_sat_solver s = sat_solver := s
-let set_tableaux_cdcl b = tableaux_cdcl := b
 
 let get_arith_matching () = !arith_matching
 let get_bottom_classes () = !bottom_classes
@@ -509,7 +507,10 @@ let get_no_sat_learning () = !no_sat_learning
 let get_sat_learning () = not (!no_sat_learning)
 let get_sat_plugin () = !sat_plugin
 let get_sat_solver () = !sat_solver
-let get_tableaux_cdcl () = !tableaux_cdcl
+let get_tableaux_cdcl () =
+  match !sat_solver with
+  | Tableaux_CDCL -> true
+  | _ -> false
 
 (** Term options *)
 

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -424,9 +424,6 @@ val set_sat_plugin : string -> unit
 (** Set [sat_solver] accessible with {!val:get_sat_solver} *)
 val set_sat_solver : Util.sat_solver -> unit
 
-(** Set [tableaux_cdcl] accessible with {!val:get_tableaux_cdcl} *)
-val set_tableaux_cdcl : bool -> unit
-
 (** Set [disable_ites] accessible with {!val:get_disable_ites} *)
 val set_disable_ites : bool -> unit
 


### PR DESCRIPTION
This patch adds support for `(set-option :sat-solver)` in the SMT-LIB frontend.

The patch mostly lifts SAT-independent bits out of `Frontend.Make`, allowing to use a first-class module stored on the Dolmen state to provide access to the frontend.

Changing solvers is only allowed in the initial state (before any assertions are made) as a forward-compatibility measure: it would currently be possible to switch solvers on the fly because we merely accumulate commands in the context and only call the solver on `(check-sat)`, but allowing solver changes anywhere would make it harder to remove the command stack, which we will probably do at some point (see also #382).

The rationale behind this, as discussed offline, is to allow more flexibility in test files that require the use of a specific solver.