### PR TITLE
Use default solver for testing models

### DIFF
--- a/tests/models/bool/bool1.models.expected
+++ b/tests/models/bool/bool1.models.expected
@@ -4,7 +4,7 @@ unknown
   (define-fun q () Bool false)
 )
 ((notp unknown)
- (notnq true))
+ (notnq unknown))
 
 
 unknown
@@ -12,6 +12,6 @@ unknown
   (define-fun p () Bool true)
   (define-fun q () Bool true)
 )
-((notp false)
- (notnq false))
+((notp unknown)
+ (notnq unknown))
 

--- a/tests/models/bool/bool3.models.expected
+++ b/tests/models/bool/bool3.models.expected
@@ -1,9 +1,9 @@
 
 unknown
 (
-  (define-fun x () Bool true)
-  (define-fun y () Bool true)
+  (define-fun x () Bool false)
+  (define-fun y () Bool false)
 )
-((foo true)
+((foo unknown)
  (bar unknown))
 

--- a/tools/gentest.ml
+++ b/tools/gentest.ml
@@ -258,7 +258,7 @@ end = struct
                   acc with
                   exclude =
                     "legacy" :: "fpa" :: acc.exclude;
-                  filters = Some ["tableaux"]
+                  filters = Some ["dolmen"]
                 }
               | "fpa" ->
                 {acc with filters = Some ["fpa"]}


### PR DESCRIPTION
Prior to c1e43876d82a143459a9c0ad37f7e034a6531aca (#829) we did not have model generation in the default solver, and model generation required to use the Tableaux solver, so we used the Tableaux solver when testing models.

Since the default solver now supports model generation, we should use it to test model generation instead, since the models generated by both solvers can be different and most users will use the default solver rather than the Tableaux solver.

Unfortunately, this causes some tests using `get-assignment` to fail (see https://github.com/OCamlPro/alt-ergo/issues/937).