### PR TITLE
Update the lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ dev-switch:
 	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 
 js-deps:
-	opam pin add js_of_ocaml 5.0.1
+	opam pin add js_of_ocaml 5.4.0
 	opam install js_of_ocaml-lwt js_of_ocaml-ppx data-encoding zarith_stubs_js lwt_ppx -y
 
 deps:

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -16,13 +16,10 @@ homepage: "https://alt-ergo.ocamlpro.com/"
 doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
-  "astring" {= "0.8.5" & with-doc}
   "base-bigarray" {= "base"}
   "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "biniou" {= "1.2.1"}
-  "camlp-streams" {= "5.0.1" & with-doc}
   "camlzip" {= "1.11"}
   "cmdliner" {= "1.2.0"}
   "conf-gmp" {= "4"}
@@ -30,15 +27,13 @@ depends: [
   "conf-zlib" {= "1"}
   "cppo" {= "1.6.9"}
   "csexp" {= "1.5.2"}
-  "dolmen" {= "0.9"}
-  "dolmen_loop" {= "0.9"}
-  "dolmen_type" {= "0.9"}
+  "dolmen" {= "dev"}
+  "dolmen_loop" {= "dev"}
+  "dolmen_type" {= "dev"}
   "dune" {= "3.11.1"}
   "dune-build-info" {= "3.11.1"}
   "dune-configurator" {= "3.11.1"}
-  "easy-format" {= "1.3.4"}
   "fmt" {= "0.9.0"}
-  "fpath" {= "0.7.3" & with-doc}
   "gen" {= "1.1"}
   "js_of_ocaml" {= "5.4.0"}
   "js_of_ocaml-compiler" {= "5.4.0"}
@@ -49,29 +44,23 @@ depends: [
   "menhirSdk" {= "20230608"}
   "num" {= "1.4"}
   "ocaml-compiler-libs" {= "v0.12.4"}
-  "ocaml-options-vanilla" {= "1"}
   "ocamlbuild" {= "0.14.2"}
   "ocamlfind" {= "1.9.6"}
   "ocplib-endian" {= "1.2"}
   "ocplib-simplex" {= "0.5"}
-  "odoc" {= "2.2.1" & with-doc}
-  "odoc-parser" {= "2.0.0" & with-doc}
   "pp_loc" {= "2.1.0"}
   "ppx_blob" {= "0.7.2"}
   "ppx_derivers" {= "1.2.1"}
   "ppx_deriving" {= "5.2.1"}
   "ppxlib" {= "0.31.0"}
-  "re" {= "1.11.0" & with-doc}
   "result" {= "1.5"}
-  "sedlex" {= "3.2"}
   "seq" {= "base"}
   "sexplib0" {= "v0.16.0"}
   "spelll" {= "0.4"}
   "stdlib-shims" {= "0.3.0"}
   "topkg" {= "1.0.7"}
-  "tyxml" {= "4.6.0" & with-doc}
   "uutf" {= "1.0.3"}
-  "yojson" {= "1.7.0"}
+  "yojson" {= "2.1.1"}
   "zarith" {= "1.13"}
 ]
 build: [
@@ -94,4 +83,22 @@ dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"
 conflicts: [
   "ppxlib" {< "0.30.0"}
   "result" {< "1.5"}
+]
+pin-depends: [
+  [
+    "dolmen.dev"
+    "git+https://github.com/Gbury/dolmen.git#baaf1f92ccd473294679dd9025c3ae9a441a82fa"
+  ]
+  [
+    "dolmen_loop.dev"
+    "git+https://github.com/Gbury/dolmen.git#baaf1f92ccd473294679dd9025c3ae9a441a82fa"
+  ]
+  [
+    "dolmen_type.dev"
+    "git+https://github.com/Gbury/dolmen.git#baaf1f92ccd473294679dd9025c3ae9a441a82fa"
+  ]
+  [
+    "js_of_ocaml.5.4.0"
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.4.0/js_of_ocaml-5.4.0.tbz"
+  ]
 ]


### PR DESCRIPTION
It seems the lock file haven't been updated correctly in the PR #893. We have to lock `dolmen` to the dev version.