### PR TITLE
cleanup(Shostak): Remove unused SXS and MXS

### DIFF
--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -852,11 +852,3 @@ module MXH =
 (** set of semantic values using Combine.hash_cmp *)
 module SXH =
   Set.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)
-
-(** map of semantic values using structural compare Combine.str_cmp *)
-module MXS =
-  Map.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)
-
-(** set of semantic values using structural compare Combine.str_cmp *)
-module SXS =
-  Set.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)

--- a/src/lib/reasoners/shostak.mli
+++ b/src/lib/reasoners/shostak.mli
@@ -66,9 +66,3 @@ module MXH : Map.S with type key = Combine.r
 
 (** set of semantic values using Combine.hash_cmp *)
 module SXH : Set.S with type elt = Combine.r
-
-(** map of semantic values using structural compare Combine.str_cmp *)
-module MXS : Map.S with type key = Combine.r
-
-(** set of semantic values using structural compare Combine.str_cmp *)
-module SXS : Set.S with type elt = Combine.r


### PR DESCRIPTION
We lie about Shostak.SXS and Shostak.MXS using structural comparisons when they are actually using the hash comparison. Since they are incidentally also unused, this patch removes them.