### PR TITLE
[gentest] Restore automatic creation of expected files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ packages:
 # Generate new Dune tests from the problems in
 # the directory tests/.
 gentest: $(wildcard tests/**/*)
+	# TODO: There should be an option to gentest to avoid printing the
+	# dune.inc file and only touch the expected files in this call.
+	dune exec -- tools/gentest.exe tests >/dev/null
 	dune build @tests/gentest --auto-promote
 
 # Run non-regression tests.


### PR DESCRIPTION
The `gentest.ml` scripts automatically creates the `.expected` files when it is run. However, since we are now running the `gentest.ml` script through `dune` to create the `dune.inc` file, it is run in the build directory and the created `.expected` files are not moved back to the source directory.

This patch is a dirty hack that runs the `gentest.ml` script twice (first time in the source directory to create the `.expected` files, second time through `dune` to update the `dune.inc`) to restore the automatic creation of `.expected` files. Long-term it would probably be better to have an option (or a different script) instead, but for now this should do.