### PR TITLE
Removing testers in the ADT Shostak theory

### DIFF
--- a/src/lib/reasoners/adt.mli
+++ b/src/lib/reasoners/adt.mli
@@ -32,8 +32,6 @@ type 'a abstract =
   | Constr of
       { c_name : Hstring.t ; c_ty : Ty.t ; c_args : (Hstring.t * 'a) list }
   | Select of { d_name : Hstring.t ; d_ty : Ty.t ; d_arg : 'a }
-  | Tester of { t_name : Hstring.t ; t_arg : 'a }
-  (* tester is currently not used to build values *)
 
   | Alien of 'a
 

--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -297,7 +297,7 @@ let deduce_is_constr uf r h eqs env ex =
         Printer.print_err "%a" X.print r;
         assert false
     end
-  | Constr _ | Tester _ | Select _ -> env, eqs
+  | Constr _ | Select _ -> env, eqs
 
 (* Collect all the constructors of the ADT type [ty]. *)
 let values_of ty =
@@ -552,7 +552,7 @@ let assume_is_constr uf hs r dep env eqs =
 
   | Adt.Constr _ -> env, eqs
 
-  | Adt.Tester _ | Adt.Select _ ->
+  | Adt.Select _ ->
     (* We never call this function on such semantic values. *)
     assert false
 


### PR DESCRIPTION
We don't need to build tester semantic values. Testers are managed by the ADT Relation theory and the Shostak `solve` function has nothing to do on testers. This commit removes them completely.