### PR TITLE
Copy the ocp-checker binary even if one already exists

### DIFF
--- a/rsc/extra/ocpchecker/Makefile
+++ b/rsc/extra/ocpchecker/Makefile
@@ -1,7 +1,7 @@
 
 bin:
 	@dune build ocp_checker.exe
-	@cp ../../../_build/default/rsc/extra/ocpchecker/ocp_checker.exe ocp-checker
+	@cp -f ../../../_build/default/rsc/extra/ocpchecker/ocp_checker.exe ocp-checker
 
 clean:
 	rm -f ocp-checker


### PR DESCRIPTION
No more "cp: cannot create regular file 'ocp-checker': Permission denied".