### PR TITLE
fix(build): Use opam install --locked for Docker build

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -46,4 +46,4 @@ jobs:
       - run: opam switch create . ocaml-system --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 
       # Install the project packages
-      - run: opam install .
+      - run: opam install . --locked


### PR DESCRIPTION
Missed in #965 