### PR TITLE
Fix the locked file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
+          allow-prelease-opam: true
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
@@ -66,6 +67,7 @@ jobs:
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
+          allow-prelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
           dune-cache: true
 
@@ -95,6 +97,7 @@ jobs:
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
+          allow-prelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
           dune-cache: true
 

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
+          allow-prelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
 
       # Install dependencies

--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -60,18 +60,3 @@ license: [
   "LicenseRef-OCamlpro-Non-Commercial"
   "Apache-2.0"
 ]
-
-pin-depends: [
-  [
-  "dolmen.dev"
-  "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
-  ]
-  [
-  "dolmen_loop.dev"
-  "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
-  ]
-  [
-  "dolmen_type.dev"
-  "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
-  ]
-]

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -88,15 +88,15 @@ conflicts: [
 pin-depends: [
   [
     "dolmen.dev"
-    "git+https://github.com/Gbury/dolmen.git#baaf1f92ccd473294679dd9025c3ae9a441a82fa"
+    "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
   ]
   [
     "dolmen_loop.dev"
-    "git+https://github.com/Gbury/dolmen.git#baaf1f92ccd473294679dd9025c3ae9a441a82fa"
+    "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
   ]
   [
     "dolmen_type.dev"
-    "git+https://github.com/Gbury/dolmen.git#baaf1f92ccd473294679dd9025c3ae9a441a82fa"
+    "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
   ]
   [
     "js_of_ocaml.5.4.0"

--- a/alt-ergo-lib.opam.template
+++ b/alt-ergo-lib.opam.template
@@ -6,18 +6,3 @@ license: [
   "LicenseRef-OCamlpro-Non-Commercial"
   "Apache-2.0"
 ]
-
-pin-depends: [
-  [
-  "dolmen.dev"
-  "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
-  ]
-  [
-  "dolmen_loop.dev"
-  "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
-  ]
-  [
-  "dolmen_type.dev"
-  "git+https://github.com/Gbury/dolmen.git#b14eb8a2400c3dd2c34cded212c2135bbce1a57c"
-  ]
-]


### PR DESCRIPTION
We should never pin dependencies in `opam` files or their templates. This commit removes all the pins in `alt-ergo-lib.opam` and `alt-ergo-lib.opam.template` and update the locked file.