### PR TITLE
Do not test .smt2 files with the legacy frontend

### DIFF
--- a/tools/gentest.ml
+++ b/tools/gentest.ml
@@ -250,6 +250,10 @@ end = struct
                   exclude = "legacy" :: acc.exclude;
                   filters = Some ["dolmen"]
                 }
+              | "smt2" -> {
+                  acc with
+                  exclude = "legacy" :: acc.exclude;
+                }
               | "models" -> {
                   acc with
                   exclude =


### PR DESCRIPTION
Since we don't officially support the SMT-LIB input with the legacy frontend, and that the legacy frontend is deprecated and scheduled for removal, there really is no need to test SMT-LIB input with the legacy frontend.

This means we no longer will have to tag `.smt2` tests with `.dolmen.` just because we use some SMT-LIB features (such as bit-vector primitives) that are not supported by the legacy frontend.