### PR TITLE
fix(CDCL): Fix and document `pop` assertion

### DIFF
--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -1974,7 +1974,11 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         (* all previous guards are decided *)
         env.next_dec_guard <- Vec.size env.increm_guards
       end
-    else (assert (env.next_dec_guard = 0));
+    else
+      (* We are not decided, so the `next_dec_guard` should point to an
+         earlier guard or we have a bug because guards must be decided in
+         the `increm_guards` order. *)
+      assert (env.next_dec_guard <= Vec.size env.increm_guards);
     enqueue env g.neg 0 None
 
   let optimize env ~is_max obj = env.tenv <- Th.optimize env.tenv ~is_max obj


### PR DESCRIPTION
All guards are decided at the beginning of the search process, and so when popping we should be in one of two states: either all guards have been decided (we started the search) or none are (we did not start the search). This is what the assertion tries to ensure (if it is not the case, there is probably a bug).

However, with incremental solving, the assertion is not right: if we do push, push, solve, pop, push, and finally pop, the first pop will reset the solver to a state where the first guard is decided, and after the last push, the first guard is decided and the second is not.

This would be valid behavior, and so this patch modifies (and documents) the assertion to instead check that the next guard is actually a guard (in range of the `increm_guards` vector).