### PR TITLE
Warnings as errors on the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,8 @@ jobs:
       - name: Install dependencies
         run: opam exec -- make deps js-deps
 
-      - name: Run make
-        run: opam exec -- make
+      - name: Build the project
+        run: opam exec -- dune build --profile ci @check
 
       - name: Monitor changes
         uses: getsentry/action-git-diff-suggestions@main

--- a/src/dune
+++ b/src/dune
@@ -3,9 +3,9 @@
   (flags
    (:standard -bin-annot -w -22 -warn-error -A))
   (ocamlopt_flags -g))
- (warnings ;; This profile can be used to simply enable all warnings.
+ (ci ;; This profile is used by the CI.
   (flags
-   (:standard -bin-annot -w +A -warn-error -A))
+   (:standard -bin-annot -w -22 -warn-error +A))
   (ocamlopt_flags -g))
  (release ;; The release profile has optimizations enabled.
   (flags


### PR DESCRIPTION
This PR turns warnings into errors in the CI by adding a new profile `ci` in `dune`.

I also remove the useless `warnings` profile.