### PR TITLE
fix: Do not call [X.make] on non-subterms for bv2nat

### DIFF
--- a/tests/bitv/testfile-bitv024.expected
+++ b/tests/bitv/testfile-bitv024.expected
@@ -1,0 +1,2 @@
+
+unknown

--- a/tests/bitv/testfile-bitv024.smt2
+++ b/tests/bitv/testfile-bitv024.smt2
@@ -1,0 +1,4 @@
+(set-logic ALL)
+(declare-const x (_ BitVec 4))
+(assert (= (bv2nat ((_ extract 3 2) x)) 0))
+(check-sat)


### PR DESCRIPTION
It turns out that https://github.com/OCamlPro/alt-ergo/pull/881 revealed a latent issue with the implementation in
https://github.com/OCamlPro/alt-ergo/pull/733

When we encounter a [bv2nat] term, we create a *term* that represents the [bv2nat] computation, then call [X.make] on the result. This has the unfortunate effect that the sub-terms of that new term are not added to the Union-Find (or at least not before the term itself). This is bad, but was harmless at the time.

However, the resulting term from a call of [bv2nat] includes divisions. And since https://github.com/OCamlPro/alt-ergo/pull/881 divisions are represented by an uninterpreted term rather than an existential variable — and [IntervalCalculus.add] inspects that term, rightfully expecting that its sub-terms have been added to the Union-Find, which in this case they are not, and so we crash.

This patch fixes the issue by introducing an uninterpreted term for the result of [bv2nat] and adding the equality between that uninterpreted term and the [bv2nat] computation. This equality is then processed as a term on its own, ensuring that subterms are added to the Union-Find before the terms that contain them.

Note that long-term, we probably want to get rid of the construction of [bv2nat] terms directly in [X.make] in favor of propagators in a follow-up to https://github.com/OCamlPro/alt-ergo/pull/944 . This would avoid needing to go through terms for this.