### PR TITLE
cleanup: Remove "fake" symbols and trigger guards

### DIFF
--- a/src/lib/frontend/cnf.ml
+++ b/src/lib/frontend/cnf.ml
@@ -170,60 +170,13 @@ let rec make_term quant_basename t =
 
 
 and make_trigger ~in_theory name quant_basename hyp (e, from_user) =
-  let content, guard = match e with
-    | [({ c = { tt_desc = TTapp(s, t1::t2::l); _ }; _ }
-        : (_ Typed.tterm, _) Typed.annoted)]
-      when Sy.equal s Sy.fake_eq ->
-      let trs = List.filter (fun t -> not (List.mem t l)) [t1; t2] in
-      let trs = List.map (make_term quant_basename) trs in
-      let lit =
-        E.mk_eq ~iff:true
-          (make_term quant_basename t1)
-          (make_term quant_basename t2)
-      in
-      trs, Some lit
-
-    | [{ c = { tt_desc = TTapp(s, t1::t2::l); _ }; _ }]
-      when Sy.equal s Sy.fake_neq ->
-      let trs = List.filter (fun t -> not (List.mem t l)) [t1; t2] in
-      let trs = List.map (make_term quant_basename) trs in
-      let lit =
-        E.mk_distinct ~iff:true
-          [make_term quant_basename t1;
-           make_term quant_basename t2]
-      in
-      trs, Some lit
-
-    | [{ c = { tt_desc = TTapp(s, t1::t2::l); _ }; _ }]
-      when Sy.equal s Sy.fake_le ->
-      let trs = List.filter (fun t -> not (List.mem t l)) [t1; t2] in
-      let trs = List.map (make_term quant_basename) trs in
-      let lit =
-        E.mk_builtin ~is_pos:true Sy.LE
-          [make_term quant_basename t1;
-           make_term quant_basename t2]
-      in
-      trs, Some lit
-
-    | [{ c = { tt_desc = TTapp(s, t1::t2::l); _ }; _ }]
-      when Sy.equal s Sy.fake_lt ->
-      let trs = List.filter (fun t -> not (List.mem t l)) [t1; t2] in
-      let trs = List.map (make_term quant_basename) trs in
-      let lit =
-        E.mk_builtin ~is_pos:true Sy.LT
-          [make_term quant_basename t1;
-           make_term quant_basename t2]
-      in
-      trs, Some lit
-
-    | lt -> List.map (make_term quant_basename) lt, None
-  in
+  let content = List.map (make_term quant_basename) e in
   let t_depth =
     List.fold_left (fun z t -> max z (E.depth t)) 0 content in
   (* clean trigger:
      remove useless terms in multi-triggers after inlining of lets*)
   let trigger =
-    { E.content ; guard ; t_depth; semantic = []; (* will be set by theories *)
+    { E.content ; t_depth; semantic = []; (* will be set by theories *)
       hyp; from_user;
     }
   in

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2369,21 +2369,18 @@ let new_facts_for_axiom
               ~function_name:"new_facts_for_axiom"
               "try to extend synt sbt %a of ax %a@ "
               (Var.Map.print E.print) sbs E.print orig;
-          match tr.E.guard with
-          | Some _ -> assert false (*guards not supported for TH axioms*)
-
-          | None when tr.E.semantic == [] && not do_syntactic_matching ->
+          if tr.E.semantic == [] && not do_syntactic_matching then
             (* pure syntactic insts already generated *)
             env, acc
 
-          | None when not (terms_linear_dep env torig) ->
+          else if not (terms_linear_dep env torig) then (
             if get_debug_fpa () >= 2 then
               Printer.print_dbg
                 ~header:false
                 "semantic matching failed(1)";
             env, acc
 
-          | None ->
+          ) else
             match semantic_matching lem_name tr s env uf optimized with
             | env, None ->
               if get_debug_fpa () >= 2 then

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -100,7 +100,6 @@ and trigger = {
   hyp : t list;
   t_depth : int;
   from_user : bool;
-  guard : t option
 }
 
 type expr = t
@@ -1350,15 +1349,11 @@ let rec apply_subst_aux (s_t, s_ty) t =
       | _ ->
         mk_term f xs' ty'
 
-and apply_subst_trigger subst ({ content; guard; _ } as tr) =
+and apply_subst_trigger subst ({ content; _ } as tr) =
   {tr with
    content = List.map (apply_subst_aux subst) content;
    (* semantic_trigger = done on theory side *)
    (* hyp = done on theory side *)
-   guard =
-     match guard with
-     | None -> guard
-     | Some g -> Some (apply_subst_aux subst g)
   }
 
 (* *1* We should never subst formulas inside termes. We could allow to
@@ -1638,7 +1633,6 @@ let resolution_triggers ~is_back { kind; main = f; binders; _ } =
             semantic = [];
             t_depth = t.depth;
             from_user = false;
-            guard = None
           } ]
     | Dtheory -> []
     | Daxiom
@@ -1660,7 +1654,6 @@ let resolution_triggers ~is_back { kind; main = f; binders; _ } =
                semantic = [];
                t_depth = t.depth;
                from_user = false;
-               guard = None
              } :: acc
         )cand []
 
@@ -2255,7 +2248,6 @@ module Triggers = struct
            semantic = [];
            hyp = [];
            from_user = false;
-           guard = None;
            t_depth = List.fold_left (fun z t -> max z (depth t)) 0 content
          }
       ) l

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -98,7 +98,6 @@ and trigger = (*private*) {
   hyp : t list;
   t_depth : int;
   from_user : bool;
-  guard : t option
 }
 
 module Set : Set.S with type elt = t

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -514,14 +514,6 @@ let is_fresh_skolem = function
 let is_get f = equal f (Op Get)
 let is_set f = equal f (Op Set)
 
-
-let fake_eq  =  name "@eq"
-let fake_neq =  name "@neq"
-let fake_lt  =  name "@lt"
-let fake_le  =  name "@le"
-
-
-
 module Labels = Hashtbl.Make(struct
     type t = s
     let equal = equal

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -151,12 +151,6 @@ val is_fresh_skolem : t -> bool
 val is_get : t -> bool
 val is_set : t -> bool
 
-val fake_eq  : t
-val fake_neq : t
-val fake_lt  : t
-val fake_le  : t
-
-
 val add_label : Hstring.t -> t -> unit
 val label : t -> Hstring.t
 


### PR DESCRIPTION
The `fake_eq`, `fake_neq`, `fake_le` and `fake_lt` were used in trigger computation somehow, but this was removed in five yers ago in aebf5ac7437b57aacc6aa6389e237c6968a3a84f and are unused since.

These were the only use of the `gard` field in triggers, which is now also unused.