### PR TITLE
Using `dune build @check` to build the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ plugins:
 # Alias to build all the bytecode artefacts using dune
 # Hopefully more efficient than making "all" depend
 # on "lib" and "bin", since dune can parralelize more
-all: dune build @check
+all:
+	$(DUNE) build $(DUNE_FLAGS) @check
 
 # declare these targets as phony to avoid name clashes with existing directories,
 # particularly the "plugins" target

--- a/Makefile
+++ b/Makefile
@@ -90,13 +90,10 @@ AB-Why3:
 plugins:
 	$(DUNE) build $(DUNE_FLAGS) @$(PLUGINS_DIR)/all
 
-# Alias to build all targets using dune
+# Alias to build all the bytecode artefacts using dune
 # Hopefully more efficient than making "all" depend
-# on "lib" and "bin", since dune can
-# parralelize more
-all:
-	$(DUNE) build $(DUNE_FLAGS) @$(LIB_DIR)/all @$(BTEXT_DIR)/all \
-		@$(PARSERS_DIR)/all @$(BJS_DIR)/all @$(PLUGINS_DIR)/all
+# on "lib" and "bin", since dune can parralelize more
+all: dune build @check
 
 # declare these targets as phony to avoid name clashes with existing directories,
 # particularly the "plugins" target


### PR DESCRIPTION
The current target `all` of the `Makefile` is a bit complicated as we want to build only the codebase without running tests when we type `make`. After looking for a better solution, I found this issue on the `dune` GitHub (https://github.com/ocaml/dune/issues/7203) explaining we have to use `dune build @check` and `dune build` builds everything by design.

I modify the `Makefile` accordingly.