### PR TITLE
Starting missing timer

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -112,7 +112,6 @@ let main () =
     O.get_sat_solver (),
     (module SatCont.Make(TH) : Sat_solver_sig.S)
   in
-
   let solve (module SAT : Sat_solver_sig.S) all_context (cnf, goal_name) =
     let module FE = Frontend.Make (SAT) in
     if Options.get_debug_commands () then
@@ -805,7 +804,7 @@ let main () =
     try
       Options.with_timelimit_if (not (Options.get_timelimit_per_goal ()))
       @@ fun () ->
-
+      Options.Time.start ();
       let builtin_dir = "<builtin>" in
       let theory_preludes =
         Options.get_theory_preludes ()


### PR DESCRIPTION
The `Options.Timer` was not started at the beginning of alt-ergo. This led to a very strange behavior:

```
$time dune exec -- alt-ergo --timelimit=1 --enable-assertions --output=smtlib2 --sat-solver CDCL tests/everything/f1.ae 

; File "tests/everything/f1.ae", line 159, characters 1-166: Valid (1.6413) (13477 steps) (goal WP_create)
;

real 0m1,804s
user 0m1,654s
sys 0m0,138s

```

As you can see, the goal is verified after 1.6413 even though we set a timelimit at 1. This is because alt-ergo's time corresponds (more or less) to the user time of the whole process with `dune exec`. If we remove `dune exec --` and execute directly the binary, we get more consistent results : 

```
$./alt-ergo --timelimit=1 --enable-assertions --output=smtlib2 --frontend dolmen --sat-solver CDCL tests/everything/f1.ae 
alt-ergo: option '--frontend': this option is deprecated and will be ignored in the next version

; File "tests/everything/f1.ae", line 159, characters 1-166: Valid (0.6038) (13477 steps) (goal WP_create)
; 

```

If we set the timer (as it is done for the legacy loop), we get consistent results.
