### PR TITLE
Fix the target `all` of the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,8 @@ plugins:
 # Hopefully more efficient than making "all" depend
 # on "lib" and "bin", since dune can parralelize more
 all:
-	$(DUNE) build $(DUNE_FLAGS) @check
+	$(DUNE) build $(DUNE_FLAGS) @$(SRC_DIR)/all @examples/all
+	ln -sf src/bin/text/Main_text.exe alt-ergo
 
 # declare these targets as phony to avoid name clashes with existing directories,
 # particularly the "plugins" target


### PR DESCRIPTION
The PR #887 was wrong... The target `@check` of `Dune` doesn't build all the binaries, it builds only binary artefacts `cmi`, `cmx`, ... but no linkage is performed.

This commit mostly reverts the changes. As the sources are located in `src/`, I use the target `@src/all`. Now the command `make` will build everything in the directory `src`. I also add `examples` since we want to check the libusage module still compile.

-------

I also tried two other ways to fix the situation. I discover the stanza `enabled_if` for Dune's tests. We can create a `profile` or use an environment variable to enable or disable tests. For instance, we could have an environment variable `DISABLE_TESTS` whose the default value would be `false` and the `all` target of the `Makefile` would be `DISABLE_TESTS=true dune build`.

Note: the new `all` target copies the binary of AE at the root of the project as the target `bin` does. In my opinion, using `dune exec -- alt-ergo ...` is better since it prevents to perform tests on the wrong binary, but I remember @bclement-ocp  had a good argument to keep copying the binary (something about the option `--version` of AE?)