### PR TITLE
feat: Allow interactive SMT-LIB input

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -434,17 +434,27 @@ let main () =
         Filename.(chop_extension path |> extension) |> set_output_format;
         let content = AltErgoLib.My_zip.extract_zip_file path in
         `Raw (Filename.chop_extension filename, content))
-      else (
-        Filename.extension path |> set_output_format;
-        let content =
-          if not (String.equal path "") then
-            let cin = open_in path in
-            let content = read_all cin in
-            close_in cin;
-            content
-          else read_all stdin
+      else
+        let is_stdin = String.equal path "" in
+        let is_incremental =
+          match lang with
+          | Some (Dl.Logic.Smtlib2 _) | None -> true
+          | _ -> false
         in
-        `Raw (filename, content))
+        if is_stdin then (
+          if is_incremental then (
+            set_output_format ".smt2";
+            `Stdin
+          ) else (
+            `Raw (filename, read_all stdin)
+          )
+        ) else (
+          Filename.extension path |> set_output_format;
+          let cin = open_in path in
+          let content = read_all cin in
+          close_in cin;
+          `Raw (filename, content)
+        )
     in
     let logic_file =
       State.mk_file ?lang ~loc:(Dolmen.Std.Loc.mk_file path) dir source


### PR DESCRIPTION
Dolmen supports interactive SMT-LIB input on stdin, but we currently do not make use of it because we *first* read everything from stdin (awaiting a ^D end-of-file from the user), then pass that to Dolmen, making things useless for interactive input.

This patch makes it so that interactive input works properly (provided you also set `--continue-on-error`, and maybe redirect `stderr` to oblivion).

Note that Dolmen does not support reading from `stdin` in the native format, so we keep the old mode of operations if the user explicitly requested `--input native`. Otherwise, we default to SMT-LIB format when reading from stdin, and set the output format to SMT-LIB by default.

Changing the default format for stdin is not a breaking change because previously we were rejecting stdin input without an explicit format with an error:

> Error The following extension was not recognized: ''.
>      Please use a recognised extension or specify an input language \
on the command line