### PR TITLE
cleanup(CDCL): Minor CDCL cleanups

### DIFF
--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -83,10 +83,6 @@ module type SAT_ML = sig
   val decision_level : t -> int
   val cancel_until : t -> int -> unit
 
-  val update_lazy_cnf :
-    t ->
-    do_bcp : bool ->
-    Atom.atom option FF.Map.t -> dec_lvl:int -> unit
   val exists_in_lazy_cnf : t -> FF.t -> bool
 
   val known_lazy_formulas : t -> int FF.Map.t

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -69,7 +69,7 @@ module type SAT_ML = sig
     t ->
     Atom.atom list list -> Atom.atom list list -> E.t ->
     cnumber : int ->
-    Atom.atom option FF.Map.t -> dec_lvl:int ->
+    FF.Set.t -> dec_lvl:int ->
     unit
 
   val boolean_model : t -> Atom.atom list
@@ -1625,25 +1625,19 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       if Options.get_profiling() then Profiling.elim true
 
 
-  let update_lazy_cnf env ~do_bcp mff ~dec_lvl =
+  let update_lazy_cnf env ~do_bcp sff ~dec_lvl =
     if Options.get_cdcl_tableaux () && dec_lvl <= decision_level env then begin
       let s =
         try Util.MI.find dec_lvl env.lvl_ff
         with Not_found -> SFF.empty
       in
       let lz, s =
-        MFF.fold (fun ff lz_kd (l, s) ->
-            match lz_kd with
-            | None ->
-              assert (not (MFF.mem ff env.ff_lvl));
-              assert (not (SFF.mem ff s));
-              env.ff_lvl <- MFF.add ff dec_lvl env.ff_lvl;
-              add_form_to_lazy_cnf env l ff, SFF.add ff s
-            | Some _ ->
-              (* TODO for case 'Some a' *)
-              assert false
-
-          ) mff (env.lazy_cnf, s)
+        SFF.fold (fun ff (l, s) ->
+            assert (not (MFF.mem ff env.ff_lvl));
+            assert (not (SFF.mem ff s));
+            env.ff_lvl <- MFF.add ff dec_lvl env.ff_lvl;
+            add_form_to_lazy_cnf env l ff, SFF.add ff s
+          ) sff (env.lazy_cnf, s)
       in
       env.lazy_cnf <- lz;
       env.lvl_ff <- Util.MI.add dec_lvl s env.lvl_ff;
@@ -1682,19 +1676,19 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     env.proxies <- proxies
 
   let try_to_backjump_further =
-    let rec better_bj env mf =
+    let rec better_bj env sf =
       let old_dlvl = decision_level env in
       let old_lazy = env.lazy_cnf in
       let old_relevants = env.relevants in
       let old_tenv = env.tenv in
       let fictive_lazy =
-        MFF.fold (fun ff _ acc -> add_form_to_lazy_cnf env acc ff)
-          mf old_lazy
+        SFF.fold (fun ff acc -> add_form_to_lazy_cnf env acc ff)
+          sf old_lazy
       in
       env.lazy_cnf <- fictive_lazy;
       propagate_and_stabilize env all_propagations (ref 0) Auto;
       let new_dlvl = decision_level env in
-      if old_dlvl > new_dlvl then better_bj env mf
+      if old_dlvl > new_dlvl then better_bj env sf
       else
         begin
           assert (old_dlvl == new_dlvl);
@@ -1703,12 +1697,12 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
           env.tenv     <- old_tenv
         end
     in
-    fun env mff ->
+    fun env sff ->
       if Options.get_cdcl_tableaux () then
-        better_bj env mff
+        better_bj env sff
 
 
-  let assume env unit_cnf nunit_cnf f ~cnumber mff ~dec_lvl =
+  let assume env unit_cnf nunit_cnf f ~cnumber sff ~dec_lvl =
     begin
       match unit_cnf, nunit_cnf with
       | [], [] -> ()
@@ -1729,12 +1723,12 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
             (Vec.size env.learnts);
     end;
     (* do it after add clause and before T-propagate, disable bcp*)
-    update_lazy_cnf env ~do_bcp:false mff ~dec_lvl;
+    update_lazy_cnf env ~do_bcp:false sff ~dec_lvl;
     (* do bcp globally *)
     propagate_and_stabilize env all_propagations (ref 0) Auto;
     if dec_lvl > decision_level env then
       (*dec_lvl <> 0 and a bj have been made*)
-      try_to_backjump_further env mff
+      try_to_backjump_further env sff
 
   let exists_in_lazy_cnf env f' =
     not (Options.get_cdcl_tableaux ()) ||

--- a/src/lib/reasoners/satml.mli
+++ b/src/lib/reasoners/satml.mli
@@ -79,11 +79,6 @@ module type SAT_ML = sig
   val decision_level : t -> int
   val cancel_until : t -> int -> unit
 
-  val update_lazy_cnf :
-    t ->
-    do_bcp : bool ->
-    Satml_types.Atom.atom option Flat_Formula.Map.t -> dec_lvl:int -> unit
-
   val exists_in_lazy_cnf : t -> Flat_Formula.t -> bool
   val known_lazy_formulas : t -> int Flat_Formula.Map.t
 

--- a/src/lib/reasoners/satml.mli
+++ b/src/lib/reasoners/satml.mli
@@ -65,7 +65,7 @@ module type SAT_ML = sig
     Satml_types.Atom.atom list list ->
     Expr.t ->
     cnumber : int ->
-    Satml_types.Atom.atom option Flat_Formula.Map.t -> dec_lvl:int ->
+    Flat_Formula.Set.t -> dec_lvl:int ->
     unit
 
   val boolean_model : t -> Satml_types.Atom.atom list

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -729,7 +729,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
   type pending = {
     seen_f : SE.t;
-    activate : Atom.atom option FF.Map.t;
+    activate : FF.Set.t;
     new_vars : Atom.var list;
     unit : Atom.atom list list;
     nunit : Atom.atom list list;
@@ -756,7 +756,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
           if SAT.exists_in_lazy_cnf env.satml ff then acc
           else
             {acc with
-             activate = FF.Map.add ff None acc.activate;
+             activate = FF.Set.add ff acc.activate;
              updated = true}
       with Not_found ->
         Debug.assume gf;
@@ -798,7 +798,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
             if SAT.exists_in_lazy_cnf env.satml ff then acc
             else
               {acc with
-               activate = FF.Map.add ff None acc.activate;
+               activate = FF.Set.add ff acc.activate;
                updated = true}
           else
             let ff_abstr,new_proxies,proxies_mp, new_vars =
@@ -813,7 +813,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
                new_vars;
                nunit;
                unit = [ff_abstr] :: acc.unit;
-               activate = FF.Map.add ff None acc.activate;
+               activate = FF.Set.add ff acc.activate;
                updated = true
               }
             in
@@ -830,7 +830,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     fprintf fmt "pending : updated = %b@." updated;
   *)
     if SE.is_empty seen_f then begin
-      assert (FF.Map.is_empty activate);
+      assert (FF.Set.is_empty activate);
       assert (new_vars == []);
       assert (unit == []);
       assert (nunit == []);
@@ -852,7 +852,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
   let assume_aux_bis ~dec_lvl env l : bool * Atom.atom list =
     let pending = {
-      seen_f = SE.empty; activate = FF.Map.empty;
+      seen_f = SE.empty; activate = FF.Set.empty;
       new_vars = []; unit = []; nunit = []; updated = false;
       new_abstr_vars = [];
     }

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -845,7 +845,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
         let nbv = FF.nb_made_vars env.ff_hcons_env in
         let unit, nunit = SAT.new_vars env.satml ~nbv new_vars unit nunit in
         (*update_lazy_cnf done inside assume at the right place *)
-        (*SAT.update_lazy_cnf activate ~dec_lvl;*)
         SAT.assume env.satml unit nunit f ~cnumber:0 activate ~dec_lvl;
       with
       | Satml.Unsat (lc) -> raise (IUnsat (env, make_explanation lc))


### PR DESCRIPTION
Removes a bit of dead code and change a type from `Atom.atom option Map.t` to `Set.t` since all the values in the `Map` are always `None` (and having anything else would cause an assertion failure anyways).