### PR TITLE
cleanup: Use an inline record for Sy.Name

### DIFF
--- a/src/lib/frontend/models.ml
+++ b/src/lib/frontend/models.ml
@@ -206,7 +206,7 @@ module Pp_smtlib_term = struct
     | Sy.In(lb, rb), [t] ->
       fprintf fmt "(%a in %a, %a)" print t Sy.print_bound lb Sy.print_bound rb
 
-    | Sy.Name (n, _, _), l -> begin
+    | Sy.Name { hs = n; _ }, l -> begin
         let constraint_name =
           try let constraint_name,_,_ =
                 (MS.find (Hstring.view n) !constraints) in
@@ -444,7 +444,8 @@ module SmtlibCounterExample = struct
             because they could be record accessors that must be added to the
             `records` reference *)
          match f with
-         | Sy.Name (_, _, false) -> print_fun_def fmt f xs_ty_named ty rep
+         | Sy.Name { defined = false; _ } ->
+           print_fun_def fmt f xs_ty_named ty rep
          | _ -> ()
       ) fprofs;
     !records

--- a/src/lib/reasoners/ac.ml
+++ b/src/lib/reasoners/ac.ml
@@ -168,7 +168,7 @@ module Make (X : Sig.X) = struct
     | Some ac when Sy.equal sy ac.h -> r, acc
     | None -> r, acc
     | Some _ -> match Expr.term_view t with
-      | { Expr.f = Sy.Name (hs, Sy.Ac, _); xs; ty; _ } ->
+      | { Expr.f = Sy.Name { hs; kind = Sy.Ac; _ }; xs; ty; _ } ->
         let aro_sy = Sy.name ("@" ^ (HS.view hs)) in
         let aro_t = Expr.mk_term aro_sy xs ty  in
         let eq = Expr.mk_eq ~iff:false aro_t t in

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -125,7 +125,7 @@ module Main_Default : S = struct
       SE.fold
         (fun t mp ->
            match E.term_view t with
-           | { E.f = Sy.Name (hs, ((Sy.Ac | Sy.Other) as is_ac), _);
+           | { E.f = Sy.Name { hs; kind = ((Sy.Ac | Sy.Other) as is_ac); _ };
                xs; ty; _ } ->
              let xs = List.map E.type_info xs in
              let xs, ty =

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -421,9 +421,9 @@ module SmtPrinter = struct
 
     | Sy.False, [] -> Fmt.pf ppf "false"
 
-    | Sy.Name (n, _, _), [] -> Symbols.pp_name ppf (Hstring.view n)
+    | Sy.Name { hs = n; _ }, [] -> Symbols.pp_name ppf (Hstring.view n)
 
-    | Sy.Name (n, _, _), _ :: _ ->
+    | Sy.Name { hs = n; _ }, _ :: _ ->
       Fmt.pf ppf "@[<hv 2>(%a@ %a@])"
         Symbols.pp_name (Hstring.view n)
         Fmt.(list ~sep:sp pp) xs
@@ -2294,7 +2294,7 @@ module Triggers = struct
       | { f = Op _; _ } ->
         if eq exclude e then acc else e :: acc
 
-      | { f = Name (_, _, _); _ } ->
+      | { f = Name _; _ } ->
         if eq exclude e then acc else e :: acc
 
       | { f = ( True | False | Void | Int _ | Real _

--- a/src/lib/structures/modelMap.ml
+++ b/src/lib/structures/modelMap.ml
@@ -100,7 +100,7 @@ let is_suspicious_symbol = function
           | Max_int | Max_real | Min_int | Min_real
           | Pow | Integer_log2 | Int2BV _ | BV2Nat
           | BVand | BVor | Integer_round) -> true
-  | Sy.Name (hs, _, _) when is_suspicious_name hs -> true
+  | Sy.Name { hs; _ } when is_suspicious_name hs -> true
   | _ -> false
 
 let add ((sy, _, _) as p) v { values; suspicious } =
@@ -114,7 +114,7 @@ let add ((sy, _, _) as p) v { values; suspicious } =
 let iter f { values; _ } =
   P.iter (fun ((sy, _, _) as key) value ->
       match sy with
-      | Sy.Name (_, _, true) ->
+      | Sy.Name { defined = true; _ } ->
         (* We don't print constants defined by the user. *)
         ()
       | _ -> f key value

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -927,7 +927,7 @@ module Flat_Formula : FLAT_FORMULA = struct
   let mk_new_proxy n =
     let hs = Hs.make (".PROXY__" ^ (string_of_int n)) in
     (* TODO: we should use a smart constructor here. *)
-    let sy = Symbols.Name (hs, Symbols.Other, false) in
+    let sy = Symbols.Name { hs; kind = Symbols.Other; defined = false } in
     E.mk_term sy [] Ty.Tbool
 
   let get_proxy_of f proxies_mp =

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -85,7 +85,7 @@ type t =
   | True
   | False
   | Void
-  | Name of Hstring.t * name_kind * bool
+  | Name of { hs : Hstring.t ; kind : name_kind ; defined : bool }
   | Int of Z.t
   | Real of Q.t
   | Bitv of int * Z.t
@@ -100,7 +100,7 @@ type t =
 type s = t
 
 let name ?(kind=Other) ?(defined=false) s =
-  Name (Hstring.make s, kind, defined)
+  Name { hs = Hstring.make s ; kind ; defined }
 
 let var s = Var s
 let int i = Int (Z.of_string i)
@@ -127,12 +127,12 @@ let mk_in b1 b2 =
 let mk_maps_to x = MapsTo x
 
 let is_ac x = match x with
-  | Name(_, Ac, _) -> true
+  | Name { kind = Ac; _ } -> true
   | _           -> false
 
 let is_internal sy =
   match sy with
-  | Name (hs, _, _) ->
+  | Name { hs; _ } ->
     let s = Hstring.view hs in
     Stdcompat.String.starts_with ~prefix:"." s ||
     Stdcompat.String.starts_with ~prefix:"@" s
@@ -221,7 +221,7 @@ let compare s1 s2 =
       | Int z1, Int z2 -> Z.compare z1 z2
       | Real h1, Real h2 -> Q.compare h1 h2
       | Var v1, Var v2 | MapsTo v1, MapsTo v2 -> Var.compare v1 v2
-      | Name (h1, k1, _), Name (h2, k2, _) ->
+      | Name { hs = h1; kind = k1; _ }, Name { hs = h2; kind = k2; _ } ->
         let c = Hstring.compare h1 h2 in
         if c <> 0 then c else compare_kinds k1 k2
       | Bitv (n1, s1), Bitv (n2, s2) ->
@@ -250,8 +250,8 @@ let hash x =
   | Let -> 3
   | Bitv (n, s) -> 19 * (Hashtbl.hash n + Hashtbl.hash s) + 3
   | In (b1, b2) -> 19 * (Hashtbl.hash b1 + Hashtbl.hash b2) + 4
-  | Name (n, Ac, _) -> 19 * Hstring.hash n + 5
-  | Name (n, Other, _) -> 19 * Hstring.hash n + 6
+  | Name { hs = n; kind = Ac; _ } -> 19 * Hstring.hash n + 5
+  | Name { hs = n; kind = Other; _ } -> 19 * Hstring.hash n + 6
   | Int z -> 19 * Z.hash z + 7
   | Real n -> 19 * Hashtbl.hash n + 7
   | Var v -> 19 * Var.hash v + 8
@@ -373,7 +373,7 @@ module AEPrinter = struct
     | True -> Fmt.pf ppf "true"
     | False -> Fmt.pf ppf "false"
     | Void -> Fmt.pf ppf "void"
-    | Name (n, _, _) -> pp_name ppf (Hstring.view n)
+    | Name { hs = n; _ } -> pp_name ppf (Hstring.view n)
     | Var v when show_vars -> Fmt.pf ppf "'%s'" (Var.to_string v)
     | Var v -> Fmt.string ppf (Var.to_string v)
 
@@ -503,11 +503,11 @@ let fresh_skolem_name base = name (fresh_skolem_string base)
 let make_as_fresh_skolem str = name (SkolemId.make_as_fresh str)
 
 let is_fresh_internal_name = function
-  | Name (hd, _, _) -> InternalId.is_id (Hstring.view hd)
+  | Name { hs = hd; _ } -> InternalId.is_id (Hstring.view hd)
   | _ -> false
 
 let is_fresh_skolem = function
-  | Name (hd, _, _) -> SkolemId.is_id (Hstring.view hd)
+  | Name { hs = hd; _ } -> SkolemId.is_id (Hstring.view hd)
   | _ -> false
 
 let is_get f = equal f (Op Get)

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -84,7 +84,7 @@ type t =
   | True
   | False
   | Void
-  | Name of Hstring.t * name_kind * bool
+  | Name of { hs : Hstring.t ; kind : name_kind ; defined : bool }
   | Int of Z.t
   | Real of Q.t
   | Bitv of int * Z.t


### PR DESCRIPTION
Main goal is to make it clear from usage what the boolean parameter is for.