### PR TITLE
fix: Make --profiling not crash

### DIFF
--- a/src/lib/util/timers.ml
+++ b/src/lib/util/timers.ml
@@ -186,8 +186,8 @@ end = struct
 
   let create () =
     Array.init
-      max_ty_module
-      (fun _ -> Array.init max_ty_function (fun _ -> 0.))
+      (max_ty_module + 1)
+      (fun _ -> Array.init (max_ty_function + 1) (fun _ -> 0.))
 
   let clear =
     Array.iter (fun a -> Array.iteri (fun j _ -> a.(j) <- 0.) a)


### PR DESCRIPTION
As noted in https://github.com/OCamlPro/alt-ergo/issues/935 the --profiling option currently makes Alt-Ergo instantly crash because in https://github.com/OCamlPro/alt-ergo/pull/863 we forgot a slot for the last element in the array. This patch fixes that.