### PR TITLE
Add a SMT-LIB compliant printer for `Expr`

### DIFF
--- a/src/lib/frontend/models.ml
+++ b/src/lib/frontend/models.ml
@@ -312,10 +312,19 @@ module SmtlibCounterExample = struct
     | [Ty.Trecord _r, _arg] -> begin
         match xs_values with
         | [record_name,_] ->
+          (* HOTFIX: this fix is temporary. The current implementation of
+             model generation for records relies on string representants,
+             which means the printer for access symbols has to agree with
+             the name of the field in the type trecord. As the printer
+             [Symbols.print] will always output AE native format, this
+             doesn't agree when the output format is SMT-LIB. But the
+             printer of expression will output the right string if we don't
+             give the arguments of the field. *)
+          let access = Fmt.str "%a" Expr.print (Expr.mk_term f [] ty) in
           add_records_destr
             records
             (asprintf "%a" Expr.print record_name)
-            (Sy.to_string f)
+            access
             rep
         | [] | _ -> records
       end

--- a/src/lib/frontend/models.ml
+++ b/src/lib/frontend/models.ml
@@ -319,7 +319,9 @@ module SmtlibCounterExample = struct
              [Symbols.print] will always output AE native format, this
              doesn't agree when the output format is SMT-LIB. But the
              printer of expression will output the right string if we don't
-             give the arguments of the field. *)
+             give the arguments of the field.
+
+             Issue: https://github.com/OCamlPro/alt-ergo/issues/958 *)
           let access = Fmt.str "%a" Expr.print (Expr.mk_term f [] ty) in
           add_records_destr
             records

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -277,28 +277,7 @@ let string_of_bound b =
 
 let print_bound fmt b = Format.fprintf fmt "%s" (string_of_bound b)
 
-let string_of_lit lit = match lit with
-  | L_eq -> "="
-  | L_neg_eq -> "<>"
-  | L_neg_pred -> "not "
-  | L_built LE -> "<="
-  | L_built LT -> "<"
-  | L_neg_built LE -> ">"
-  | L_neg_built LT -> ">="
-  | L_built (IsConstr h) ->
-    Format.sprintf "? %s" (Hstring.view h)
-  | L_neg_built (IsConstr h) ->
-    Format.sprintf "?not? %s" (Hstring.view h)
-
-let string_of_form f = match f with
-  | F_Unit _ -> "/\\"
-  | F_Clause _ -> "\\/"
-  | F_Lemma -> "Lemma"
-  | F_Skolem -> "Skolem"
-  | F_Iff -> "<->"
-  | F_Xor -> "xor"
-
-let name_to_string =
+let pp_name ppf =
   let no_need_to_quote s =
     String.length s > 0 &&
     (match s.[0] with | '0'..'9' -> false | _ -> true) &&
@@ -316,80 +295,203 @@ let name_to_string =
       true
     with Exit -> false
   in
-  fun s -> if no_need_to_quote s then s else Format.sprintf "|%s|" s
-
-let to_string ?(show_vars=true) x = match x with
-  | Name (n, _, _) -> name_to_string @@ Hstring.view n
-  | Var v when show_vars -> Format.sprintf "'%s'" (Var.to_string v)
-  | Var v -> Var.to_string v
-  | Int n -> Z.to_string n
-  | Real n -> Q.to_string n
-  | Bitv (n, s) -> Fmt.str "[|%s|]" (Z.format (Fmt.str "%%0%db" n) s)
-  | Op Plus -> "+"
-  | Op Minus -> "-"
-  | Op Mult -> "*"
-  | Op Div -> "/"
-  | Op Modulo -> "%"
-  | Op (Access s) ->
-    if Options.get_output_smtlib () then
-      (Hstring.view s)
+  fun s ->
+    if no_need_to_quote s then
+      Fmt.string ppf s
     else
-      "@Access_"^(Hstring.view s)
-  | Op (Constr s) -> (Hstring.view s)
-  | Op (Destruct (s,g)) ->
-    Format.sprintf "%s%s" (if g then "" else "!") (Hstring.view s)
+      Fmt.pf ppf "|%s|" s
 
-  | Op Record -> "@Record"
-  | Op Get -> "get"
-  | Op Set -> "set"
-  | Op Float -> "float"
-  | Op Abs_int -> "abs_int"
-  | Op Abs_real -> "abs_real"
-  | Op Sqrt_real -> "sqrt_real"
-  | Op Sqrt_real_default -> "sqrt_real_default"
-  | Op Sqrt_real_excess -> "sqrt_real_excess"
-  | Op Real_of_int -> "real_of_int"
-  | Op Real_is_int -> "real_is_int"
-  | Op Int_floor -> "int_floor"
-  | Op Int_ceil -> "int_ceil"
-  | Op Max_real -> "max_real"
-  | Op Max_int -> "max_int"
-  | Op Min_real -> "min_real"
-  | Op Min_int -> "min_int"
-  | Op Integer_log2 -> "integer_log2"
-  | Op Pow -> "**"
-  | Op Integer_round -> "integer_round"
-  | Op Not_theory_constant -> "not_theory_constant"
-  | Op Is_theory_constant -> "is_theory_constant"
-  | Op Linear_dependency -> "linear_dependency"
-  | Op Concat -> "@"
-  | Op Extract (i, j) -> Format.sprintf "^{%d; %d}" i j
-  | Op BVnot -> "bvnot"
-  | Op BVand -> "bvand"
-  | Op BVor -> "bvor"
-  | Op Int2BV n -> Format.sprintf "int2bv[%d]" n
-  | Op BV2Nat -> "bv2nat"
-  | Op Tite -> "ite"
-  | True -> "true"
-  | False -> "false"
-  | Void -> "void"
-  | In (lb, rb) ->
-    Format.sprintf "%s , %s" (string_of_bound lb) (string_of_bound rb)
+module AEPrinter = struct
+  let pp_operator ppf op =
+    match op with
+    (* Core theory *)
+    | Tite -> Fmt.pf ppf "ite"
 
-  | MapsTo x ->  Format.sprintf "%s |->" (Var.to_string x)
+    (* Reals and Ints theories *)
+    | Plus -> Fmt.pf ppf "+"
+    | Minus -> Fmt.pf ppf "-"
+    | Mult -> Fmt.pf ppf "*"
+    | Div -> Fmt.pf ppf "/"
+    | Modulo -> Fmt.pf ppf "%%"
+    | Pow -> Fmt.pf ppf "**"
+    | Sqrt_real -> Fmt.pf ppf "sqrt_real"
+    | Sqrt_real_default -> Fmt.pf ppf "sqrt_real_default"
+    | Sqrt_real_excess -> Fmt.pf ppf "sqrt_real_excess"
+    | Int_floor -> Fmt.pf ppf "int_floor"
+    | Int_ceil -> Fmt.pf ppf "int_ceil"
+    | Max_real -> Fmt.pf ppf "max_real"
+    | Max_int -> Fmt.pf ppf "max_int"
+    | Min_real -> Fmt.pf ppf "min_real"
+    | Min_int -> Fmt.pf ppf "min_int"
+    | Integer_log2 -> Fmt.pf ppf "integer_log2"
+    | Integer_round -> Fmt.pf ppf "integer_round"
 
-  | Lit lit -> string_of_lit lit
-  | Form form -> string_of_form form
-  | Let -> "let"
+    (* Reals_Ints theory *)
+    | Abs_int -> Fmt.pf ppf "abs_int"
+    | Abs_real -> Fmt.pf ppf "abs_real"
+    | Real_of_int -> Fmt.pf ppf "real_of_int"
+    | Real_is_int -> Fmt.pf ppf "real_is_int"
 
-  | Op (Optimize {order; is_max=true}) -> Format.sprintf "maximize(-,%d)" order
-  | Op (Optimize {order; is_max=false}) -> Format.sprintf "minimize(-,%d)" order
+    (* FixedSizedBitVectors theory *)
+    | Extract (i, j) -> Fmt.pf ppf "^{%d; %d}" i j
+    | Concat -> Fmt.pf ppf "@"
+    | BV2Nat -> Fmt.pf ppf "bv2nat"
+    | Int2BV n -> Fmt.pf ppf "int2bv[%d]" n
+    | BVnot -> Fmt.pf ppf "bvnot"
+    | BVand -> Fmt.pf ppf "bvand"
+    | BVor -> Fmt.pf ppf "bvor"
 
-let to_string_clean s = to_string ~show_vars:false s
-let to_string s = to_string ~show_vars:true s
+    (* ArraysEx theory *)
+    | Get -> Fmt.pf ppf "get"
+    | Set -> Fmt.pf ppf "set"
 
-let print_clean fmt s = Format.fprintf fmt "%s" (to_string_clean s)
-let print fmt s = Format.fprintf fmt "%s" (to_string s)
+    (* DT theory *)
+    | Record -> Fmt.pf ppf "@Record"
+    | Access s -> Fmt.pf ppf "@Access_%a" Hstring.print s
+    | Constr s -> Hstring.print ppf s
+    | Destruct (s, g) ->
+      Fmt.pf ppf "%s%a" (if g then "" else "!") Hstring.print s
+
+    (* Float theory *)
+    | Float -> Fmt.pf ppf "float"
+
+    | Not_theory_constant -> Fmt.pf ppf "not_theory_constant"
+    | Is_theory_constant -> Fmt.pf ppf "is_theory_constant"
+    | Linear_dependency -> Fmt.pf ppf "linear_dependency"
+
+    | Optimize {order; is_max=true} ->
+      Fmt.pf ppf "maximize(-,%d)" order
+    | Optimize {order; is_max=false} ->
+      Fmt.pf ppf "minimize(-,%d)" order
+
+  let pp_lit ppf lit =
+    match lit with
+    | L_eq -> Fmt.pf ppf "="
+    | L_neg_eq -> Fmt.pf ppf "distinct"
+    | L_built LE -> Fmt.pf ppf "<="
+    | L_built LT -> Fmt.pf ppf "<"
+    | L_neg_built LE -> Fmt.pf ppf ">"
+    | L_neg_built LT -> Fmt.pf ppf ">="
+    | L_neg_pred -> Fmt.pf ppf "not "
+    | L_built (IsConstr h) ->
+      Fmt.pf ppf "? %a" Hstring.print h
+    | L_neg_built (IsConstr h) ->
+      Fmt.pf ppf "?not? %a" Hstring.print h
+
+  let pp_form ppf f =
+    match f with
+    | F_Unit _ -> Fmt.pf ppf "/\\"
+    | F_Clause _ -> Fmt.pf ppf "\\/"
+    | F_Lemma -> Fmt.pf ppf "Lemma"
+    | F_Skolem -> Fmt.pf ppf "Skolem"
+    | F_Iff -> Fmt.pf ppf "<->"
+    | F_Xor -> Fmt.pf ppf "xor"
+
+  let pp ?(show_vars = true) ppf sy =
+    match sy with
+    | Lit lit -> pp_lit ppf lit
+    | Form form -> pp_form ppf form
+    | Let -> Fmt.pf ppf "let"
+    | Op op -> pp_operator ppf op
+
+    (* Core theory *)
+    | True -> Fmt.pf ppf "true"
+    | False -> Fmt.pf ppf "false"
+    | Void -> Fmt.pf ppf "void"
+    | Name (n, _, _) -> pp_name ppf (Hstring.view n)
+    | Var v when show_vars -> Fmt.pf ppf "'%s'" (Var.to_string v)
+    | Var v -> Fmt.string ppf (Var.to_string v)
+
+    (* Reals and Ints theories *)
+    | Int i -> Z.pp_print ppf i
+    | Real q -> Q.pp_print ppf q
+
+    (* FixedSizedBitVectors theory *)
+    | Bitv (n, s) ->
+      Fmt.pf ppf "[|%s|]" (Z.format (Fmt.str "%%0%db" n) s)
+
+    (* Symbols used in semantic triggers *)
+    | In (lb, rb) ->
+      Fmt.pf ppf "%s, %s" (string_of_bound lb) (string_of_bound rb)
+    | MapsTo v -> Fmt.pf ppf "%a |->" Var.print v
+end
+
+module SmtPrinter = struct
+  let pp_operator ppf op =
+    match op with
+    (* Core theory *)
+    |Tite -> Fmt.pf ppf "ite"
+
+    (* Reals and Ints theories *)
+    | Plus -> Fmt.pf ppf "+"
+    | Minus -> Fmt.pf ppf "-"
+    | Mult -> Fmt.pf ppf "*"
+    | Div -> Fmt.pf ppf "/"
+    | Modulo -> Fmt.pf ppf "%%"
+
+    (* Reals_Ints theory *)
+    | Abs_int | Abs_real -> Fmt.pf ppf "abs"
+    | Real_of_int -> Fmt.pf ppf "to_real"
+    | Real_is_int -> Fmt.pf ppf "is_int"
+    | Integer_round -> Fmt.pf ppf "to_int"
+
+    (* FixedSizedBitVectors theory *)
+    | Extract (i, j) ->
+      Fmt.pf ppf "(_ extract %d %d)" i j
+    | Concat -> Fmt.pf ppf "concat"
+    | BV2Nat -> Fmt.pf ppf "bv2nat"
+    | BVnot -> Fmt.pf ppf "bvnot"
+    | BVand -> Fmt.pf ppf "bvand"
+    | BVor -> Fmt.pf ppf "bvor"
+
+    (* ArraysEx theory *)
+    | Get -> Fmt.pf ppf "select"
+    | Set -> Fmt.pf ppf "store"
+
+    (* DT theory *)
+    | Record -> ()
+    | Access s | Constr s | Destruct (s, _) -> Hstring.print ppf s
+
+    (* Float theory *)
+    | Float -> Fmt.pf ppf "ae.round"
+
+    (* Not in the SMT-LIB standard *)
+    | Int2BV _ -> Fmt.pf ppf "(_ int2bv)"
+    | Not_theory_constant -> Fmt.pf ppf "ae.not_theory_constant"
+    | Is_theory_constant -> Fmt.pf ppf "ae.is_theory_constant"
+    | Linear_dependency -> Fmt.pf ppf "ae.linear_dependency"
+    | Sqrt_real -> Fmt.pf ppf "ae.sqrt_real"
+    | Sqrt_real_default -> Fmt.pf ppf "ae.sqrt_real_default"
+    | Sqrt_real_excess -> Fmt.pf ppf "ae.sqrt_real_excess"
+    | Int_floor -> Fmt.pf ppf "ae.int_floor"
+    | Int_ceil -> Fmt.pf ppf "ae.int_ceil"
+    | Max_real -> Fmt.pf ppf "ae.max_real"
+    | Max_int -> Fmt.pf ppf "ae.max_int"
+    | Min_real -> Fmt.pf ppf "ae.min_real"
+    | Min_int -> Fmt.pf ppf "ae.min_int"
+    | Integer_log2 -> Fmt.pf ppf "ae.integer_log2"
+    | Pow -> Fmt.pf ppf "ae.pow"
+
+    | Optimize _ ->
+      (* TODO: this case will be removed in the PR #921. *)
+      assert false
+
+end
+
+let[@inline always] pp_operator ~(format:[`Ae | `Smtlib]) ppf op =
+  match format with
+  | `Ae -> AEPrinter.pp_operator ppf op
+  | `Smtlib -> SmtPrinter.pp_operator ppf op
+
+let print_clean = AEPrinter.pp ~show_vars:false
+let print = AEPrinter.pp ~show_vars:true
+
+let to_string_clean sy =
+  Fmt.str "%a" (AEPrinter.pp ~show_vars:false) sy
+
+let to_string sy =
+  Fmt.str "%a"(AEPrinter.pp ~show_vars:true) sy
+
 
 module type Id = sig
   val fresh : ?base:string -> unit -> string

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -433,11 +433,10 @@ module SmtPrinter = struct
     | Abs_int | Abs_real -> Fmt.pf ppf "abs"
     | Real_of_int -> Fmt.pf ppf "to_real"
     | Real_is_int -> Fmt.pf ppf "is_int"
-    | Integer_round -> Fmt.pf ppf "to_int"
+    | Int_floor -> Fmt.pf ppf "to_int"
 
     (* FixedSizedBitVectors theory *)
-    | Extract (i, j) ->
-      Fmt.pf ppf "(_ extract %d %d)" i j
+    | Extract (i, j) -> Fmt.pf ppf "(_ extract %d %d)" j i
     | Concat -> Fmt.pf ppf "concat"
     | BV2Nat -> Fmt.pf ppf "bv2nat"
     | BVnot -> Fmt.pf ppf "bvnot"
@@ -456,20 +455,20 @@ module SmtPrinter = struct
     | Float -> Fmt.pf ppf "ae.round"
 
     (* Not in the SMT-LIB standard *)
-    | Int2BV _ -> Fmt.pf ppf "(_ int2bv)"
+    | Int2BV n -> Fmt.pf ppf "(_ int2bv %d)" n
     | Not_theory_constant -> Fmt.pf ppf "ae.not_theory_constant"
     | Is_theory_constant -> Fmt.pf ppf "ae.is_theory_constant"
     | Linear_dependency -> Fmt.pf ppf "ae.linear_dependency"
     | Sqrt_real -> Fmt.pf ppf "ae.sqrt_real"
     | Sqrt_real_default -> Fmt.pf ppf "ae.sqrt_real_default"
     | Sqrt_real_excess -> Fmt.pf ppf "ae.sqrt_real_excess"
-    | Int_floor -> Fmt.pf ppf "ae.int_floor"
     | Int_ceil -> Fmt.pf ppf "ae.int_ceil"
     | Max_real -> Fmt.pf ppf "ae.max_real"
     | Max_int -> Fmt.pf ppf "ae.max_int"
     | Min_real -> Fmt.pf ppf "ae.min_real"
     | Min_int -> Fmt.pf ppf "ae.min_int"
     | Integer_log2 -> Fmt.pf ppf "ae.integer_log2"
+    | Integer_round -> Fmt.pf ppf "ae.integer_round"
     | Pow -> Fmt.pf ppf "ae.pow"
 
     | Optimize _ ->
@@ -478,10 +477,8 @@ module SmtPrinter = struct
 
 end
 
-let[@inline always] pp_operator ~(format:[`Ae | `Smtlib]) ppf op =
-  match format with
-  | `Ae -> AEPrinter.pp_operator ppf op
-  | `Smtlib -> SmtPrinter.pp_operator ppf op
+let pp_ae_operator = AEPrinter.pp_operator
+let pp_smtlib_operator = SmtPrinter.pp_operator
 
 let print_clean = AEPrinter.pp ~show_vars:false
 let print = AEPrinter.pp ~show_vars:true

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -129,8 +129,13 @@ val print_clean : t Fmt.t
 
 val pp_name : string Fmt.t
 
-val pp_operator : format:[`Ae | `Smtlib] -> operator Fmt.t
-(* [pp_smtlib ppf sy] prints the symbol [sy] on the formatter [ppf]. *)
+val pp_ae_operator : operator Fmt.t
+(* [pp_ae_operator ppf op] prints the operator symbol [op] on the
+   formatter [ppf] using the Alt-Ergo native format. *)
+
+val pp_smtlib_operator : operator Fmt.t
+(* [pp_smtlib_operator ppf op] prints the operator symbol [op] on the
+   formatter [ppf] using the SMT-LIB format. *)
 
 (*val dummy : t*)
 

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -121,10 +121,16 @@ val compare_operators : operator -> operator -> int
 val hash : t -> int
 
 val to_string : t -> string
-val print : Format.formatter -> t -> unit
+val print : t Fmt.t
+(* Printer used by debugging messages. *)
 
 val to_string_clean : t -> string
-val print_clean : Format.formatter -> t -> unit
+val print_clean : t Fmt.t
+
+val pp_name : string Fmt.t
+
+val pp_operator : format:[`Ae | `Smtlib] -> operator Fmt.t
+(* [pp_smtlib ppf sy] prints the symbol [sy] on the formatter [ppf]. *)
 
 (*val dummy : t*)
 


### PR DESCRIPTION
We plan to use expression from `Expr` to store model values but we haven't appropriate printer for Symbols in the SMT-LIB format. This commit add an new printer `pp_smtlib` into `Symbols` which prints (as much as possible) symbols using the SMT-LIB standard.

This new printer should be sufficient for printing models as model values couldn't be nonconstant values or even applications of function. Still the printer `pp_smtlib` tries to be as complete as possible and outputs a correct answer for symbols of functions or literals.

I also clean up a bit the AE format printer.