### PR TITLE
Uniformization of internal identifiers generation

### DIFF
--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -2152,7 +2152,7 @@ let axioms_of_rules loc name lf acc env =
   let acc =
     List.fold_left
       (fun acc f ->
-         let name = (Hstring.fresh_string ()) ^ "_" ^ name in
+         let name = (Symbols.InternalNameId.fresh ()) ^ "_" ^ name in
          let td = {c = TAxiom(loc,name,Util.Default, f); annot = new_id () } in
          (td, env)::acc
       ) acc lf

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -2152,7 +2152,7 @@ let axioms_of_rules loc name lf acc env =
   let acc =
     List.fold_left
       (fun acc f ->
-         let name = (Symbols.InternalNameId.fresh ()) ^ "_" ^ name in
+         let name = (Symbols.InternalId.fresh ()) ^ "_" ^ name in
          let td = {c = TAxiom(loc,name,Util.Default, f); annot = new_id () } in
          (td, env)::acc
       ) acc lf

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -2152,7 +2152,11 @@ let axioms_of_rules loc name lf acc env =
   let acc =
     List.fold_left
       (fun acc f ->
-         let name = (Symbols.InternalId.fresh ()) ^ "_" ^ name in
+         let name =
+           Fmt.str "%s_%s"
+             (Symbols.fresh_internal_string ())
+             name
+         in
          let td = {c = TAxiom(loc,name,Util.Default, f); annot = new_id () } in
          (td, env)::acc
       ) acc lf

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -458,7 +458,7 @@ module Shostak
     List.exists
       (fun x ->
          match X.term_extract x with
-         | Some t, _ -> E.is_fresh t
+         | Some t, _ -> E.is_internal_name t
          | _ -> false
       ) (X.leaves xp)
 

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1854,7 +1854,8 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     Steps.reinit_steps ();
     clear_instances_cache ();
     Th.reinit_cpt ();
-    Symbols.reinit_fresh_sy_cpt ();
+    Symbols.InternalNameId.reset_fresh_cpt ();
+    Symbols.SkolemId.reset_fresh_cpt ();
     Symbols.clear_labels ();
     Var.reinit_cnt ();
     Satml_types.Flat_Formula.reinit_cpt ();

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1854,7 +1854,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     Steps.reinit_steps ();
     clear_instances_cache ();
     Th.reinit_cpt ();
-    Symbols.InternalNameId.reset_fresh_cpt ();
+    Symbols.InternalId.reset_fresh_cpt ();
     Symbols.SkolemId.reset_fresh_cpt ();
     Symbols.clear_labels ();
     Var.reinit_cnt ();

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1854,9 +1854,8 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     Steps.reinit_steps ();
     clear_instances_cache ();
     Th.reinit_cpt ();
-    Symbols.InternalId.reset_fresh_cpt ();
-    Symbols.SkolemId.reset_fresh_cpt ();
     Symbols.clear_labels ();
+    Symbols.reset_id_builders ();
     Var.reinit_cnt ();
     Satml_types.Flat_Formula.reinit_cpt ();
     Ty.reinit_decls ();

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1252,8 +1252,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let reinit_ctx () =
     Steps.reinit_steps ();
     Th.reinit_cpt ();
-    Symbols.InternalId.reset_fresh_cpt ();
-    Symbols.SkolemId.reset_fresh_cpt ();
+    Symbols.reset_id_builders ();
     Symbols.clear_labels ();
     Var.reinit_cnt ();
     Satml_types.Flat_Formula.reinit_cpt ();

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1252,7 +1252,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let reinit_ctx () =
     Steps.reinit_steps ();
     Th.reinit_cpt ();
-    Symbols.InternalNameId.reset_fresh_cpt ();
+    Symbols.InternalId.reset_fresh_cpt ();
     Symbols.SkolemId.reset_fresh_cpt ();
     Symbols.clear_labels ();
     Var.reinit_cnt ();

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1252,7 +1252,8 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let reinit_ctx () =
     Steps.reinit_steps ();
     Th.reinit_cpt ();
-    Symbols.reinit_fresh_sy_cpt ();
+    Symbols.InternalNameId.reset_fresh_cpt ();
+    Symbols.SkolemId.reset_fresh_cpt ();
     Symbols.clear_labels ();
     Var.reinit_cnt ();
     Satml_types.Flat_Formula.reinit_cpt ();

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -1029,7 +1029,7 @@ let compute_concrete_model ({ make; _ } as env) =
        (* Keep record constructors because models.ml expects them to be there *)
        if (X.is_solvable_theory_symbol f ty
            && not (Shostak.Records.is_mine_symb f ty))
-       || E.is_fresh t || E.is_fresh_skolem t
+       || E.is_internal_name t || E.is_internal_skolem t
        || E.equal t E.vrai || E.equal t E.faux
        || Sy.is_internal f
        then

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -927,14 +927,14 @@ let vrai =
 let faux = neg (vrai)
 let void = mk_term (Sy.Void) [] Ty.Tunit
 
-let fresh_name ty = mk_term (Sy.fresh_name ()) [] ty
+let fresh_name ty = mk_term (Sy.fresh_internal_name ()) [] ty
 
 let is_internal_name t =
   match t with
-  | { f; xs = []; _ } -> Sy.is_internal_name f
+  | { f; xs = []; _ } -> Sy.is_fresh_internal_name f
   | _ -> false
 
-let is_internal_skolem t = Sy.is_skolem t.f
+let is_internal_skolem t = Sy.is_fresh_skolem t.f
 
 let positive_int i = mk_term (Sy.int i) [] Ty.Tint
 

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1712,10 +1712,9 @@ let skolemize { main = f; binders; sko_v; sko_vty; _ } =
   let tyvars = Format.asprintf "[%a]" pp_list sko_vty in
 
   let mk_sym cpt s =
-    (* garder le suffixe "__" car cela influence l'ordre *)
     Fmt.kstr
       (fun str -> Sy.make_as_fresh_skolem str)
-      "__%s%s!%d"
+      "%s%s!%d"
       s
       tyvars
       cpt

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -172,8 +172,8 @@ val size : t -> int
 val depth : t -> int
 val is_positive : t -> bool
 val neg : t -> t
-val is_fresh : t -> bool
-val is_fresh_skolem : t -> bool
+val is_internal_name : t -> bool
+val is_internal_skolem : t -> bool
 val is_int : t -> bool
 val is_real : t -> bool
 val type_info : t -> Ty.t

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -412,7 +412,8 @@ module MakeId(S : sig val prefix : string end) : Id = struct
 end
 
 module InternalId = MakeId(struct let prefix = "!k" end)
-module SkolemId = MakeId(struct let prefix = "!?" end)
+module SkolemId = MakeId(struct let prefix = "!?__" end)
+(* garder le suffixe "__" car cela influence l'ordre *)
 
 let fresh_internal_string () = InternalId.fresh ()
 let fresh_internal_name () = name (fresh_internal_string ())

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -408,15 +408,14 @@ module MakeId(S : sig val prefix : string end) : Id = struct
     in
     fresh_string, reset_fresh_string_cpt
 
-  let len_pre = String.length S.prefix
-
   let is_id = Compat.String.starts_with ~prefix:S.prefix
 end
 
 module InternalId = MakeId(struct let prefix = "!k" end)
 module SkolemId = MakeId(struct let prefix = "!?" end)
 
-let fresh_internal_name () = name (InternalId.fresh ())
+let fresh_internal_string () = InternalId.fresh ()
+let fresh_internal_name () = name (fresh_internal_string ())
 
 let fresh_skolem ?(is_var=false) base =
   let fresh = SkolemId.fresh ~base () in

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -421,10 +421,10 @@ module MakeId(S : sig val prefix : string end) : Id = struct
     in len_s >= len_pre && aux 0
 end
 
-module InternalNameId = MakeId(struct let prefix = "!k" end)
+module InternalId = MakeId(struct let prefix = "!k" end)
 module SkolemId = MakeId(struct let prefix = "!?" end)
 
-let fresh_name () = name (InternalNameId.fresh ())
+let fresh_internal_name () = name (InternalId.fresh ())
 
 let fresh_skolem ?(is_var=false) base =
   let fresh = SkolemId.fresh ~base () in
@@ -435,11 +435,11 @@ let fresh_skolem ?(is_var=false) base =
 
 let make_as_fresh_skolem str = name (SkolemId.make_as_fresh str)
 
-let is_internal_name = function
-  | Name (hd, _, _) -> InternalNameId.is_id (Hstring.view hd)
+let is_fresh_internal_name = function
+  | Name (hd, _, _) -> InternalId.is_id (Hstring.view hd)
   | _ -> false
 
-let is_skolem = function
+let is_fresh_skolem = function
   | Name (hd, _, _) -> SkolemId.is_id (Hstring.view hd)
   | _ -> false
 

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -386,7 +386,6 @@ let to_string s = to_string ~show_vars:true s
 let print_clean fmt s = Format.fprintf fmt "%s" (to_string_clean s)
 let print fmt s = Format.fprintf fmt "%s" (to_string s)
 
-
 module type Id = sig
   val fresh : ?base:string -> unit -> string
   val reset_fresh_cpt : unit -> unit
@@ -411,14 +410,7 @@ module MakeId(S : sig val prefix : string end) : Id = struct
 
   let len_pre = String.length S.prefix
 
-  let is_id s =
-    let len_s = String.length s in
-    let rec aux i =
-      if i = len_pre then true
-      else
-        Char.equal (String.unsafe_get s i) (String.unsafe_get S.prefix i)
-        && aux (i + 1)
-    in len_s >= len_pre && aux 0
+  let is_id = Compat.String.starts_with ~prefix:S.prefix
 end
 
 module InternalId = MakeId(struct let prefix = "!k" end)
@@ -467,6 +459,10 @@ let add_label lbl t = Labels.replace labels t lbl
 let label t = try Labels.find labels t with Not_found -> Hstring.empty
 
 let clear_labels () = Labels.clear labels
+
+let reset_id_builders () =
+  InternalId.reset_fresh_cpt ();
+  SkolemId.reset_fresh_cpt ()
 
 module Set : Set.S with type elt = t =
   Set.Make (struct type t=s let compare=compare end)

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -128,9 +128,23 @@ val print_clean : Format.formatter -> t -> unit
 
 (*val dummy : t*)
 
-val fresh : ?is_var:bool -> string -> t
+module type Id = sig
+  val fresh : ?base:string -> unit -> string
+  val reset_fresh_cpt : unit -> unit
+  val is_id : string -> bool
+  val make_as_fresh : string -> string
+end
 
-val reinit_fresh_sy_cpt : unit -> unit
+module InternalNameId : Id
+module SkolemId : Id
+
+val fresh_name : unit -> t
+val is_internal_name : t -> bool
+
+val fresh_skolem : ?is_var:bool -> string -> t
+val make_as_fresh_skolem : string -> t
+val is_skolem : t -> bool
+
 (** Resets to 0 the fresh symbol counter *)
 
 val is_get : t -> bool

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -135,15 +135,15 @@ module type Id = sig
   val make_as_fresh : string -> string
 end
 
-module InternalNameId : Id
+module InternalId : Id
 module SkolemId : Id
 
-val fresh_name : unit -> t
-val is_internal_name : t -> bool
+val fresh_internal_name : unit -> t
+val is_fresh_internal_name : t -> bool
 
 val fresh_skolem : ?is_var:bool -> string -> t
 val make_as_fresh_skolem : string -> t
-val is_skolem : t -> bool
+val is_fresh_skolem : t -> bool
 
 (** Resets to 0 the fresh symbol counter *)
 

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -128,23 +128,13 @@ val print_clean : Format.formatter -> t -> unit
 
 (*val dummy : t*)
 
-module type Id = sig
-  val fresh : ?base:string -> unit -> string
-  val reset_fresh_cpt : unit -> unit
-  val is_id : string -> bool
-  val make_as_fresh : string -> string
-end
-
-module InternalId : Id
-module SkolemId : Id
-
+val fresh_internal_string : unit -> string
 val fresh_internal_name : unit -> t
 val is_fresh_internal_name : t -> bool
 
 val fresh_skolem : ?is_var:bool -> string -> t
 val make_as_fresh_skolem : string -> t
 val is_fresh_skolem : t -> bool
-
 (** Resets to 0 the fresh symbol counter *)
 
 val is_get : t -> bool
@@ -164,6 +154,9 @@ val string_of_bound : bound -> string
 
 val clear_labels : unit -> unit
 (** Empties the labels Hashtable *)
+
+val reset_id_builders : unit -> unit
+(** Resets the `fresh_internal_name` and `fresh_skolem` counters. *)
 
 module Set : Set.S with type elt = t
 

--- a/src/lib/util/hstring.ml
+++ b/src/lib/util/hstring.ml
@@ -58,35 +58,29 @@ let rec list_assoc x = function
   | [] -> raise Not_found
   | (y, v) :: l -> if equal x y then v else list_assoc x l
 
-let fresh_string, reset_fresh_string_cpt =
-  let cpt = ref 0 in
-  let fresh_string () =
-    incr cpt;
-    "!k" ^ (string_of_int !cpt)
-  in
-  let reset_fresh_string_cpt () =
-    cpt := 0
-  in
-  fresh_string, reset_fresh_string_cpt
-
-let is_fresh_string s =
-  try s.[0] == '!' && s.[1] == 'k'
-  with Invalid_argument s ->
-    assert (String.compare s "index out of bounds" = 0);
-    false
-
-let is_fresh_skolem s =
-  try s.[0] == '!' && s.[1] == '?'
-  with Invalid_argument s ->
-    assert (String.compare s "index out of bounds" = 0);
-    false
+(* let fresh_string, reset_fresh_string_cpt =
+ *   let cpt = ref 0 in
+ *   let fresh_string () =
+ *     incr cpt;
+ *     "!k" ^ (string_of_int !cpt)
+ *   in
+ *   let reset_fresh_string_cpt () =
+ *     cpt := 0
+ *   in
+ *   fresh_string, reset_fresh_string_cpt
+ * 
+ * let is_fresh_string s =
+ *   try s.[0] == '!' && s.[1] == 'k'
+ *   with Invalid_argument s ->
+ *     assert (String.compare s "index out of bounds" = 0);
+ *     false *)
 
 let save_cache () =
   HC.save_cache ()
 
 let reinit_cache () =
-  HC.reinit_cache ();
-  reset_fresh_string_cpt ()
+  HC.reinit_cache ()
+  (* reset_fresh_string_cpt () *)
 
 module Arg = struct type t'= t type t = t' let compare = compare end
 module Set : Set.S with type elt = t = Set.Make(Arg)

--- a/src/lib/util/hstring.ml
+++ b/src/lib/util/hstring.ml
@@ -58,29 +58,11 @@ let rec list_assoc x = function
   | [] -> raise Not_found
   | (y, v) :: l -> if equal x y then v else list_assoc x l
 
-(* let fresh_string, reset_fresh_string_cpt =
- *   let cpt = ref 0 in
- *   let fresh_string () =
- *     incr cpt;
- *     "!k" ^ (string_of_int !cpt)
- *   in
- *   let reset_fresh_string_cpt () =
- *     cpt := 0
- *   in
- *   fresh_string, reset_fresh_string_cpt
- * 
- * let is_fresh_string s =
- *   try s.[0] == '!' && s.[1] == 'k'
- *   with Invalid_argument s ->
- *     assert (String.compare s "index out of bounds" = 0);
- *     false *)
-
 let save_cache () =
   HC.save_cache ()
 
 let reinit_cache () =
   HC.reinit_cache ()
-  (* reset_fresh_string_cpt () *)
 
 module Arg = struct type t'= t type t = t' let compare = compare end
 module Set : Set.S with type elt = t = Set.Make(Arg)

--- a/src/lib/util/hstring.mli
+++ b/src/lib/util/hstring.mli
@@ -46,12 +46,6 @@ val empty : t
 
 val list_assoc : t -> (t * 'a) list -> 'a
 
-val fresh_string : unit -> string
-
-val is_fresh_string : string -> bool
-
-val is_fresh_skolem : string -> bool
-
 val save_cache : unit -> unit
 (** Saves the module's cache *)
 


### PR DESCRIPTION
This PR centralizes how internal identifiers are created. This work is a first step before a simpler task, which is to replace the '!' by '.' in name identifiers.