### PR TITLE
Always allow polymorphic input in smt-lib format

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -426,8 +426,21 @@ let main () =
     let lang =
       match Options.get_input_format () with
       | Some Native -> Some Dl.Logic.Alt_ergo
-      | Some Smtlib2 -> Some (Dl.Logic.Smtlib2 `Latest)
-      | None | Some (Why3 | Unknown _) -> None
+      | Some Smtlib2 -> Some (Dl.Logic.Smtlib2 `Poly)
+      | None ->
+        (* Dolmen auto-detects .smt2 files as adhering to the SMT-LIB standard,
+           but we want to allow the polymorphic extensions instead. *)
+        let filename =
+          if Filename.check_suffix path ".zip" then
+            Filename.chop_extension path
+          else
+            path
+        in
+        if Filename.check_suffix filename ".smt2" then
+          Some (Dl.Logic.Smtlib2 `Poly)
+        else
+          None
+      | Some (Why3 | Unknown _) -> None
     in
     let source =
       if Filename.check_suffix path ".zip" then (

--- a/tests/cram.t/poly.smt2
+++ b/tests/cram.t/poly.smt2
@@ -1,0 +1,25 @@
+(set-logic ALL)
+(set-info :smt-lib-version 2.6)
+
+(declare-sort list 1)
+
+(declare-fun cons (par (a) (a (list a)) (list a)))
+(declare-fun nil (par (a) () (list a)))
+
+(define-fun singleton (par (a) ((x a)) (list a) (cons x nil)))
+
+(assert (par (a) (exists ((x a)) (not (= nil (singleton x))))))
+
+(assert (forall ((x Int)) (not (= nil (singleton x)))))
+
+(assert (par (a) (forall ((x a)) (not (= nil (singleton x))))))
+
+(declare-sort s 0)
+(declare-fun foo () s)
+
+(assert (not (= nil (singleton foo))))
+(assert (not (= nil (singleton 1))))
+
+(check-sat)
+(get-value ((as nil (list Int)) (singleton 1) (as nil (list s)) (singleton foo)))
+(get-model)

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -93,3 +93,7 @@ Some errors are unescapable though. It its the case of syntax error in commands.
   
   (error "Invalid set-option")
   (error "Error on parsing errors (code 3)")
+
+Let us check that we can parse psmt2 files with a .smt2 extension. No output,
+no errors expected.
+  $ alt-ergo poly.smt2 --type-only


### PR DESCRIPTION
This makes the Dolmen frontend behave like the legacy frontend and always allows polymorphic extensions of smt-lib input (this means .smt2 and .psmt2 files as well as the `--input smtlib2` option).

As pointed out by @Gbury this means that we need to override Dolmen's language inference for `.smt2` files. We also need to properly take care of `.zip` input.

Fixes #933