### PR TITLE
Removing exhaustive exception catch in satml_frontend

### DIFF
--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1275,11 +1275,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
       end;
       dep
     | (Util.Timeout | I_dont_know ) as e -> raise e
-    | e ->
-      Printer.print_dbg
-        ~module_name:"Satml_frontend" ~function_name:"unsat"
-        "%s" (Printexc.to_string e);
-      assert false
 
   let assume env gf _dep =
     (* dep currently not used. No unsat-cores in satML yet *)

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1274,7 +1274,6 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
           )dep true
       end;
       dep
-    | (Util.Timeout | I_dont_know ) as e -> raise e
 
   let assume env gf _dep =
     (* dep currently not used. No unsat-cores in satML yet *)


### PR DESCRIPTION
This catch breaks the call stack tracking; the frontend and the binary already handles the exceptions, no need to to it at the reasoner level.