### PR TITLE
cleanup: Remove unused upvar computations

### DIFF
--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -501,8 +501,6 @@ module Env = struct
 
   let find { var_map = m; _ } n = MString.find n m
 
-  let list_of { var_map = m; _ } = MString.fold (fun _ c acc -> c::acc) m []
-
   let add_type_decl ?(recursive=false) env vars id body loc =
     let ty, types = Types.add_decl ~recursive env.types vars id body loc in
     ty, { env with types = types; }
@@ -1305,7 +1303,6 @@ and type_form ?(in_theory=false) env f =
       let ty_triggers =
         List.map (fun (tr, b) -> type_trigger in_theory env' tr, b) triggers in
       let qf_hyp = List.map (fun h -> type_form env' h) hyp in
-      let upbvars = Env.list_of env in
       let bvars =
         List.fold_left
           (fun acc (v,_) ->
@@ -1313,7 +1310,6 @@ and type_form ?(in_theory=false) env f =
              ty :: acc) [] ty_vars
       in
       let qf_form = {
-        qf_upvars = upbvars ;
         qf_bvars = bvars ;
         qf_triggers = ty_triggers ;
         qf_hyp = qf_hyp;
@@ -1352,7 +1348,6 @@ and type_form ?(in_theory=false) env f =
              (sy, Var.of_string sy, xx, tty):: binders
           )[] binders
       in
-      let up = Env.list_of env in
       let env =
         List.fold_left
           (fun env (v, sv, _, ty) ->
@@ -1366,7 +1361,7 @@ and type_form ?(in_theory=false) env f =
           (fun binders (_,sv,e,_) -> (sv, e) :: binders)
           [] binders
       in
-      TFlet (up ,binders, f)
+      TFlet (binders, f)
 
     (* Remove labels : *)
     | PPforall_named (vs_tys, trs, hyp, f) ->
@@ -2144,7 +2139,6 @@ and monomorphize_form tf =
     | TFforall qf ->
       TFforall
         {  qf_bvars = List.map monomorphize_var qf.qf_bvars;
-           qf_upvars = List.map monomorphize_var qf.qf_upvars;
            qf_hyp = List.map monomorphize_form qf.qf_hyp;
            qf_form = monomorphize_form qf.qf_form;
            qf_triggers =
@@ -2152,14 +2146,12 @@ and monomorphize_form tf =
     | TFexists qf ->
       TFexists
         {  qf_bvars = List.map monomorphize_var qf.qf_bvars;
-           qf_upvars = List.map monomorphize_var qf.qf_upvars;
            qf_hyp = List.map monomorphize_form qf.qf_hyp;
            qf_form = monomorphize_form qf.qf_form;
            qf_triggers =
              List.map (fun (l, b) -> List.map mono_term l, b) qf.qf_triggers}
 
-    | TFlet (l, binders, tf) ->
-      let l = List.map monomorphize_var l in
+    | TFlet (binders, tf) ->
       let binders =
         List.rev_map
           (fun (sy, e) ->
@@ -2168,7 +2160,7 @@ and monomorphize_form tf =
              | TletForm ff -> sy, TletForm (monomorphize_form ff)
           )(List.rev binders)
       in
-      TFlet(l, binders, monomorphize_form tf)
+      TFlet(binders, monomorphize_form tf)
 
     | TFnamed (hs,tf) ->
       TFnamed(hs, monomorphize_form tf)

--- a/src/lib/structures/typed.ml
+++ b/src/lib/structures/typed.ml
@@ -110,7 +110,6 @@ and 'a tatom =
 and 'a quant_form = {
   (* quantified variables that appear in the formula *)
   qf_bvars : (Symbols.t * Ty.t) list ;
-  qf_upvars : (Symbols.t * Ty.t) list ;
   qf_triggers : ('a atterm list * bool) list ;
   qf_hyp : 'a atform list;
   qf_form : 'a atform
@@ -123,8 +122,7 @@ and 'a tform =
   | TFop of oplogic * ('a atform) list
   | TFforall of 'a quant_form
   | TFexists of 'a quant_form
-  | TFlet of (Symbols.t * Ty.t) list *
-             (Var.t * 'a tlet_kind) list * 'a atform
+  | TFlet of (Var.t * 'a tlet_kind) list * 'a atform
   | TFnamed of Hstring.t * 'a atform
   | TFmatch of 'a atterm * (pattern * 'a atform) list
 
@@ -329,7 +327,7 @@ and print_formula =
       fprintf fmt "forall %a [%a]. %a"
         print_binders l print_triggers t print_formula f
 
-    | TFlet (_, binders, f) ->
+    | TFlet (binders, f) ->
       List.iter
         (fun (sy, let_e) ->
            fprintf fmt " let %a = " Var.print sy;

--- a/src/lib/structures/typed.mli
+++ b/src/lib/structures/typed.mli
@@ -180,8 +180,6 @@ and 'a tatom =
 and 'a quant_form = {
   qf_bvars : (Symbols.t * Ty.t) list;
   (** Variables that are quantified by this formula. *)
-  qf_upvars : (Symbols.t * Ty.t) list;
-  (** Free variables that occur in the formula. *)
   qf_triggers : ('a atterm list * bool) list;
   (** Triggers associated wiht the formula.
       For each trigger, the boolean specifies whether the trigger
@@ -206,11 +204,9 @@ and 'a tform =
   (** Universal quantification. *)
   | TFexists of 'a quant_form
   (** Existencial quantification. *)
-  | TFlet of (Symbols.t * Ty.t) list *
-             (Var.t * 'a tlet_kind) list *
+  | TFlet of (Var.t * 'a tlet_kind) list *
              'a atform
-  (** Let binding.
-      TODO: what is in the first list ? *)
+  (** Let binding. *)
   | TFnamed of Hstring.t * 'a atform
   (** Attach a name to a formula. *)
 


### PR DESCRIPTION
These were only used by the GUI, which has been removed in #601. They no longer seem to do anything.