### PR TITLE
Print unknown reason in SMT-LIB syntax

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -683,7 +683,7 @@ let main () =
         match SAT.get_unknown_reason sat with
         | None -> err ()
         | Some ur ->
-          print_std Sat_solver_sig.pp_unknown_reason ur
+          print_std Sat_solver_sig.pp_smt_unknown_reason ur
     in
     match name with
     | ":authors" ->

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -160,7 +160,7 @@ let main () =
             let ur = SAT.get_unknown_reason partial_model in
             Printer.print_fmt (Options.Output.get_fmt_diagnostic ())
               "@[<v 0>Returned unknown reason = %a@]"
-              Sat_solver_sig.pp_unknown_reason_opt ur;
+              Sat_solver_sig.pp_ae_unknown_reason_opt ur;
             FE.print_model (Options.Output.get_fmt_models ()) partial_model
           end;
           Some mdl

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -504,7 +504,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
          far. You may need to change your model generation strategy \
          or to increase your timeouts. \
          Returned unknown reason = %a@]"
-        Sat_solver_sig.pp_unknown_reason_opt ur;
+        Sat_solver_sig.pp_ae_unknown_reason_opt ur;
 
     | Some (lazy model) ->
       Models.output_concrete_model ppf model

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -52,7 +52,7 @@ type unknown_reason =
   | Step_limit of int
   | Timeout of timeout_reason
 
-let pp_unknown_reason ppf = function
+let pp_smt_unknown_reason ppf = function
   | Incomplete -> Fmt.pf ppf "incomplete"
   | Memout -> Fmt.pf ppf "memout"
   | Step_limit i -> Fmt.pf ppf "(:step-limit %i)" i

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -36,7 +36,7 @@ type timeout_reason =
   | ProofSearch
   | ModelGen
 
-let pp_timeout_reason ppf = function
+let pp_smt_timeout_reason ppf = function
   | Assume -> Fmt.pf ppf ":assume"
   | ProofSearch -> Fmt.pf ppf ":proof-search"
   | ModelGen -> Fmt.pf ppf ":model-gen"
@@ -56,10 +56,10 @@ let pp_unknown_reason ppf = function
   | Incomplete -> Fmt.pf ppf "incomplete"
   | Memout -> Fmt.pf ppf "memout"
   | Step_limit i -> Fmt.pf ppf "(:step-limit %i)" i
-  | Timeout t -> Fmt.pf ppf "(:timeout %a)" pp_timeout_reason t
+  | Timeout t -> Fmt.pf ppf "(:timeout %a)" pp_smt_timeout_reason t
 
 let pp_ae_unknown_reason_opt ppf = function
-  | None -> Fmt.pf ppf ":decided"
+  | None -> Fmt.pf ppf "Decided"
   | Some Incomplete -> Fmt.pf ppf "Incomplete"
   | Some Memout -> Fmt.pf ppf "Memout"
   | Some Step_limit i -> Fmt.pf ppf "StepLimit:%i" i

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -35,7 +35,16 @@ type timeout_reason =
   | Assume
   | ProofSearch
   | ModelGen
-[@@deriving show]
+
+let pp_timeout_reason ppf = function
+  | Assume -> Fmt.pf ppf ":assume"
+  | ProofSearch -> Fmt.pf ppf ":proof-search"
+  | ModelGen -> Fmt.pf ppf ":model-gen"
+
+let pp_ae_timeout_reason ppf = function
+  | Assume -> Fmt.pf ppf "Assume"
+  | ProofSearch -> Fmt.pf ppf "ProofSearch"
+  | ModelGen -> Fmt.pf ppf "ModelGen"
 
 type unknown_reason =
   | Incomplete
@@ -44,14 +53,17 @@ type unknown_reason =
   | Timeout of timeout_reason
 
 let pp_unknown_reason ppf = function
-  | Incomplete -> Fmt.pf ppf "Incomplete"
-  | Memout -> Fmt.pf ppf "Memout"
-  | Step_limit i -> Fmt.pf ppf "Step limit: %i" i
-  | Timeout t -> Fmt.pf ppf "Timeout:%a" pp_timeout_reason t
+  | Incomplete -> Fmt.pf ppf "incomplete"
+  | Memout -> Fmt.pf ppf "memout"
+  | Step_limit i -> Fmt.pf ppf "(:step-limit %i)" i
+  | Timeout t -> Fmt.pf ppf "(:timeout %a)" pp_timeout_reason t
 
-let pp_unknown_reason_opt ppf = function
-  | None -> Fmt.pf ppf "Decided"
-  | Some ur -> pp_unknown_reason ppf ur
+let pp_ae_unknown_reason_opt ppf = function
+  | None -> Fmt.pf ppf ":decided"
+  | Some Incomplete -> Fmt.pf ppf "Incomplete"
+  | Some Memout -> Fmt.pf ppf "Memout"
+  | Some Step_limit i -> Fmt.pf ppf "StepLimit:%i" i
+  | Some Timeout t -> Fmt.pf ppf "Timeout:%a" pp_ae_timeout_reason t
 
 module type S = sig
   type t

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -40,7 +40,7 @@ type unknown_reason =
   | Timeout of timeout_reason
 
 (** Prints the unknown reason in the default SMT-LIB format *)
-val pp_unknown_reason: unknown_reason Fmt.t
+val pp_smt_unknown_reason: unknown_reason Fmt.t
 
 (** Prints an optional unknown reason in Alt-Ergo format *)
 val pp_ae_unknown_reason_opt : unknown_reason option Fmt.t

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -39,8 +39,11 @@ type unknown_reason =
   | Step_limit of int
   | Timeout of timeout_reason
 
+(** Prints the unknown reason in the default SMT-LIB format *)
 val pp_unknown_reason: unknown_reason Fmt.t
-val pp_unknown_reason_opt : unknown_reason option Fmt.t
+
+(** Prints an optional unknown reason in Alt-Ergo format *)
+val pp_ae_unknown_reason_opt : unknown_reason option Fmt.t
 
 module type S = sig
   type t

--- a/tests/smtlib/testfile-get-info1.dolmen.expected
+++ b/tests/smtlib/testfile-get-info1.dolmen.expected
@@ -8,5 +8,5 @@ unsupported
 (:authors "Alt-Ergo developers")
 (:error-behavior immediate-exit)
 (:name "Alt-Ergo")
-(:reason-unknown Incomplete)
+(:reason-unknown incomplete)
 (:version dev)

--- a/tests/smtlib/testfile-steps-bound.dolmen.expected
+++ b/tests/smtlib/testfile-steps-bound.dolmen.expected
@@ -1,5 +1,5 @@
 
 unknown
-(:reason-unknown Step limit: 3)
+(:reason-unknown (:step-limit 3))
 
 unsat


### PR DESCRIPTION
> The old format is preserved for legacy messages in the Alt-Ergo format, but the SMT-LIB format is the default one for pretty-printers, since we are moving towards preferring the SMT-LIB format.
Fixes https://github.com/OCamlPro/alt-ergo/issues/966

( cf https://github.com/Stevendeo/alt-ergo/pull/1 )