### PR TITLE
Add ml_z_extract_small JS stub

### DIFF
--- a/src/lib/missing_primitives.js
+++ b/src/lib/missing_primitives.js
@@ -39,3 +39,11 @@ function unix_getpid() {
 function unix_kill() {
   return 0;
 }
+
+// Fast path in ZArith 1.13, not in zarith_stubs_js
+// https://github.com/janestreet/zarith_stubs_js/issues/10
+// Provides: ml_z_extract_small
+// Requires: ml_z_extract
+function ml_z_extract_small(z1, pos, len) {
+  return ml_z_extract(z1, pos, len);
+}


### PR DESCRIPTION
ml_z_extract_small was added as a fast path in ZArith 1.13. It is not (yet) supported by zarith_stubs_js. Since it is a fast path for ml_z_extract, we can simply call ml_z_extract in missing_primitives.js for the time being.

Fixes #895