### PR TITLE
fix(arith): Do not overly tighten bounds over infinite domains

### DIFF
--- a/tests/issues/777.models.expected
+++ b/tests/issues/777.models.expected
@@ -1,5 +1,5 @@
 
 unknown
 (
-  (define-fun i () Int 2)
+  (define-fun i () Int 1)
 )

--- a/tests/models/uf/uf2.models.expected
+++ b/tests/models/uf/uf2.models.expected
@@ -1,7 +1,7 @@
 
 unknown
 (
-  (define-fun f ((arg_0 Int)) Int (ite (= arg_0 (- 2)) 0 2))
+  (define-fun f ((arg_0 Int)) Int (ite (= arg_0 (- 1)) 0 1))
   (define-fun a () Int 0)
-  (define-fun b () Int (- 2))
+  (define-fun b () Int (- 1))
 )


### PR DESCRIPTION
Model generation for arithmetic constraints proceeds in two stages:

 - In the first stage, we only choose a value for variables that are within a finite domain (i.e. integer variables bounded from both above and below). This is the behavior of regular case splits, and happens in function `default_case_split`.

 - In the second stage, which we only reach if model generation is enabled, we must select a value for all variables. In this case, we select one interval for variables that can have multiple intervals (recall that we model arithmetic domains using unions of intervals). This happens in function `case_split_union_of_intervals`. If the selected interval is finite, we go back to the first stage in the next case split.

 - In the final stage, all remaining variables have infinite intervals as domains, and we must now pick a value for these. This happens in `model_from_unbounded_domains` -- even though for rational variables, the domain can still be bounded. For integers however, infinite intervals mean that they lack either a finite lower or upper bound (or both). For integers, we create a new simplex environment in `fm_simplex_unbounded_integers_encoding` where we adjust the bounds by a factor of half the sum of the absolute values of the coefficients. This means that an inequality `0 < 3x + 4y` becomes `0 + (3 + 4) / 2 < 3x + 4y`, i.e. `3.5 < 3x + 4y`. This removes `x = 1, y = 0` from the domain. On its own, this would be correct (albeit strange) because after removing a finite number of elements from an infinite domain there is still an infinite number of elements to choose from. But within a larger system this can (and is) problematic.

This patch removes the "adjustment" of the bounds which is not justified and actually causes unsoundness.

Fixes #1022