### PR TITLE
fix(AC): Abstract AC arguments that contain other AC symbols

### DIFF
--- a/src/lib/reasoners/ac.ml
+++ b/src/lib/reasoners/ac.ml
@@ -192,7 +192,13 @@ module Make (X : Sig.X) = struct
      correctness of the corresponding abstraction process has not been proven.
      See also https://github.com/OCamlPro/alt-ergo/issues/989
 
-     [1]: https://arxiv.org/pdf/1207.3262.pdf *)
+     [1]: Canonized Rewriting and Ground AC Completion Modulo Shostak Theories:
+            Design and Implementation.
+          Sylvain Conchon, Evelyne Contejean, Mohamed Iguernelala.
+          lmcs:1034 - Logical Methods in Computer Science, September 14, 2012,
+            Volume 8, Issue 3.
+          doi:10.2168/LMCS-8(3:16)2012
+          https://arxiv.org/pdf/1207.3262.pdf *)
   let abstract2 sy t r acc =
     if List.exists (is_other_ac_symbol sy) (X.leaves r) then
       match X.ac_extract r, Expr.term_view t with

--- a/src/lib/reasoners/ac.ml
+++ b/src/lib/reasoners/ac.ml
@@ -163,25 +163,60 @@ module Make (X : Sig.X) = struct
   let fold_flatten sy f =
     List.fold_left (fun z (rt,n) -> flatten sy ((f rt),n) z) []
 
-  let abstract2 sy t r acc =
+  let is_other_ac_symbol sy r =
     match X.ac_extract r with
-    | Some ac when Sy.equal sy ac.h -> r, acc
-    | None -> r, acc
-    | Some _ -> match Expr.term_view t with
-      | { Expr.f = Sy.Name { hs; kind = Sy.Ac; _ }; xs; ty; _ } ->
+    | Some ac -> not (Sy.equal sy ac.h)
+    | None -> false
+
+  (* This implements a variant of the term abstraction process described in
+     section 6 of the AC(X) paper [1].
+
+     The abstraction process given in the paper requires to abstract all AC
+     symbols appearing in a non-AC context, but the implementation does not
+     know about the context at the time the abstraction is performed (note that
+     rules Abstract1 and Abstract2 are concerned with *equations* while the
+     abstraction process here occurs at the time of building semantic values,
+     which is earlier). Further, the implementation seems to implicitly rely on
+     term ordering (older terms are ordered before newer terms, so in
+     particular subterms are always smaller than terms that contains them) to
+     cheaply prevent loops rather than introducing all the abstracted variables
+     that the theoretical presentation in the paper would require.
+
+     So the implementation below of the Abstract2 rules deviates from the
+     presentation in the paper to accomodate those differences, globally,
+     between the implementation and theoretical description of AC(X).
+
+     More precisely, `abstract2` will abstract terms that *contain* AC leaves
+     when they appear as argument of an AC symbol. This ensures that AC terms
+     satisfy the T_AC definition from page 22 of the paper, although
+     correctness of the corresponding abstraction process has not been proven.
+     See also https://github.com/OCamlPro/alt-ergo/issues/989
+
+     [1]: https://arxiv.org/pdf/1207.3262.pdf *)
+  let abstract2 sy t r acc =
+    if List.exists (is_other_ac_symbol sy) (X.leaves r) then
+      match X.ac_extract r, Expr.term_view t with
+      | Some ac, { f = Name { hs; kind = Ac; _ } ; xs; ty; _ } ->
+        (* It should have been abstracted when building [r] *)
+        assert (not (Sy.equal sy ac.h));
         let aro_sy = Sy.name ~ns:Internal ("@" ^ (HS.view hs)) in
         let aro_t = Expr.mk_term aro_sy xs ty  in
         let eq = Expr.mk_eq ~iff:false aro_t t in
         X.term_embed aro_t, eq::acc
-      | { Expr.f = Sy.Op Sy.Mult; xs; ty; _ } ->
+      | Some ac, { f = Op Mult; xs; ty; _ } ->
+        (* It should have been abstracted when building [r] *)
+        assert (not (Sy.equal sy ac.h));
         let aro_sy = Sy.name ~ns:Internal "@*" in
         let aro_t = Expr.mk_term aro_sy xs ty  in
         let eq = Expr.mk_eq ~iff:false aro_t t in
         X.term_embed aro_t, eq::acc
-      | { Expr.ty; _ } ->
+      | _, { ty; _ } ->
         let k = Expr.fresh_name ty in
         let eq = Expr.mk_eq ~iff:false k t in
         X.term_embed k, eq::acc
+
+    else
+      r, acc
 
   let make t =
     match Expr.term_view t with

--- a/tests/issues/964.ae
+++ b/tests/issues/964.ae
@@ -1,0 +1,4 @@
+logic ac u : int, int -> int
+logic ac v : int, int -> int
+
+goal g : v(0, 1) = u(-v(0, 1), 2)

--- a/tests/issues/964.expected
+++ b/tests/issues/964.expected
@@ -1,0 +1,2 @@
+
+unknown


### PR DESCRIPTION
This patch implements a variation of the abstraction mechanism described in the AC(X) paper. This should hopefully ensure that we can't create substitution cycles due to improper term ordering.

Note that the issue is related to comparing distinct AC symbols: when the AC symbols are identical, the AC theory uses a multiset ordering on its argument, which prevent substitution cycles. But when the AC symbols are different, only the symbols are compared, not the arguments, and so we must rely on the abstraction mechanism to prevent cycles.

This is a do-over of https://github.com/OCamlPro/alt-ergo/pull/974 that should be closer in spirit to the implementation of the paper and without the associated regressions (based upon a manual inspection; will re-run the benchmarks).

Fixes #964