### PR TITLE
fix(BV): Do not call [X.make] on non-subterm, reloaded

### DIFF
--- a/tests/bitv/testfile-bitv025.expected
+++ b/tests/bitv/testfile-bitv025.expected
@@ -1,0 +1,2 @@
+
+unknown

--- a/tests/bitv/testfile-bitv025.smt2
+++ b/tests/bitv/testfile-bitv025.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_BV)
+(declare-fun s () (_ BitVec 32))
+(declare-fun t () (_ BitVec 32))
+(assert (= (bvshl s (bvnot (bvmul s t))) (_ bv0 32)))
+(check-sat)


### PR DESCRIPTION
This is a follow-up to https://github.com/OCamlPro/alt-ergo/pull/954

Somehow convinced myself that the cases where we perform simplifications were fine because we would only be simplifying into a subterm, but that is obviously not the case due to negation. Let's just do the safe thing and always return the original term with the appropriate equalities.

All of this code should be removed in favor of doing these computations in the relations instead anyways, which would make sure we always treat [bv2nat] in the same way for literals and after substitution (see also https://github.com/OCamlPro/alt-ergo/issues/824 )