### PR TITLE
cleanup: Remove one layer of unique variable identifiers

### DIFF
--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -30,7 +30,7 @@
 
 (** Data structures *)
 
-type binders = (Ty.t * int) Var.Map.t (*int tag in globally unique *)
+type binders = Ty.t Var.Map.t
 
 type t
 

--- a/src/lib/structures/var.ml
+++ b/src/lib/structures/var.ml
@@ -87,7 +87,9 @@ let compare a b =
 
 let equal a b = compare a b = 0
 
-let hash { id; _ } = id
+let uid { id; _ } = id
+
+let hash = uid
 
 (* Note: there is a single [Underscore] variable, with id 1. *)
 let underscore = fresh Underscore

--- a/src/lib/structures/var.mli
+++ b/src/lib/structures/var.mli
@@ -54,6 +54,9 @@ val equal : t -> t -> bool
 
 val hash : t -> int
 
+val uid : t -> int
+(** Globally unique identifier for the variable. *)
+
 val underscore : t
 (** Unique special variable. Used to indicate fields that should be ignored in
     pattern matching and triggers. *)


### PR DESCRIPTION
Since 17877b6fd and the introduction of the `Var` module, variables already have globally unique identifiers, we don't need a second globally unique identifier associated with each globally unique identifier.