### PR TITLE
Wrong destructor for mutually recursive ADT

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1081,18 +1081,19 @@ let rec mk_expr
 
           | B.Destructor { case; field; adt; _ }, [x] ->
             begin match DT.definition adt with
-              | Some (Adt { cases; record; _ }) ->
+              | Some (Adt { cases;  _ }) ->
                 begin match cases.(case).dstrs.(field) with
                   | Some { path; _ } ->
                     let name = get_basename path in
                     let ty = dty_to_ty term_ty in
                     let e = aux_mk_expr x in
                     let sy =
-                      if record || Array.length cases = 1
-                      then
+                      match Cache.find_ty (DE.Ty.Const.hash adt) with
+                      | Trecord _ ->
                         Sy.Op (Sy.Access (Hstring.make name))
-                      else
+                      | Tadt _ ->
                         Sy.destruct ~guarded:true name
+                      | _ -> assert false
                     in
                     E.mk_term sy [e] ty
                   | _ ->

--- a/src/lib/structures/ty.mli
+++ b/src/lib/structures/ty.mli
@@ -175,7 +175,7 @@ val t_adt :
   ?body: ((string * (string * t) list) list) option ->
   string -> t list ->
   t
-(** Crearte and algebraic datatype. The body is a list of
+(** Create an algebraic datatype. The body is a list of
     constructors, where each constructor is associated with the list of
     its destructors with their respective types. If [body] is none,
     then no definition will be registered for this type. The second


### PR DESCRIPTION
The new Dolmen frontend didn't create the correct destructor in presence of mutually recursive ADT. For instance the input:
```smt2
(set-logic ALL)
(declare-datatypes ((Data1 0) (Data2 0))
  (
    ((cons1 (d1 Int) (d2 Data2)))
    (
      (cons2 (d3 Data1))
      (cons3)
    )
  )
)
(declare-const a Data1)
(declare-const b Data2)
(declare-const x Int)
(assert ((_ is cons1) a))
(assert ((_ is cons3) b))
(assert (= (d1 a) x))
(check-sat)
```
raised an assertion in the record theory.
The presence of a flaw in a test of `d_cnf` to discriminate between records and ADT produced `Sy.Access` destructors intead of `Sy.Destructor` destructors on some terms whose the type is a mutually recursive ADT. For instance `d1 a` was translated into `mk_term Sy.Access [a] ...`.

The fix consists in using the cache of AE types in `d_cnf` to discriminate between records and ADT.

Notice that the legacy frontend parses the previous file correctly.