### PR TITLE
refactor(BV): Use Z.t in BV solver

### DIFF
--- a/tests/models/bitv/manyslice.models.expected
+++ b/tests/models/bitv/manyslice.models.expected
@@ -1,0 +1,7 @@
+
+unknown
+(
+  (define-fun x () (_ BitVec 1) #b1)
+  (define-fun y () (_ BitVec 1) #b0)
+  (define-fun xy () (_ BitVec 2) #b10)
+)

--- a/tests/models/bitv/manyslice.models.smt2
+++ b/tests/models/bitv/manyslice.models.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+(set-option :produce-models true)
+(declare-const x (_ BitVec 1))
+(declare-const y (_ BitVec 1))
+(declare-const xy (_ BitVec 2))
+(assert (= (concat (concat x y) (concat xy xy)) (concat #b1010 (concat x y))))
+(check-sat)
+(get-model)


### PR DESCRIPTION
The old implementation of the solver relied on the fact that each constant fragment of a bit-vector was either all ones or all zeroes because it defined a constant zero as the smallest bit-vector, a constant one as the biggest bit-vector, and then computed the min and max elements of a set of bit-vectors to check for consistency. With the new solver based on Tarjan's union-find, this limitation is no longer necessary, and it causes the solver to needlessly split bit-vector variables involved in equalities with non-uniform constants [^1].

This patch is a simple refactoring of the bit-vector solver to use integers rather than booleans to represent the constant parts of bit-vectors, hopefully improving performance for bit-vectors with non-uniform constant parts.

[^1]: For instance, solving `x = #b0000` can be done in a single swoop, but solving `x = #b0101` currently first slices `x` into `a @ b @ c @ d` and then assigns values to each of `a`, `b`, `c` and `d`.