### PR TITLE
Simplify smart constructors for literal numbers

### DIFF
--- a/src/lib/frontend/cnf.ml
+++ b/src/lib/frontend/cnf.ml
@@ -83,9 +83,12 @@ let rec make_term up_qv quant_basename t =
         E.mk_term s [t1; t2] ty
       end
 
-    | TTprefix ((Sy.Op Sy.Minus) as s, n) ->
-      let t1 = if ty == Ty.Tint then E.Ints.of_int 0 else E.Reals.of_int 0 in
-      E.mk_term s [t1; mk_term n] ty
+    | TTprefix (Sy.Op Sy.Minus, n) ->
+      if ty == Ty.Tint then
+        E.Ints.(~- (mk_term n))
+      else
+        E.Reals.(~- (mk_term n))
+
     | TTprefix _ ->
       assert false
 
@@ -253,10 +256,8 @@ and make_form up_qv name_base ~toplevel f loc ~decl_kind : E.t =
                 {c = {tt_ty = Ty.Tint;
                       tt_desc = TTconst(Tint "1")}; annot = t1.annot} in
               let tt2 =
-                E.mk_term (Sy.Op Sy.Minus)
-                  [make_term up_qv name_base t2;
-                   make_term up_qv name_base one]
-                  Ty.Tint
+                E.Ints.((make_term up_qv name_base t2)
+                        - (make_term up_qv name_base one))
               in
               E.mk_builtin ~is_pos:true Sy.LE
                 [make_term up_qv name_base t1; tt2]

--- a/src/lib/frontend/cnf.ml
+++ b/src/lib/frontend/cnf.ml
@@ -59,9 +59,9 @@ let rec make_term up_qv quant_basename t =
     | TTconst Tvoid ->
       E.void
     | TTconst (Tint i) ->
-      E.int i
+      E.Ints.of_Z (Z.of_string i)
     | TTconst (Treal n) ->
-      E.real (Numbers.Q.to_string n)
+      E.Reals.of_Q n
     | TTconst (Tbitv bt) ->
       E.bitv bt ty
     | TTvar s -> E.mk_term s [] ty
@@ -84,7 +84,7 @@ let rec make_term up_qv quant_basename t =
       end
 
     | TTprefix ((Sy.Op Sy.Minus) as s, n) ->
-      let t1 = if ty == Ty.Tint then E.int "0" else E.real "0"  in
+      let t1 = if ty == Ty.Tint then E.Ints.of_int 0 else E.Reals.of_int 0 in
       E.mk_term s [t1; mk_term n] ty
     | TTprefix _ ->
       assert false

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -985,7 +985,7 @@ let destruct_app e =
 let mk_lt translate ty x y =
   if ty == `Int then
     let e3 =
-      E.mk_term (Sy.Op Sy.Minus) [translate y; E.int "1"] Ty.Tint
+      E.mk_term (Sy.Op Sy.Minus) [translate y; E.Ints.of_int 1] Ty.Tint
     in
     let e1 = translate x in
     E.mk_builtin ~is_pos:true Sy.LE [e1; e3]
@@ -995,7 +995,7 @@ let mk_lt translate ty x y =
 let mk_gt translate ty x y =
   if ty == `Int then
     let e3 =
-      E.mk_term (Sy.Op Sy.Minus) [translate x; E.int "1"] Ty.Tint
+      E.mk_term (Sy.Op Sy.Minus) [translate x; E.Ints.of_int 1] Ty.Tint
     in
     let e2 = translate y in
     E.mk_builtin ~is_pos:true Sy.LE [e2; e3]
@@ -1037,8 +1037,8 @@ let rec mk_expr
         begin match builtin with
           | B.True -> E.vrai
           | B.False -> E.faux
-          | B.Integer s -> E.int s
-          | B.Decimal s -> E.real s
+          | B.Integer s -> E.Ints.of_Z (Z.of_string s)
+          | B.Decimal s -> E.Reals.of_Q (Q.of_string s)
           | B.Bitvec s ->
             let ty = dty_to_ty term_ty in
             E.bitv s ty
@@ -1081,7 +1081,9 @@ let rec mk_expr
 
           | B.Minus mty, [x] ->
             let e1, ty =
-              if mty == `Int then E.int "0", Ty.Tint else E.real "0",Ty.Treal
+              if mty == `Int
+              then E.Ints.of_int 0, Ty.Tint
+              else E.Reals.of_int 0, Ty.Treal
             in
             E.mk_term (Sy.Op Sy.Minus) [e1; aux_mk_expr x] ty
 

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -985,7 +985,7 @@ let destruct_app e =
 let mk_lt translate ty x y =
   if ty == `Int then
     let e3 =
-      E.mk_term (Sy.Op Sy.Minus) [translate y; E.Ints.of_int 1] Ty.Tint
+      E.Ints.((translate y) - (of_Z Z.one))
     in
     let e1 = translate x in
     E.mk_builtin ~is_pos:true Sy.LE [e1; e3]
@@ -995,7 +995,7 @@ let mk_lt translate ty x y =
 let mk_gt translate ty x y =
   if ty == `Int then
     let e3 =
-      E.mk_term (Sy.Op Sy.Minus) [translate x; E.Ints.of_int 1] Ty.Tint
+      E.Ints.((translate x) - (of_Z Z.one))
     in
     let e2 = translate y in
     E.mk_builtin ~is_pos:true Sy.LE [e2; e3]
@@ -1080,12 +1080,10 @@ let rec mk_expr
             E.neg (aux_mk_expr x)
 
           | B.Minus mty, [x] ->
-            let e1, ty =
-              if mty == `Int
-              then E.Ints.of_int 0, Ty.Tint
-              else E.Reals.of_int 0, Ty.Treal
-            in
-            E.mk_term (Sy.Op Sy.Minus) [e1; aux_mk_expr x] ty
+            if mty == `Int then
+              E.Ints.(~- (aux_mk_expr x))
+            else
+              E.Reals.(~- (aux_mk_expr x))
 
           | B.Destructor { case; field; adt; _ }, [x] ->
             begin match DT.definition adt with
@@ -1347,11 +1345,9 @@ let rec mk_expr
             mk_add aux_mk_expr sy rty args
 
           | B.Sub ty, h :: t ->
-            let rty = if ty == `Int then Ty.Tint else Treal in
-            let sy = Sy.Op Sy.Minus in
+            let minus = if ty == `Int then E.Ints.(-) else E.Reals.(-) in
             let args = List.rev_map aux_mk_expr (List.rev t) in
-            List.fold_left
-              (fun x y -> E.mk_term sy [x; y] rty) (aux_mk_expr h) args
+            List.fold_left minus (aux_mk_expr h) args
 
           | B.Mul ty, h :: t ->
             let rty = if ty == `Int then Ty.Tint else Treal in

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -802,12 +802,12 @@ module Shostak
       then None
       else
         let term_of_cst, cpt = match X.type_info r with
-          | Ty.Tint  -> E.int, cpt_int
-          | Ty.Treal -> E.real, cpt_real
+          | Ty.Tint  -> (fun q -> Q.num q |> E.Ints.of_Z), cpt_int
+          | Ty.Treal -> E.Reals.of_Q, cpt_real
           | _ -> assert false
         in
         cpt := Q.add Q.one (max_constant distincts !cpt);
-        Some (term_of_cst (Q.to_string !cpt), true)
+        Some (term_of_cst !cpt, true)
 
   let pp_constant ppf r =
     match P.is_const (embed r), X.type_info r with

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -353,10 +353,20 @@ module Make (X : Arg) : S with type theory = X.t = struct
       SLE.elements mtl
 
   let plus_of_minus t d ty =
-    [E.mk_term (Symbols.Op Symbols.Minus) [t; d] ty ; d]
+    match ty with
+    | Ty.Tint ->
+      [E.Ints.(t - d); d]
+    | Ty.Treal ->
+      [E.Reals.(t - d); d]
+    | _ -> assert false
 
   let minus_of_plus t d ty =
-    [E.mk_term (Symbols.Op Symbols.Plus)  [t; d] ty ; d]
+    match ty with
+    | Ty.Tint ->
+      [E.Ints.(t + d); d]
+    | Ty.Treal ->
+      [E.Reals.(t + d); d]
+    | _ -> assert false
 
   let linear_arithmetic_matching f_pat pats _ty_pat t =
     let ty = E.type_info t in

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -194,8 +194,6 @@ val mk_term : Symbols.t -> t list -> Ty.t -> t
 val vrai : t
 val faux : t
 val void : t
-val int : string -> t
-val real : string -> t
 val bitv : string -> Ty.t -> t
 val fresh_name : Ty.t -> t
 val pred : t -> t


### PR DESCRIPTION
We made a lot of conversion between string and Zarith representation for literals numbers in `Expr`. This commit simplifies the situation.

Now we perform the conversion of the string representation into Zarith one once in both legacy and Dolmen frontend.

The motivation for this modification comes from the fact we'll use expressions to store model values. If we use string here, it's not easy to normalize terms like `-(- 0 x)` to `x`.

With the Zarith representation, the library does the normalization for us.

Remove the smart constructors `int` and `real` in `Expr` which aren't useful anymore.