### PR TITLE
cleanup: Use proper ADT for variable classes

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -47,12 +47,6 @@ let unsupported msg =
     (fun str -> Errors.(run_error (Unsupported_feature str)))
     msg
 
-module Shared = struct
-  (* Shared constants to avoid allocations*)
-
-  let qm = Sy.VarBnd (Var.of_string "?")
-end
-
 module HT = Hashtbl.Make(
   struct
     type t = int
@@ -1630,7 +1624,7 @@ let rec mk_expr
     (* open-ended in interval *)
     | (B.Lt _ | B.Leq _ | B.Gt _ | B.Geq _) as b, [x; y] ->
       let main_var, main_expr = Option.get var in
-      let qm = Shared.qm in
+      let qm = Sy.Unbounded in
       let sort, lb, ub = parse_semantic_bound ~loc ~var:main_var b x y in
       let lb =
         match lb with
@@ -1687,7 +1681,7 @@ and make_trigger ?(loc = Loc.dummy) ~name_base ~decl_kind
         (fun (v : DE.term_var) ->
            let var =
              match v.path with
-             | Local { name } -> Var.of_string name
+             | Local { name } -> Var.local name
              | _ -> assert false
            in
            Cache.store_var v var)

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -600,7 +600,7 @@ let check_pattern_matching missing dead loc =
       List.rev_map
         (function
           | Constr { name; _ } -> name
-          | Var v -> (Var.view v).Var.hs
+          | Var v -> Var.to_string v |> Hstring.make
         ) dead
     in
     Printer.print_wrn "%a"
@@ -1043,7 +1043,14 @@ and type_bound env bnd ty ~is_open ~is_lower =
     | PPvar s ->
       assert (String.length s > 0);
       begin match s.[0] with
-        | '?' -> Symbols.VarBnd (Var.of_string s), ty
+        | '?' ->
+          let sy =
+            if String.length s = 1 then
+              Symbols.Unbounded
+            else
+              Symbols.VarBnd (Var.local s)
+          in
+          sy, ty
         | _ ->
           let vx, ty_x = type_var_desc env s bnd.pp_loc in
           let var_x =

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2209,10 +2209,8 @@ let extend_with_domain_substitution =
   let aux idoms sbt =
     Var.Map.fold
       (fun v_hs (lv, uv, ty) sbt ->
-         let s = Hstring.view (Var.view v_hs).Var.hs in
-         match s.[0] with
-         | '?' -> sbt
-         | _ ->
+         if Var.is_local v_hs then sbt
+         else
            let lb_var = v_hs in
            let lb_val = match lv, uv with
              | None, None -> raise Exit

--- a/src/lib/reasoners/intervals.ml
+++ b/src/lib/reasoners/intervals.ml
@@ -1064,10 +1064,6 @@ type interval_matching =
 module MV = Var.Map
 module Sy = Symbols
 
-let is_question_mark =
-  let qm = Hstring.make "?" in
-  fun s -> Hstring.equal qm (Var.view s).Var.hs
-
 let consistent_bnds low up =
   match low, up with
   | Some (q_low, str_low), Some (q_up, str_up) ->
@@ -1124,7 +1120,7 @@ let new_var idoms s ty =
 let match_interval_upper {Sy.sort; is_open; kind; is_lower} i imatch =
   assert (not is_lower);
   match kind, max_bound i with
-  | Sy.VarBnd s, _ when is_question_mark s -> imatch (* ? var *)
+  | Sy.Unbounded, _ -> imatch (* ? var *)
   | Sy.VarBnd _, Minfty -> assert false
   | Sy.VarBnd s, Pinfty -> new_var imatch s sort
   | Sy.VarBnd s, Strict (v, _) -> new_low_bound imatch s sort v false
@@ -1146,7 +1142,7 @@ let match_interval_upper {Sy.sort; is_open; kind; is_lower} i imatch =
 let match_interval_lower {Sy.sort; is_open; kind; is_lower} i imatch =
   assert (is_lower);
   match kind, min_bound i with
-  | Sy.VarBnd s, _ when is_question_mark s -> imatch (* ? var *)
+  | Sy.Unbounded, _ -> imatch (* ? var *)
   | Sy.VarBnd _, Pinfty -> assert false
   | Sy.VarBnd s,  Minfty -> new_var imatch s sort
   | Sy.VarBnd s, Strict (v, _) -> new_up_bound imatch s sort v false

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -75,7 +75,7 @@ type form =
 
 type name_kind = Ac | Other
 
-type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
+type bound_kind = Unbounded | VarBnd of Var.t | ValBnd of Numbers.Q.t
 
 type bound = (* private *)
   { kind : bound_kind; sort : Ty.t; is_open : bool; is_lower : bool }
@@ -201,7 +201,7 @@ let compare_bounds_kind a b =
     (function
       | VarBnd h1, VarBnd h2 -> Var.compare h1 h2
       | ValBnd q1, ValBnd q2 -> Numbers.Q.compare q1 q2
-      | _, (VarBnd _ | ValBnd _) -> assert false
+      | _, (VarBnd _ | ValBnd _ | Unbounded) -> assert false
     )
 
 let compare_bounds a b =
@@ -261,6 +261,7 @@ let hash x =
   | Form x -> 19 * Hashtbl.hash x + 12
 
 let string_of_bound_kind x = match x with
+  | Unbounded -> "?"
   | VarBnd v -> Var.to_string v
   | ValBnd v -> Numbers.Q.to_string v
 

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -75,7 +75,7 @@ type form =
 
 type name_kind = Ac | Other
 
-type bound_kind = VarBnd of Var.t | ValBnd of Numbers.Q.t
+type bound_kind = Unbounded | VarBnd of Var.t | ValBnd of Numbers.Q.t
 
 type bound = private
   { kind : bound_kind; sort : Ty.t; is_open : bool; is_lower : bool }

--- a/src/lib/structures/var.mli
+++ b/src/lib/structures/var.mli
@@ -30,12 +30,23 @@
 
 type t
 
-type view = {hs : Hstring.t ; id : int}
-
 val of_hstring : Hstring.t -> t
-val of_string  : string -> t
+(** Create a *fresh* variable with the given name.
 
-val view : t -> view
+    Calling [of_hstring] twice with the same [Hstring.t] as argument will result
+    in *distinct* variables. *)
+
+val of_string  : string -> t
+(** Convenient alias for [of_hstring (Hstring.make s)]. *)
+
+val local : string -> t
+(** Create a new "local" variable. Local variables are variables used
+    exclusively in user-defined theories for semantic triggers, and are
+    implicitly bound at the level of the enclosing quantifier. *)
+
+val is_local : t -> bool
+(** Indicates whether the given variable is a local variable (see {!local} above
+    for details). *)
 
 val compare : t -> t -> int
 
@@ -44,6 +55,8 @@ val equal : t -> t -> bool
 val hash : t -> int
 
 val underscore : t
+(** Unique special variable. Used to indicate fields that should be ignored in
+    pattern matching and triggers. *)
 
 val print : Format.formatter -> t -> unit
 


### PR DESCRIPTION
This patch cleans up the way we use the '?' (question mark) and '_' special variables by introducing special constructors in `Symbols.var_bnd` and `Var.t` for their corresponding purposes.

Note that it looks like this fixes a subtle bug in `IntervalCalculus`, which assumes that all variables whose name starts with a '?' are "local" variables from semantic triggers, while that is not true when using the SMT-LIB format. However, since that piece of code only runs during semantic matching, it would require defining theory extensions in the SMT-LIB format to trigger the bug, and since that is not supported, there is in fact no bug.

Following discussions in #983 and at the dev meeting. Note that there was no possible confusion in #983 — we collectively forgot that variables are identified by a globally unique identifier (and `Var.underscore` always has ID 1).