### PR TITLE
Replace Travis badges with GitHub Actions badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Also see the [Alt-Ergo Users' Club].
 ## Build status
 next | main
 ------------ | -------------
-[![Build Status (next)](https://travis-ci.org/OCamlPro/alt-ergo.svg?branch=next)](https://travis-ci.org/OCamlPro/alt-ergo) | [![Build Status (main)](https://travis-ci.org/OCamlPro/alt-ergo.svg?branch=main)](https://travis-ci.org/OCamlPro/alt-ergo) 
+![Build Status (next)](https://github.com/OCamlPro/alt-ergo/actions/workflows/build.yml/badge.svg?branch=next) | ![Build Status (main)](https://github.com/OCamlPro/alt-ergo/actions/workflows/build.yml/badge.svg?branch=main)
 
 ## Website
 


### PR DESCRIPTION
We no longer use Travis.

(Note that we don't currently have a workflow on main, so the build is "no status" — will be fixed once #831 is merged)