### PR TITLE
Imperative API 

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -136,10 +136,10 @@ let main () =
           Options.Time.set_timeout (Options.get_timelimit ());
         end;
       SAT.reset_refs ();
-      let ftdn_env =
-        List.fold_left
-          (FE.process_decl ~hook_on_status:Frontend.print_status)
-          (FE.init_env used_context)
+      let ftdn_env = FE.init_env used_context in
+      let () =
+        List.iter
+          (FE.process_decl ~hook_on_status:Frontend.print_status ftdn_env)
           cnf
       in
       if Options.get_timelimit_per_goal() then
@@ -152,8 +152,9 @@ let main () =
          we have to drop the partial model in order to prevent
          printing wrong model. *)
       match ftdn_env.FE.res with
-      | `Sat partial_model | `Unknown partial_model ->
+      | `Sat | `Unknown ->
         begin
+          let partial_model = ftdn_env.sat_env in
           let mdl = Model ((module SAT), partial_model) in
           if Options.(get_interpretation () && get_dump_models ()) then begin
             let ur = SAT.get_unknown_reason partial_model in

--- a/src/bin/js/worker_js.ml
+++ b/src/bin/js/worker_js.ml
@@ -124,21 +124,21 @@ let main worker_id content =
       let used_context = Frontend.choose_used_context all_context ~goal_name in
       SAT.reset_refs ();
       let sat_env = SAT.empty_with_inst add_inst in
-      let ftnd_env =
-        List.fold_left
-          (FE.process_decl ~hook_on_status:get_status_and_print)
-          (FE.init_env ~sat_env used_context)
-          cnf
-      in
+      let ftnd_env = FE.init_env ~sat_env used_context in
+      List.iter
+        (FE.process_decl ~hook_on_status:get_status_and_print ftnd_env)
+        cnf;
       if Options.get_unsat_core () then begin
         unsat_core := Explanation.get_unsat_core ftnd_env.FE.expl;
       end;
       let () =
         match ftnd_env.FE.res with
-        | `Sat partial_model | `Unknown partial_model ->
+        | `Sat | `Unknown ->
           begin
             if Options.(get_interpretation () && get_dump_models ()) then
-              FE.print_model (Options.Output.get_fmt_models ()) partial_model;
+              FE.print_model
+                (Options.Output.get_fmt_models ())
+                ftnd_env.sat_env;
           end
         | `Unsat -> ()
       in

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -39,7 +39,7 @@
     Models
     ; reasoners
     Ac Arith Arrays Arrays_rel Bitv Ccx Shostak Relation Enum Enum_rel
-    Fun_sat Inequalities Bitv_rel Th_util Adt Adt_rel
+    Fun_sat Fun_sat_frontend Inequalities Bitv_rel Th_util Adt Adt_rel
     Instances IntervalCalculus Intervals Ite_rel Ite Matching Matching_types
     Polynome Records Records_rel Satml_frontend_hybrid Satml_frontend Satml
     Sat_solver Sat_solver_sig Sig Sig_rel Theory Uf Use Rel_utils

--- a/src/lib/frontend/frontend.mli
+++ b/src/lib/frontend/frontend.mli
@@ -49,17 +49,17 @@ module type S = sig
   type sat_env
 
   type res = [
-    | `Sat of sat_env
-    | `Unknown of sat_env
+    | `Sat
+    | `Unknown
     | `Unsat
   ]
 
-  type env = {
+  type env = private {
     used_context : used_context;
     consistent_dep_stack: (res * Explanation.t) Stack.t;
     sat_env : sat_env;
-    res : res;
-    expl : Explanation.t
+    mutable res : res;
+    mutable expl : Explanation.t
   }
 
   val init_env : ?sat_env:sat_env -> used_context -> env
@@ -68,7 +68,7 @@ module type S = sig
       They catch the [Sat], [Unsat] and [I_dont_know] exceptions to update the
       frontend environment, but not the [Timeout] exception which is raised to
       the user. *)
-  type 'a process = ?loc:Loc.t -> env -> 'a -> env
+  type 'a process = ?loc:Loc.t -> env -> 'a -> unit
 
   val push : int process
 
@@ -86,7 +86,7 @@ module type S = sig
     ?hook_on_status:(sat_env status -> int -> unit) ->
     env ->
     Commands.sat_tdecl ->
-    env
+    unit
 
   val print_model: sat_env Fmt.t
 end

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -33,7 +33,7 @@ module SE = E.Set
 module ME = E.Map
 module Ex = Explanation
 
-module Make (Th : Theory.S) : Sat_solver_sig.S = struct
+module Make (Th : Theory.S) = struct
   module Inst = Instances.Make(Th)
   module CDCL = Satml_frontend_hybrid.Make(Th)
 

--- a/src/lib/reasoners/fun_sat.mli
+++ b/src/lib/reasoners/fun_sat.mli
@@ -28,7 +28,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** A functional implementation of the solver. *)
+(** A functional SAT solver implementation. *)
 module Make (Th : Theory.S) : sig
   type t
 

--- a/src/lib/reasoners/fun_sat_frontend.mli
+++ b/src/lib/reasoners/fun_sat_frontend.mli
@@ -28,37 +28,4 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** A functional implementation of the solver. *)
-module Make (Th : Theory.S) : sig
-  type t
-
-  exception Sat of t
-  exception Unsat of Explanation.t
-  exception I_dont_know of t
-
-  val empty : unit -> t
-
-  val empty_with_inst : (Expr.t -> bool) -> t
-
-  val push : t -> int -> t
-
-  val pop : t -> int -> t
-
-  val assume : t -> Expr.gformula -> Explanation.t -> t
-
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
-
-  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
-
-  val unsat : t -> Expr.gformula -> Explanation.t
-
-  val reset_refs : unit -> unit
-
-  val reinit_ctx : unit -> unit
-
-  val get_model: t -> Models.t Lazy.t option
-
-  val get_unknown_reason : t -> Sat_solver_sig.unknown_reason option
-
-  val get_value : t -> Expr.t -> Expr.t option
-end
+include Sat_solver_sig.SatContainer

--- a/src/lib/reasoners/sat_solver.ml
+++ b/src/lib/reasoners/sat_solver.ml
@@ -34,7 +34,7 @@ let get = function
       Printer.print_dbg
         ~module_name:"Sat_solver"
         "use Tableaux-like solver";
-    (module Fun_sat : Sat_solver_sig.SatContainer)
+    (module Fun_sat_frontend : Sat_solver_sig.SatContainer)
   | Util.CDCL | Util.CDCL_Tableaux ->
     if Options.get_verbose () then
       Printer.print_dbg

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -54,9 +54,9 @@ let pp_unknown_reason_opt ppf = function
 module type S = sig
   type t
 
-  exception Sat of t
+  exception Sat
   exception Unsat of Explanation.t
-  exception I_dont_know of t
+  exception I_dont_know
 
   (* the empty sat-solver context *)
   val empty : unit -> t
@@ -67,21 +67,21 @@ module type S = sig
       assertion level.
       Ie. assuming e after the push will become g -> e,
       a g will be forced to be true (but not propagated at level 0) *)
-  val push : t -> int -> t
+  val push : t -> int -> unit
 
   (** [pop env n] remove an assertion level.
       Internally, the guard g introduced in the push correponsding to this pop
       will be propagated to false (at level 0) *)
-  val pop : t -> int -> t
+  val pop : t -> int -> unit
 
   (* [assume env f] assume a new formula [f] in [env]. Raises Unsat if
      [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> t
+  val assume : t -> Expr.gformula -> Explanation.t -> unit
 
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> unit
 
   (* [pred_def env f] assume a new predicate definition [f] in [env]. *)
-  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
+  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> unit
 
   (* [unsat env f size] checks the unsatisfiability of [f] in
      [env]. Raises I_dont_know when the proof tree's height reaches

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -44,9 +44,9 @@ val pp_unknown_reason_opt : unknown_reason option Fmt.t
 module type S = sig
   type t
 
-  exception Sat of t
+  exception Sat
   exception Unsat of Explanation.t
-  exception I_dont_know of t
+  exception I_dont_know
 
   (** the empty sat-solver context *)
   val empty : unit -> t
@@ -57,23 +57,23 @@ module type S = sig
       assertion level.
       Ie. assuming e after the push will become g -> e,
       a g will be forced to be true (but not propagated at level 0) *)
-  val push : t -> int -> t
+  val push : t -> int -> unit
 
   (** [pop env n] remove an assertion level.
       Internally, the guard g introduced in the push correponsding to this pop
       will be propagated to false (at level 0) *)
-  val pop : t -> int -> t
+  val pop : t -> int -> unit
 
   (** [assume env f] assume a new formula [f] in [env]. Raises Unsat if
       [f] is unsatisfiable in [env] *)
-  val assume : t -> Expr.gformula -> Explanation.t -> t
+  val assume : t -> Expr.gformula -> Explanation.t -> unit
 
   (** [assume env f exp] assume a new formula [f] with the explanation [exp]
       in the theories environment of [env]. *)
-  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
+  val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> unit
 
   (** [pred_def env f] assume a new predicate definition [f] in [env]. *)
-  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
+  val pred_def : t -> Expr.t -> string -> Explanation.t -> Loc.t -> unit
 
   (** [unsat env f size] checks the unsatisfiability of [f] in
       [env]. Raises I_dont_know when the proof tree's height reaches

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1083,6 +1083,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let analyze_unknown_for_objectives env unsat_rec_prem : unit =
     let obj = Th.get_objectives (SAT.current_tbox env.satml) in
     if Util.MI.is_empty obj then raise I_dont_know;
+    env.objectives <- Some obj;
     let acc =
       try
         Util.MI.fold
@@ -1105,9 +1106,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
            we cannot go beyond infinity and the next objectives with lower
            priority cannot be optimized in presence of infinity values. *)
         raise I_dont_know;
-
       | (e, tv, is_max, is_le) :: l ->
-        env.objectives <- Some obj;
         let neg =
           List.fold_left
             (fun acc (e, tv, is_max, is_le) ->

--- a/tests/smtlib/testfile-get-info1.dolmen.expected
+++ b/tests/smtlib/testfile-get-info1.dolmen.expected
@@ -1,7 +1,7 @@
 
 unknown
 (
- :steps 8)
+ :steps 7)
 
 unsupported
 


### PR DESCRIPTION
Tackles #899 by making both Sat API imperative.
- The imperative is made... well, imperative; it still relies on `Satml_frontend` for properly wrapping calls to `Satml`. We should be able to merge them, but I choosed not to in this PR to avoid spaghettification.
- The functional sat now has an imperative frontend upadting a reference to the environment.