### PR TITLE
fix(build): Correct setup-ocaml option name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
-          allow-prelease-opam: true
+          allow-prerelease-opam: true
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
@@ -67,7 +67,7 @@ jobs:
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
-          allow-prelease-opam: true
+          allow-prerelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
           dune-cache: true
 
@@ -97,7 +97,7 @@ jobs:
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
-          allow-prelease-opam: true
+          allow-prerelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
           dune-cache: true
 

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
-          allow-prelease-opam: true
+          allow-prerelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
 
       # Install dependencies


### PR DESCRIPTION
This uses the correct `allow-prerelease-opam` option name instead of `allow-prelease-opam` which does not exist and was typo'd in https://github.com/OCamlPro/alt-ergo/pull/965

Hopefully this fixes the build, which is broken again.