### PR TITLE
feat(CDCL): Add ability to decide on semantic literals

### DIFF
--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -272,7 +272,7 @@ module Debug = struct
            ~doc:full_doc)
 end
 
-let mk_case_split_opt case_split_policy enable_adts_cs max_split
+let mk_case_split_opt case_split_policy enable_adts_cs max_split ()
   =
   let res =
     match case_split_policy with
@@ -577,6 +577,14 @@ let parse_case_split_opt =
     let doc = "Enable case-split for Algebraic Datatypes theory." in
     Arg.(value & flag & info ["enable-adts-cs"] ~docs ~doc) in
 
+  let enable_sat_cs =
+    let doc = "Enable case-split in the SAT solver (Experts only)" in
+    Term.(
+      const set_enable_sat_cs $
+      Arg.(value & flag & info ["enable-sat-cs"] ~docs ~doc)
+    )
+  in
+
   let max_split =
     let dv = Numbers.Q.to_string (get_max_split ()) in
     let doc =
@@ -585,7 +593,7 @@ let parse_case_split_opt =
     Arg.(value & opt string dv & info ["max-split"] ~docv ~docs ~doc) in
 
   Term.(ret (const mk_case_split_opt $
-             case_split_policy $ enable_adts_cs $ max_split))
+             case_split_policy $ enable_adts_cs $ max_split $ enable_sat_cs))
 
 let parse_context_opt =
 

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -55,7 +55,7 @@
     ; structures
     Commands Errors Explanation Fpa_rounding
     Parsed Profiling Satml_types Symbols
-    Expr Var Ty Typed Xliteral ModelMap Id Objective
+    Expr Var Ty Typed Xliteral ModelMap Id Objective Literal
     ; util
     Emap Gc_debug Hconsing Hstring Heap Lists Loc
     MyUnix Numbers

--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -267,7 +267,7 @@ let deduce_is_constr uf r h eqs env ex =
                 ~module_name:"Adt_rel"
                 ~function_name:"deduce_is_constr"
                 "%a" E.print is_c;
-            (Sig_rel.LTerm is_c, ex, Th_util.Other) :: eqs
+            (Literal.LTerm is_c, ex, Th_util.Other) :: eqs
         in
         begin
           match E.term_view t with
@@ -291,7 +291,7 @@ let deduce_is_constr uf r h eqs env ex =
                 ~module_name:"Adt_rel"
                 ~function_name:"deduce equal to constr"
                 "%a" E.print eq;
-            let eqs = (Sig_rel.LTerm eq, ex, Th_util.Other) :: eqs in
+            let eqs = (Literal.LTerm eq, ex, Th_util.Other) :: eqs in
             env, eqs
           | _ -> env, eqs
         end
@@ -407,7 +407,7 @@ let add_guarded_destr env uf t hs e t_ty =
   let r_e, ex_e = try Uf.find uf e with Not_found -> assert false in
   if trivial_tester r_e c || seen_tester r_e c env then
     {env with pending_deds =
-                (Sig_rel.LTerm eq, ex_e, Th_util.Other) :: env.pending_deds}
+                (Literal.LTerm eq, ex_e, Th_util.Other) :: env.pending_deds}
   else
     let m_e = try MX.find r_e env.selectors with Not_found -> MHs.empty in
     let old = try MHs.find c m_e with Not_found -> [] in
@@ -570,7 +570,7 @@ let assume_is_constr uf hs r dep env eqs =
       let eqs =
         List.fold_left
           (fun eqs (ded, dep') ->
-             (Sig_rel.LTerm ded, Ex.union dep dep', Th_util.Other) :: eqs
+             (Literal.LTerm ded, Ex.union dep dep', Th_util.Other) :: eqs
           )eqs deds
       in
       let env = update_tester r hs env in
@@ -710,7 +710,7 @@ let update_cs_modulo_eq r1 r2 ex env eqs =
                  X.print r2 Hs.print hs;
              List.iter
                (fun (a, dep) ->
-                  eqs := (Sig_rel.LTerm a, dep, Th_util.Other) :: !eqs) l;
+                  eqs := (Literal.LTerm a, dep, Th_util.Other) :: !eqs) l;
            end;
            let l = List.rev_map (fun (a, dep) -> a, Ex.union ex dep) l in
            MHs.add hs l mhs
@@ -791,7 +791,7 @@ let assume env uf la =
     Debug.print_env "after assume" env;
     let print fmt (a,_,_) =
       match a with
-      | Sig_rel.LTerm a -> Format.fprintf fmt "%a" E.print a;
+      | Literal.LTerm a -> Format.fprintf fmt "%a" E.print a;
       | _ -> assert false
     in
     if Options.get_debug_adt () then

--- a/src/lib/reasoners/arrays_rel.ml
+++ b/src/lib/reasoners/arrays_rel.ml
@@ -426,7 +426,7 @@ let assume env uf la =
   Debug.new_equalities atoms;
   let l =
     Conseq.fold (fun (a,ex) l ->
-        ((Sig_rel.LTerm a, ex, Th_util.Other)::l)) atoms []
+        ((Literal.LTerm a, ex, Th_util.Other)::l)) atoms []
   in
   env, { Sig_rel.assume = l; remove = [] }
 

--- a/src/lib/reasoners/bitv_rel.ml
+++ b/src/lib/reasoners/bitv_rel.ml
@@ -619,7 +619,7 @@ let assume env uf la =
       raise @@ Ex.Inconsistent (ex, Uf.cl_extract uf)
   in
   let assume =
-    List.rev_map (fun (lit, ex) -> Sig_rel.LSem lit, ex, Th_util.Other) eqs
+    List.rev_map (fun (lit, ex) -> Literal.LSem lit, ex, Th_util.Other) eqs
   in
   let result =
     { result with assume = List.rev_append assume result.assume }

--- a/src/lib/reasoners/ccx.ml
+++ b/src/lib/reasoners/ccx.ml
@@ -273,7 +273,7 @@ module Main : S = struct
           let ex = List.fold_left2 (explain_equality env) Ex.empty xs1 xs2 in
           let a = E.mk_eq ~iff:false t1 t2 in
           Debug.congruent a ex;
-          Q.push (Sig_rel.LTerm a, ex, Th_util.Other) facts.equas
+          Q.push (Literal.LTerm a, ex, Th_util.Other) facts.equas
         with Exit -> ()
 
   let congruents env (facts: r Sig_rel.facts) t1 s =
@@ -352,7 +352,7 @@ module Main : S = struct
                    | Some (ex_r, _) ->
                      let a = E.mk_distinct ~iff:false [x; y] in
                      Debug.contra_congruence a ex_r;
-                     Q.push (Sig_rel.LTerm a, ex_r, Th_util.Other) facts.diseqs
+                     Q.push (Literal.LTerm a, ex_r, Th_util.Other) facts.diseqs
                    | None -> assert false
                  end
              | _ -> ()
@@ -615,7 +615,7 @@ module Main : S = struct
         | A.Distinct (false, lr) -> assume_dist env facts lr ex
         | A.Distinct (true, _) -> assert false
         | A.Pred _ ->
-          Q.push (Sig_rel.LSem sa, ex, orig) facts.equas;
+          Q.push (Literal.LSem sa, ex, orig) facts.equas;
           env
         | _ -> assert false
       in

--- a/src/lib/reasoners/enum_rel.ml
+++ b/src/lib/reasoners/enum_rel.ml
@@ -164,7 +164,7 @@ let add_diseq hss sm1 sm2 dep env eqs =
       if HSS.cardinal enum = 1 then
         let h' = HSS.choose enum in
         env,
-        (Sig_rel.LSem (LR.mkv_eq r (Sh.is_mine (Cons(h',ty)))),
+        (Literal.LSem (LR.mkv_eq r (Sh.is_mine (Cons(h',ty)))),
          ex, Th_util.Other)::eqs
       else env, eqs
 
@@ -177,7 +177,7 @@ let add_diseq hss sm1 sm2 dep env eqs =
         let ex = Ex.union dep ex1 in
         let h' = HSS.choose enum1 in
         let ty = X.type_info r1 in
-        (Sig_rel.LSem (LR.mkv_eq r1 (Sh.is_mine (Cons(h',ty)))),
+        (Literal.LSem (LR.mkv_eq r1 (Sh.is_mine (Cons(h',ty)))),
          ex, Th_util.Other)::eqs
       else eqs
     in
@@ -186,7 +186,7 @@ let add_diseq hss sm1 sm2 dep env eqs =
         let ex = Ex.union dep ex2 in
         let h' = HSS.choose enum2 in
         let ty = X.type_info r2 in
-        (Sig_rel.LSem (LR.mkv_eq r2 (Sh.is_mine (Cons(h',ty)))),
+        (Literal.LSem (LR.mkv_eq r2 (Sh.is_mine (Cons(h',ty)))),
          ex, Th_util.Other)::eqs
       else eqs
     in
@@ -226,7 +226,7 @@ let add_eq hss sm1 sm2 dep env eqs =
     if HSS.cardinal diff = 1 then
       let h' = HSS.choose diff in
       let ty = X.type_info r1 in
-      env, (Sig_rel.LSem (LR.mkv_eq r1 (Sh.is_mine (Cons(h',ty)))),
+      env, (Literal.LSem (LR.mkv_eq r1 (Sh.is_mine (Cons(h',ty)))),
             ex, Th_util.Other)::eqs
     else env, eqs
 

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -846,9 +846,11 @@ module Make (Th : Theory.S) = struct
                  "%a is not ground" E.print a;
                assert false
              end;
-             let facts = (a, ex, dlvl, plvl) :: facts in
+             let alit = Shostak.Literal.make (LTerm a) in
+             let facts = (alit, Th_util.Other, ex, dlvl, plvl) :: facts in
              let ufacts =
-               if Ex.has_no_bj ex then (a, ex, dlvl, plvl) :: ufacts
+               if Ex.has_no_bj ex then
+                 (alit, Th_util.Other, ex, dlvl, plvl) :: ufacts
                else ufacts
              in
              if not ff.E.mf then begin
@@ -1129,9 +1131,8 @@ module Make (Th : Theory.S) = struct
     else begin
       try
         (* also performs case-split and pushes pending atoms to CS *)
-        let model, _ =
-          Th.compute_concrete_model ~declared_ids:!(env.declare_top) env.tbox
-        in
+        let declared_ids = !(env.declare_top) in
+        let model, _ = Th.extract_concrete_model ~declared_ids env.tbox in
         env.last_saved_model := Some model;
         env
       with Ex.Inconsistent (expl, classes) ->

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -1996,9 +1996,10 @@ let case_split env uf ~for_model =
   | _ -> res
 
 (* Helper function used in [optimizing_objective] to pick a value
-   for the polynomial [p] in its interval. We use this function in the case
-   the value produced by the optimization procedure doesn't satisfy some
-   constraints that involve strict inequalities or the problem is unbounded. *)
+   for the polynomial [p] in its interval. We use this function to split the
+   search space and bias it towards the optimum in the case the value produced
+   by the optimization procedure doesn't satisfy some constraints that involve
+   strict inequalities or the problem is unbounded. *)
 let middle_value env ~is_max ty p bound =
   let interval =
     match MP0.find_opt p env.polynomes, bound with

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -552,7 +552,7 @@ module Debug = struct
   let implied_equalities l =
     if get_debug_fm () then
       let pp_literal ppf = function
-        | Sig_rel.LTerm e -> Expr.print ppf e
+        | Literal.LTerm e -> Expr.print ppf e
         | LSem ra -> LR.print ppf (LR.make ra)
       in
       let print fmt (ra, ex, _) =
@@ -2070,11 +2070,16 @@ let optimizing_objective env uf Objective.Function.{ e; is_max; _ } =
             Objective.Value.Minfinity
         in
         (* As the problem is unbounded, we need to produce a value for the
-           objective function. In this case, we pick a value in the domain
-           of the polynomial [p]. *)
+           objective function. Rather than picking a value directly, we add a
+           constraint to let the case split mechanism pick a "large" (or
+           "small") value in the interval (otherwise, later objectives are
+           computed while assuming that the middle value is forced, which is
+           incorrect). *)
         let case_split =
-          LR.mkv_eq r1 (middle_value env ~is_max ty p None), true, Th_util.CS
-            (Th_util.Th_arith, Q.one)
+          LR.mkv_builtin false LT
+            [r1; (middle_value env ~is_max ty p None)],
+          true,
+          Th_util.CS (Th_util.Th_arith, Q.one)
         in
         Some Th_util.{ value; case_split }
 

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2077,7 +2077,7 @@ let optimizing_objective env uf Objective.Function.{ e; is_max; _ } =
            incorrect). *)
         let case_split =
           LR.mkv_builtin false LT
-            [r1; (middle_value env ~is_max ty p None)],
+            [r1; middle_value env ~is_max ty p None],
           true,
           Th_util.CS (Th_util.Th_arith, Q.one)
         in

--- a/src/lib/reasoners/ite_rel.ml
+++ b/src/lib/reasoners/ite_rel.ml
@@ -172,7 +172,7 @@ let extract_pending_deductions env =
              ~module_name:"Ite_rel" ~function_name:"assume"
              "deduce that %a with expl %a"
              E.print a Ex.print ex;
-         (Sig_rel.LTerm a, ex, Th_util.Other) :: acc)
+         (Literal.LTerm a, ex, Th_util.Other) :: acc)
       env.pending_deds []
   in
   {env with pending_deds = ME2.empty}, l

--- a/src/lib/reasoners/rel_utils.ml
+++ b/src/lib/reasoners/rel_utils.ml
@@ -40,7 +40,7 @@ let assume_nontrivial_eqs
          if SR.mem sa m then acc else e :: eqs, SR.add sa m
       )([], la) eqs
   in
-  List.rev_map (fun (sa, _, ex, orig) -> Sig_rel.LSem sa, ex, orig) eqs
+  List.rev_map (fun (sa, _, ex, orig) -> Literal.LSem sa, ex, orig) eqs
 
 (* The type of delayed functions. A delayed function is given an [Uf.t] instance
    for resolving expressions to semantic values, the operator to compute, and a

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -1393,7 +1393,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
            Note that if the [fuip] is itself a semantic literal, it will act as
            a (local) learned clause (see [semantic_expansion]). *)
         let has_split = Vec.exists is_semantic lclause.atoms in
-        if has_split then (
+        if not has_split then (
           Vec.push env.learnts lclause;
           attach_clause env lclause;
           clause_bump_activity env lclause

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -1382,9 +1382,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
           Atom.make_clause name learnt vraie_form true history
         in
         (* Do not learn clauses involving semantic literals (but still record
-           them as a reason for the propagated literal), otherwise we could
-           learn stuff about these semantic literals in a scope where they are
-           no longer valid.
+           them as a reason for the propagated literal). Learned clauses are
+           valid at level 0, but semantic literals can contain terms created by
+           the Shostak module that are only useful in a portion of the search
+           tree, and in particular would not exist (in Uf) at lower levels.
 
            Note that we try to avoid semantic literals as much as possible in
            [conflict_analyze_aux], but we can still have semantic decisions

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -666,6 +666,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       Queue.clear env.tatoms_queue;
       Queue.clear env.th_tableaux;
       env.tenv <- Vec.get env.tenv_queue lvl; (* recover the right tenv *)
+      env.nchoices <- Vec.get env.nchoices_stack lvl;
       if Options.get_cdcl_tableaux () then begin
         env.lazy_cnf <- Vec.get env.lazy_cnf_queue lvl;
         env.relevants <- Vec.get env.relevants_queue lvl;

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -91,6 +91,10 @@ module type SAT_ML = sig
   type t
 
   val solve : t -> unit
+  val compute_concrete_model :
+    declared_ids:Id.typed list ->
+    t ->
+    Models.t Lazy.t * Objective.Model.t
 
   val set_new_proxies : t -> FF.proxies -> unit
 
@@ -113,7 +117,7 @@ module type SAT_ML = sig
     t -> FF.hcons_env -> Satml_types.Atom.Set.t
   val current_tbox : t -> th
   val set_current_tbox : t -> th -> unit
-  val empty : unit -> t
+  val create : Atom.hcons_env -> t
 
   val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> unit
   val decision_level : t -> int
@@ -154,6 +158,11 @@ module Vheap = Heap.Make(struct
     let compare (a : t) (b : t) = Stdlib.compare b.weight a.weight
   end)
 
+let is_semantic (a : Atom.atom) =
+  match Shostak.Literal.view a.lit with
+  | LTerm _ -> false
+  | LSem _ -> true
+
 module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
   module Matoms = Atom.Map
@@ -161,6 +170,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
   type th = Th.t
   type t =
     {
+      hcons_env : Atom.hcons_env;
+
       (* si vrai, les contraintes sont deja fausses *)
       mutable is_unsat : bool;
 
@@ -186,6 +197,15 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
       (* une pile qui pointe vers les niveaux de decision dans trail *)
       mutable trail_lim : int Vec.t;
+
+      mutable nchoices : int ;
+      (** Number of semantic choices (case splits) that have been made. Semantic
+          literals are not counted as assignments but are still part of the
+          trail; we keep track of this number to properly compute the number of
+          assignments to boolean literals in [nb_assigns]. *)
+
+      mutable nchoices_stack : int Vec.t;
+      (** Stack for [nchoices] values. *)
 
       (* Tete de la File des faits unitaires a propager.
          C'est un index vers le trail *)
@@ -368,13 +388,31 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       mutable increm_guards : Atom.atom Vec.t;
 
       mutable next_dec_guard : int;
+
+      mutable next_decisions : Atom.atom list;
+      (** Literals that must be decided on before the solver can answer [Sat].
+
+          These are added by the theory through calls to [acts_add_decision]. *)
+
+      mutable next_objective :
+        (Objective.Function.t * Objective.Value.t * Atom.atom) option;
+      (** Objective functions that must be optimized before the solver can
+          answer [Sat].
+
+          The provided [Atom.atom] correspond to a decision forcing the
+          [Function.t] to the corresponding [Value.t] (or nudging the model
+          towards "more optimal" values if the objective is not reachable); once
+          the decision is made by the solver, the optimized value is sent back
+          to the theory through [Th.add_objective]. *)
     }
 
   exception Conflict of Atom.clause
   (*module Make (Dummy : sig end) = struct*)
 
-  let empty () =
+  let create hcons_env =
     {
+      hcons_env;
+
       is_unsat = false;
 
       unsat_core = None;
@@ -395,6 +433,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       trail = Vec.make 601 ~dummy:Atom.dummy_atom;
 
       trail_lim = Vec.make 601 ~dummy:(-105);
+
+      nchoices = 0;
+
+      nchoices_stack = Vec.make 100 ~dummy:(-105);
 
       qhead = 0;
 
@@ -472,6 +514,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       increm_guards = Vec.make 1 ~dummy:Atom.dummy_atom;
 
       next_dec_guard = 0;
+
+      next_decisions = [];
+
+      next_objective = None;
     }
 
   let insert_var_order env (v : Atom.var) =
@@ -506,7 +552,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
   let decision_level env = Vec.size env.trail_lim
 
-  let nb_assigns env = Vec.size env.trail
+  let nb_choices env = env.nchoices
+  let nb_assigns env = Vec.size env.trail - nb_choices env
   let nb_clauses env = Vec.size env.clauses
   (* unused -- let nb_learnts env = Vec.size env.learnts *)
   let nb_vars    env = Vec.size env.vars
@@ -514,6 +561,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
   let new_decision_level env =
     env.decisions <- env.decisions + 1;
     Vec.push env.trail_lim (Vec.size env.trail);
+    Vec.push env.nchoices_stack env.nchoices;
     if Options.get_profiling() then
       Profiling.decision (decision_level env) "<none>";
     Vec.push env.tenv_queue env.tenv; (* save the current tenv *)
@@ -579,7 +627,9 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       a.neg.timp <- -1
     end;
     assert (a.var.level >= 0);
-    Vec.push env.trail a
+    Vec.push env.trail a;
+    if is_semantic a then
+      env.nchoices <- env.nchoices + 1
 
   let cancel_ff_lvls_until env lvl =
     for i = decision_level env downto lvl + 1 do
@@ -609,7 +659,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
           unassign_atom a;
           if a.is_guard then
             env.next_dec_guard <- env.next_dec_guard - 1;
-          insert_var_order env a.var
+          if not (is_semantic a) then
+            insert_var_order env a.var
         end
       done;
       Queue.clear env.tatoms_queue;
@@ -621,6 +672,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       end;
       Vec.shrink env.trail env.qhead;
       Vec.shrink env.trail_lim lvl;
+      Vec.shrink env.nchoices_stack lvl;
       Vec.shrink env.tenv_queue lvl;
       if Options.get_cdcl_tableaux () then begin
         Vec.shrink
@@ -635,33 +687,14 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
          env.cpt_current_propagations <- (Vec.size env.trail) - last_dec
        with _ -> assert false
       );
+      env.next_decisions <- [];
+      env.next_objective <- None
     end;
     if Options.get_profiling() then Profiling.reset_dlevel (decision_level env);
     assert (Vec.size env.trail_lim = Vec.size env.tenv_queue);
+    assert (Vec.size env.trail_lim = Vec.size env.nchoices_stack);
     assert (Options.get_minimal_bj () || (!repush == []));
     List.iter (enqueue_assigned env) !repush
-
-  let rec pick_branch_var env =
-    if Vheap.size env.order = 0 then raise Sat;
-    let v = Vheap.remove_min env.order in
-    if v.level>= 0 then begin
-      assert (v.pa.is_true || v.na.is_true);
-      pick_branch_var env
-    end
-    else v
-
-  let pick_branch_lit env =
-    if env.next_dec_guard < Vec.size env.increm_guards then
-      begin
-        let a = Vec.get env.increm_guards env.next_dec_guard in
-        (assert (not (a.neg.is_guard || a.neg.is_true)));
-        env.next_dec_guard <- env.next_dec_guard + 1;
-        a
-      end
-    else
-      let v = pick_branch_var env in
-      v.na
-
 
   let debug_enqueue_level a lvl reason =
     match reason with
@@ -700,6 +733,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     if Options.get_debug_sat () then
       Printer.print_dbg "[satml] enqueue: %a@." Atom.pr_atom a;
     Vec.push env.trail a;
+    if is_semantic a then
+      env.nchoices <- env.nchoices + 1;
     a.var.index <- Vec.size env.trail;
     if Options.get_enable_assertions() then  debug_enqueue_level a lvl reason
 
@@ -790,10 +825,32 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     end;
     Vec.shrink watched !new_sz_w
 
+  let acts_add_decision_lit env lit =
+    let atom, _ = Atom.add_lit_atom env.hcons_env lit [] in
+    if atom.var.level < 0 then (
+      assert (not atom.is_true && not atom.neg.is_true);
+      env.next_decisions <- atom :: env.next_decisions
+    ) else
+      assert (atom.is_true || atom.neg.is_true)
+
+  let acts_add_objective env fn value lit =
+    (* Note: we must store the objective even if the atom is already true,
+       because we must send back the objective to the theory afterwards.
+
+       We can't update the theory inside this function, because it is called
+       from within the theory. *)
+    let atom, _ = Atom.add_lit_atom env.hcons_env lit [] in
+    env.next_objective <- Some (fn, value, atom)
+
+  let[@inline] theory_slice env : _ Th_util.acts = {
+    acts_add_decision_lit = acts_add_decision_lit env ;
+    acts_add_objective = acts_add_objective env ;
+  }
 
   let do_case_split env origin =
     try
-      let tenv, _terms = Th.do_case_split env.tenv origin in
+      let acts = theory_slice env in
+      let tenv, _terms = Th.do_case_split ~acts env.tenv origin in
       (* TODO: terms not added to matching !!! *)
       env.tenv <- tenv;
       C_none
@@ -879,29 +936,36 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       formula that [a] was a proxy for to the [lazy_cnf] (see
       [add_form_to_lazy_cnf]). *)
   let relevancy_propagation env ma a =
-    try
-      let parents, f_a = Matoms.find a ma in
-      let ma = Matoms.remove a ma in
-      let ma =
-        MFF.fold
-          (fun fp lp ma ->
-             List.fold_left
-               (fun ma bf ->
-                  let b = get_atom_or_proxy bf env.proxies in
-                  if Atom.eq_atom a b then ma
-                  else
-                    let mf_b, fb =
-                      try Matoms.find b ma with Not_found -> assert false in
-                    assert (FF.equal bf fb);
-                    let mf_b = MFF.remove fp mf_b in
-                    if MFF.is_empty mf_b then Matoms.remove b ma
-                    else Matoms.add b (mf_b, fb) ma
-               )ma lp
-          )parents ma
-      in
-      assert (let a = get_atom_or_proxy f_a env.proxies in a.is_true);
-      add_form_to_lazy_cnf env ma f_a
-    with Not_found -> ma
+    match Shostak.Literal.view @@ Atom.literal a with
+    | LSem _ ->
+      (* Always propagate back semantic literals to the theory. *)
+      Queue.push a env.th_tableaux;
+      ma
+
+    | LTerm _ ->
+      try
+        let parents, f_a = Matoms.find a ma in
+        let ma = Matoms.remove a ma in
+        let ma =
+          MFF.fold
+            (fun fp lp ma ->
+               List.fold_left
+                 (fun ma bf ->
+                    let b = get_atom_or_proxy bf env.proxies in
+                    if Atom.eq_atom a b then ma
+                    else
+                      let mf_b, fb =
+                        try Matoms.find b ma with Not_found -> assert false in
+                      assert (FF.equal bf fb);
+                      let mf_b = MFF.remove fp mf_b in
+                      if MFF.is_empty mf_b then Matoms.remove b ma
+                      else Matoms.add b (mf_b, fb) ma
+                 )ma lp
+            )parents ma
+        in
+        assert (let a = get_atom_or_proxy f_a env.proxies in a.is_true);
+        add_form_to_lazy_cnf env ma f_a
+      with Not_found -> ma
 
 
   (* Note: although this seems to only update [env.lazy_cnf], the call to
@@ -941,7 +1005,8 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
            assert (ta.var.level >= 0);
            if ta.var.level = 0 then begin
              incr nb_f;
-             (ta.lit, Ex.empty, 0, env.cpt_current_propagations) :: acc
+             (ta.lit, Th_util.Other, Ex.empty, 0, env.cpt_current_propagations)
+             :: acc
            end
            else acc
         )[] lazy_q
@@ -996,22 +1061,26 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
             Ex.singleton (Ex.Literal ta)
           else Ex.empty
         in
-        assert (E.is_ground ta.lit);
+        assert (Shostak.Literal.is_ground ta.lit);
         let th_imp =
           if ta.timp = -1 then
-            let lit = Atom.literal a in
-            match Th.query lit env.tenv with
-            | Some _ ->
-              a.timp <- 1;
-              a.neg.timp <- 1;
-              true
-            | None ->
-              false
+            match Shostak.Literal.view @@ Atom.literal a with
+            | LSem _ -> false
+            | LTerm lit ->
+              match Th.query lit env.tenv with
+              | Some _ ->
+                a.timp <- 1;
+                a.neg.timp <- 1;
+                true
+              | None ->
+                false
           else
             ta.timp = 1
         in
         if not th_imp then
-          facts := (ta.lit, ex, dlvl,env.cpt_current_propagations) :: !facts;
+          facts :=
+            (ta.lit, Th_util.Other, ex, dlvl,env.cpt_current_propagations) ::
+            !facts;
         env.cpt_current_propagations <- env.cpt_current_propagations + 1
       done;
       if Options.get_debug_sat () then
@@ -1300,15 +1369,34 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       | [] -> assert false
       | [(fuip : Atom.atom)] ->
         fuip.var.vpremise <- history;
+        (* Note: there could potentially be semantic values that are no longer
+           valid in the union-find at level 0 contained in [fuip] if [fuip] is
+           a semantic literal, which could cause crashes -- although it is not
+           clear to me that it can really happen since if we learn it at level
+           0 it must be explainable by facts at level 0. *)
         enqueue env fuip 0 None
       | fuip :: _ ->
         let name = Atom.fresh_lname () in
         let lclause =
           Atom.make_clause name learnt vraie_form true history
         in
-        Vec.push env.learnts lclause;
-        attach_clause env lclause;
-        clause_bump_activity env lclause;
+        (* Do not learn clauses involving semantic literals (but still record
+           them as a reason for the propagated literal), otherwise we could
+           learn stuff about these semantic literals in a scope where they are
+           no longer valid.
+
+           Note that we try to avoid semantic literals as much as possible in
+           [conflict_analyze_aux], but we can still have semantic decisions
+           that would end up in clauses.
+
+           Note that if the [fuip] is itself a semantic literal, it will act as
+           a (local) learned clause (see [semantic_expansion]). *)
+        let has_split = Vec.exists is_semantic lclause.atoms in
+        if has_split then (
+          Vec.push env.learnts lclause;
+          attach_clause env lclause;
+          clause_bump_activity env lclause
+        );
         let propag_lvl = best_propagation_level env lclause in
         enqueue env fuip propag_lvl (Some lclause)
     end;
@@ -1316,6 +1404,33 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       var_decay_activity env;
       clause_decay_activity env
     end
+
+  (* If [a] is a semantic literal that is not a decision, we ideally would
+     like to replace it with its reason.
+
+     For instance, if [x = 0] is implied by [a1 /\ .. /\ an] (i.e.  the
+     reason for [x = 0] is [x <> 0 \/ not a1 \/ .. \/ not an]) and [x = 0] is
+     in conflict with [b] (i.e. we are learning [x <> 0 \/ not b]) we can
+     apply resolution to learn [not a1 \/ .. \/ not an \/ not b] instead,
+     eliminating the semantic literal [x = 0] in the process. *)
+  let rec semantic_expansion env max_lvl blevel learnt seen (a : Atom.atom) =
+    assert (a.is_true || a.neg.is_true && a.var.level >= 0);
+    assert (a.var.level <= max_lvl);
+    if not a.var.seen && a.var.level > 0 then (
+      var_bump_activity env a.var;
+      a.var.seen <- true;
+      seen := a :: !seen;
+      match a.var.reason with
+      | Some c when is_semantic a ->
+        assert a.neg.is_true;
+        Vec.iter (fun (b : Atom.atom) ->
+            assert (b.neg == a || b.neg.is_true);
+            semantic_expansion env max_lvl blevel learnt seen b
+          ) c.atoms
+      | _ ->
+        learnt := SA.add a !learnt;
+        blevel := max !blevel a.var.level
+    )
 
   let conflict_analyze_aux env c_clause max_lvl =
     let pathC = ref 0 in
@@ -1332,13 +1447,13 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       Vec.iter (fun (a : Atom.atom) ->
           assert (a.is_true || a.neg.is_true && a.var.level >= 0);
           if not a.var.seen && a.var.level > 0 then begin
-            var_bump_activity env a.var;
-            a.var.seen <- true;
-            seen := a :: !seen;
-            if a.var.level >= max_lvl then incr pathC
-            else begin
-              learnt := SA.add a !learnt;
-              blevel := max !blevel a.var.level
+            if a.var.level >= max_lvl then begin
+              var_bump_activity env a.var;
+              a.var.seen <- true;
+              seen := a :: !seen;
+              incr pathC
+            end else begin
+              semantic_expansion env a.var.level blevel learnt seen a;
             end
           end
         ) !c.atoms;
@@ -1352,8 +1467,15 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       decr pathC;
       let p = Vec.get env.trail !tr_ind in
       decr tr_ind;
+      (* Do not use semantic literals as UIPs unless forced to (i.e. there is
+         no term UIP and the decision was a semantic literal) *)
+      let is_good_uip (p : Atom.atom) =
+        match p.var.reason with
+        | None -> true
+        | Some _ -> not (is_semantic p)
+      in
       match !pathC,p.var.reason with
-      | 0, _ ->
+      | 0, _ when is_good_uip p ->
         cond := false;
         learnt := SA.add p.neg !learnt
       | _, None -> assert false
@@ -1404,6 +1526,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       with Exit -> None
 
   let conflict_analyze_and_fix env confl =
+    env.next_decisions <- [];
     env.conflicts <- env.conflicts + 1;
     if decision_level env = 0 then report_conflict env confl;
     match confl with
@@ -1553,17 +1676,84 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
   let th_entailed tenv a =
     if Options.get_no_tcp () || not (Options.get_minimal_bj ()) then None
     else
-      let lit = Atom.literal a in
-      match Th.query lit tenv with
-      | Some (d,_) ->
-        a.timp <- 1;
-        Some (clause_of_dep d a)
-      | None  ->
-        match Th.query (E.neg lit) tenv with
+      match Shostak.Literal.view @@ Atom.literal a with
+      | LSem _ -> None
+      | LTerm lit ->
+        match Th.query lit tenv with
         | Some (d,_) ->
-          a.neg.timp <- 1;
-          Some (clause_of_dep d a.Atom.neg)
-        | None -> None
+          a.timp <- 1;
+          Some (clause_of_dep d a)
+        | None  ->
+          match Th.query (E.neg lit) tenv with
+          | Some (d,_) ->
+            a.neg.timp <- 1;
+            Some (clause_of_dep d a.Atom.neg)
+          | None -> None
+
+  let make_decision env atom =
+    match th_entailed env.tenv atom with
+    | None ->
+      new_decision_level env;
+      let current_level = decision_level env in
+      env.cpt_current_propagations <- 0;
+      assert (atom.var.level < 0);
+      if Options.get_debug_sat () then
+        Printer.print_dbg "[satml] decide: %a" Atom.pr_atom atom;
+      enqueue env atom current_level None
+    | Some (c, _) ->
+      (* right decision level will be set inside record_learnt_clause *)
+      record_learnt_clause env ~is_T_learn:true (decision_level env) c []
+
+  let rec pick_branch_aux env (atom : Atom.atom) =
+    let v = atom.var in
+    if v.level >= 0 then begin
+      assert (v.pa.is_true || v.na.is_true);
+      pick_branch_lit env
+    end else
+      make_decision env atom
+
+  and pick_branch_lit env =
+    match env.next_objective with
+    | Some (fn, value, atom) ->
+      env.next_objective <- None;
+      let v = atom.var in
+      if v.level >= 0 then (
+        assert (v.pa.is_true || v.na.is_true);
+        if atom.is_true then
+          env.tenv <- Th.add_objective env.tenv fn value;
+        pick_branch_lit env
+      ) else (
+        make_decision env atom;
+        if atom.is_true then
+          env.tenv <- Th.add_objective env.tenv fn value
+      )
+    | None ->
+      match env.next_decisions with
+      | atom :: tl ->
+        env.next_decisions <- tl;
+        pick_branch_aux env atom
+      | [] ->
+        match Vheap.remove_min env.order with
+        | v -> pick_branch_aux env v.na
+        | exception Not_found -> raise_notrace Sat
+
+  let pick_branch_lit env =
+    if env.next_dec_guard < Vec.size env.increm_guards then
+      begin
+        let a = Vec.get env.increm_guards env.next_dec_guard in
+        (assert (not (a.neg.is_guard || a.neg.is_true)));
+        env.next_dec_guard <- env.next_dec_guard + 1;
+        make_decision env a
+      end
+    else
+      pick_branch_lit env
+
+  let is_sat env =
+    Lists.is_empty env.next_decisions &&
+    Option.is_none env.next_objective && (
+      nb_assigns env = nb_vars env ||
+      (Options.get_cdcl_tableaux_inst () &&
+       Matoms.is_empty env.lazy_cnf))
 
   let search env strat n_of_conflicts n_of_learnts =
     let conflictC = ref 0 in
@@ -1571,9 +1761,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     while true do
       propagate_and_stabilize env all_propagations conflictC !strat;
 
-      if nb_assigns env = nb_vars env ||
-         (Options.get_cdcl_tableaux_inst () &&
-          Matoms.is_empty env.lazy_cnf) then
+      if is_sat env then
         raise Sat;
       if Options.get_enable_restarts ()
       && n_of_conflicts >= 0 && !conflictC >= n_of_conflicts then begin
@@ -1587,26 +1775,12 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
          Vec.size env.learnts - nb_assigns env >= n_of_learnts then
         reduce_db();
 
-      let next =
-        match !strat with
-        | Auto -> pick_branch_lit env
-        | Stop -> raise Stopped
-        | Interactive f ->
-          strat := Stop; f
-      in
-
-      match th_entailed env.tenv next with
-      | None ->
-        new_decision_level env;
-        let current_level = decision_level env in
-        env.cpt_current_propagations <- 0;
-        assert (next.var.level < 0);
-        if Options.get_debug_sat () then
-          Printer.print_dbg "[satml] decide: %a" Atom.pr_atom next;
-        enqueue env next current_level None
-      | Some(c, _) ->
-        record_learnt_clause env ~is_T_learn:true (decision_level env) c []
-        (* right decision level will be set inside record_learnt_clause *)
+      match !strat with
+      | Auto -> pick_branch_lit env
+      | Stop -> raise Stopped
+      | Interactive f ->
+        strat := Stop;
+        make_decision env f
     done
 
   (* unused --
@@ -1649,6 +1823,22 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     | (Unsat _) as e ->
       (* check_unsat_core cl; *)
       raise e
+
+  let rec compute_concrete_model ~declared_ids env =
+    let acts = theory_slice env in
+    match Th.compute_concrete_model ~acts env.tenv with
+    | () -> (
+        if is_sat env then
+          Th.extract_concrete_model ~declared_ids env.tenv
+        else
+          try
+            solve env; assert false
+          with Sat ->
+            compute_concrete_model ~declared_ids env
+      )
+    | exception Ex.Inconsistent (ex, _) ->
+      conflict_analyze_and_fix env (C_theory ex);
+      compute_concrete_model ~declared_ids env
 
   exception Trivial
 
@@ -1777,6 +1967,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         List.fold_left
           (fun ((unit_cnf, nunit_cnf) as accu) (v : Atom.var) ->
              Vec.push env.vars v;
+             assert (not (is_semantic v.pa));
              insert_var_order env v;
              match th_entailed tenv0 v.pa with
              | None -> accu
@@ -1789,7 +1980,9 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
                        if minimal-bj is ON"]
           ) (unit_cnf, nunit_cnf) new_v
       in
-      assert (nbv = Vec.size env.vars);
+      (* This assert is no longer true because some of the vars in the
+         [hcons_env] are now semantic literals.
+         assert (nbv = Vec.size env.vars); *)
       accu
 
   let set_new_proxies env proxies =
@@ -1961,5 +2154,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       assert (env.next_dec_guard <= Vec.size env.increm_guards);
     enqueue env g.neg 0 None
 
-  let optimize env ~is_max obj = env.tenv <- Th.optimize env.tenv ~is_max obj
+  let optimize env ~is_max obj =
+    let fn = Objective.Function.mk ~is_max obj in
+    env.tenv <- Th.add_objective env.tenv fn Objective.Value.Unknown
 end

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -840,7 +840,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
     Vec.shrink watched !new_sz_w
 
   let acts_add_decision_lit env lit =
-    let atom, _ = Atom.add_lit_atom env.hcons_env lit [] in
+    let atom, _ = Atom.add_atom env.hcons_env lit [] in
     if atom.var.level < 0 then (
       assert (not atom.is_true && not atom.neg.is_true);
       env.next_decisions <- atom :: env.next_decisions
@@ -848,7 +848,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       assert (atom.is_true || atom.neg.is_true)
 
   let acts_add_split env lit =
-    let atom, _ = Atom.add_lit_atom env.hcons_env lit [] in
+    let atom, _ = Atom.add_atom env.hcons_env lit [] in
     if atom.var.level < 0 then (
       assert (not atom.is_true && not atom.neg.is_true);
       env.next_split <- Some atom
@@ -861,7 +861,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
        We can't update the theory inside this function, because it is called
        from within the theory. *)
-    let atom, _ = Atom.add_lit_atom env.hcons_env lit [] in
+    let atom, _ = Atom.add_atom env.hcons_env lit [] in
     env.next_objective <- Some (fn, value, atom)
 
   let[@inline] theory_slice env : _ Th_util.acts = {

--- a/src/lib/reasoners/satml.mli
+++ b/src/lib/reasoners/satml.mli
@@ -46,6 +46,10 @@ module type SAT_ML = sig
   type t
 
   val solve : t -> unit
+  val compute_concrete_model :
+    declared_ids:Id.typed list ->
+    t ->
+    Models.t Lazy.t * Objective.Model.t
 
   val set_new_proxies : t -> Flat_Formula.proxies -> unit
 
@@ -70,7 +74,7 @@ module type SAT_ML = sig
     t -> Satml_types.Flat_Formula.hcons_env -> Satml_types.Atom.Set.t
   val current_tbox : t -> th
   val set_current_tbox : t -> th -> unit
-  val empty : unit -> t
+  val create : Atom.hcons_env -> t
 
   val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> unit
   val decision_level : t -> int

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1092,7 +1092,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
             | Limit (_, v) ->
               raise (Give_up ((e, v, is_max, false) :: acc))
             | Unknown ->
-              [] (* assert false *)
+              assert false
           ) objs []
       with Give_up acc -> acc
     in

--- a/src/lib/reasoners/satml_frontend_hybrid.ml
+++ b/src/lib/reasoners/satml_frontend_hybrid.ml
@@ -55,11 +55,12 @@ module Make (Th : Theory.S) = struct
   exception Bottom of Explanation.t * E.Set.t list * t
 
   let empty () =
-    {sat = SAT.empty ();
+    let hcons_env = Atom.empty_hcons_env () in
+    {sat = SAT.create hcons_env;
      assumed = SE.empty;
      proxies = ME.empty;
      inv_proxies = MA.empty;
-     hcons_env = Atom.empty_hcons_env ();
+     hcons_env ;
      decisions=[];
      pending=[]}
 

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -771,3 +771,13 @@ module MXH =
 (** set of semantic values using Combine.hash_cmp *)
 module SXH =
   Set.Make(struct type t = Combine.r let compare = Combine.hash_cmp end)
+
+module L = Xliteral.Make(struct
+    type t = Combine.r
+
+    include Combine
+
+    let compare = hash_cmp
+  end)
+
+module Literal = Literal.Make(L)

--- a/src/lib/reasoners/shostak.mli
+++ b/src/lib/reasoners/shostak.mli
@@ -60,3 +60,7 @@ module MXH : Map.S with type key = Combine.r
 
 (** set of semantic values using Combine.hash_cmp *)
 module SXH : Set.S with type elt = Combine.r
+
+module L : Xliteral.S with type elt = Combine.r
+
+module Literal : Literal.S with type elt = L.t

--- a/src/lib/reasoners/sig_rel.mli
+++ b/src/lib/reasoners/sig_rel.mli
@@ -28,7 +28,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type 'a literal = LTerm of Expr.t | LSem of 'a Xliteral.view
+type 'a literal = 'a Xliteral.view Literal.view
 
 type instances = (Expr.t list * Expr.gformula * Explanation.t) list
 

--- a/src/lib/reasoners/th_util.ml
+++ b/src/lib/reasoners/th_util.ml
@@ -52,3 +52,9 @@ type optimized_split = {
   value : Objective.Value.t;
   case_split : case_split;
 }
+
+type 'literal acts = {
+  acts_add_decision_lit : 'literal -> unit ;
+  acts_add_objective :
+    Objective.Function.t -> Objective.Value.t -> 'literal -> unit ;
+}

--- a/src/lib/reasoners/th_util.ml
+++ b/src/lib/reasoners/th_util.ml
@@ -55,6 +55,7 @@ type optimized_split = {
 
 type 'literal acts = {
   acts_add_decision_lit : 'literal -> unit ;
+  acts_add_split : 'literal -> unit ;
   acts_add_objective :
     Objective.Function.t -> Objective.Value.t -> 'literal -> unit ;
 }

--- a/src/lib/reasoners/th_util.mli
+++ b/src/lib/reasoners/th_util.mli
@@ -118,7 +118,7 @@ type optimized_split = {
 type 'literal acts = {
   acts_add_decision_lit : 'literal -> unit ;
   (** Ask the SAT solver to decide on the given formula before it can answer
-      [SAT]. The order of decisions is among multiple calls of
+      [SAT]. The order of decisions among multiple calls of
       [acts_add_decision_lit] is unspecified.
 
       Decisions added using [acts_add_decision_lit] are forgotten when

--- a/src/lib/reasoners/th_util.mli
+++ b/src/lib/reasoners/th_util.mli
@@ -124,6 +124,15 @@ type 'literal acts = {
       Decisions added using [acts_add_decision_lit] are forgotten when
       backtracking. *)
 
+  acts_add_split : 'literal -> unit ;
+  (** Let the SAT solver know about a case split. The SAT solver should decide
+      on the provided formula before answering [Sat], although it is not
+      required to do so. The order of decisions among multiple calls of
+      [acts_add_split] is unspecified, and the solver is allowed to drop some
+      of them.
+
+      Splits added using [acts_add_split] are forgotten when backtracking. *)
+
   acts_add_objective :
     Objective.Function.t -> Objective.Value.t -> 'literal -> unit ;
   (** Ask the SAT solver to optimistically select the appropriate value for the

--- a/src/lib/reasoners/th_util.mli
+++ b/src/lib/reasoners/th_util.mli
@@ -107,3 +107,36 @@ type optimized_split = {
       Indeed, [value] isn't always a proper model value when the problem
       is unbounded or some objective functions involved strict inequalities. *)
 }
+
+(** The type of actions that a theory can take.
+
+    Inspired by mSAT's equivalent type [1].
+
+    [1] :
+      https://github.com/Gbury/mSAT/blob/ \
+      1496a48bc8b948e4d5a2bc20edaec33a6901c8fa/src/core/Solver_intf.ml#L104 *)
+type 'literal acts = {
+  acts_add_decision_lit : 'literal -> unit ;
+  (** Ask the SAT solver to decide on the given formula before it can answer
+      [SAT]. The order of decisions is among multiple calls of
+      [acts_add_decision_lit] is unspecified.
+
+      Decisions added using [acts_add_decision_lit] are forgotten when
+      backtracking. *)
+
+  acts_add_objective :
+    Objective.Function.t -> Objective.Value.t -> 'literal -> unit ;
+  (** Ask the SAT solver to optimistically select the appropriate value for the
+      given objective function (encoded as a decision in the ['literal]). If
+      the solver backtracks on that decision, the theory will have an
+      opportunity to select another value in a context where the ['literal] is
+      negated.
+
+      In case multiple objectives are added before the solver gets to make a
+      decision, only the *last* objective is taken into consideration; you
+      cannot assume that the objective has been optimized until the objective is
+      sent back to the theory through [add_objective].
+
+      Objectives added using [acts_add_objective] are forgotten when
+      backtracking. *)
+}

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -737,7 +737,12 @@ module Main_Default : S = struct
                 | LSem a ->
                   (* When assuming a semantic literal (typically a case split),
                      we may end up in cases where they contain terms that have
-                     not been added. *)
+                     not been added.
+
+                     One reason this can happen is when (the negation of)
+                     semantic literals are pushed onto the trail at lower
+                     levels than they were initially created (notably with
+                     with minimal backjumps). *)
                   let aview = LR.view a in
                   let trms = extract_terms_from_xliteral SE.empty aview in
                   let gamma = SE.fold (fun t gamma ->

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -702,7 +702,7 @@ module Main_Default : S = struct
         do_case_split_aux t ~for_model:false
       | (lview, _, _) :: _ ->
         let lit = Shostak.(Literal.make @@ LSem (L.make lview)) in
-        acts.Th_util.acts_add_decision_lit lit;
+        acts.Th_util.acts_add_split lit;
         t, SE.empty
 
   let do_case_split_or_optimize ?acts t =

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -652,7 +652,7 @@ module Main_Default : S = struct
            the procedure will success to produce the upper bound of [x] and
            [y] modulo the other constraints on it.
          - If the objective function isn't linear, the nonlinear part of the
-           expression have seen as uninterpreted term of the arithemic theory.
+           expression is seen as uninterpreted term of the arithmetic theory.
            Let's imagine we try to maximize the expression:
              5 * x * x + 2 * y + 3,
            The objective function given to Ocplib-simplex looks like:
@@ -945,7 +945,7 @@ module Main_Default : S = struct
   let get_objectives env = env.objectives
 
   let add_objective env fn value =
-    (* We have to add the term [f] and its subterms as the MaxSMT
+    (* We have to add the term [fn] and its subterms as the MaxSMT
        syntax allows to optimize expressions that aren't part of
        the current context. *)
     let expr = fn.Objective.Function.e in

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -39,6 +39,8 @@ module Sy = Symbols
 
 module CC_X = Ccx.Main
 
+module L = Shostak.Literal
+
 module type S = sig
   type t
 
@@ -49,21 +51,25 @@ module type S = sig
      decreasing order with respect to (dlvl, plvl) *)
   val assume :
     ?ordered:bool ->
-    (E.t * Explanation.t * int * int) list -> t ->
+    (L.t * Th_util.lit_origin * Explanation.t * int * int) list -> t ->
     t * Expr.Set.t * int
 
-  val optimize : t -> is_max:bool -> Expr.t -> t
+  val add_objective : t -> Objective.Function.t -> Objective.Value.t -> t
   val query : E.t -> t -> Th_util.answer
   val cl_extract : t -> Expr.Set.t list
   val extract_ground_terms : t -> Expr.Set.t
   val get_real_env : t -> Ccx.Main.t
   val get_case_split_env : t -> Ccx.Main.t
-  val do_case_split : t -> Util.case_split_policy -> t * Expr.Set.t
+  val do_case_split :
+    ?acts:Shostak.Literal.t Th_util.acts ->
+    t -> Util.case_split_policy -> t * Expr.Set.t
 
   val add_term : t -> Expr.t -> add_in_cs:bool -> t
   val compute_concrete_model :
-    t ->
+    acts:Shostak.Literal.t Th_util.acts -> t -> unit
+  val extract_concrete_model :
     declared_ids:Id.typed list ->
+    t ->
     Models.t Lazy.t * Objective.Model.t
 
   val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
@@ -86,21 +92,16 @@ module Main_Default : S = struct
 
 
   type choice =
-    X.r Xliteral.view * Th_util.lit_origin * choice_sign * Ex.t * int option
+    X.r Xliteral.view * Th_util.lit_origin * choice_sign * Ex.t
   (** the choice, the size, choice_sign,  the explication set,
         the explication for this choice. *)
 
-  let pp_choice ppf (sem_lit, lit_orig, _, ex, ord) =
-    let pp_ord ppf ord =
-      match ord with
-      | Some o -> Fmt.pf ppf "Optim-cs(ord=%d)" o
-      | None -> ()
-    in
+  let pp_choice ppf (sem_lit, lit_orig, _, ex) =
     let sem_lit = LR.make sem_lit in
     match (lit_orig : Th_util.lit_origin) with
     | CS (k, _) ->
-      Fmt.pf ppf "%a %a cs: %a (because %a)"
-        Th_util.pp_theory k pp_ord ord LR.print sem_lit Ex.print ex
+      Fmt.pf ppf "%a cs: %a (because %a)"
+        Th_util.pp_theory k LR.print sem_lit Ex.print ex
     | NCS (k, _) ->
       Fmt.pf ppf "%a ncs: %a (because %a)"
         Th_util.pp_theory k LR.print sem_lit Ex.print ex
@@ -113,7 +114,11 @@ module Main_Default : S = struct
     let subterms_of_assumed l =
       List.fold_left
         (List.fold_left
-           (fun st (a, _, _) -> Expr.Set.union st (E.sub_terms SE.empty a))
+           (fun st (a, _, _) ->
+              match L.view a with
+              | LTerm a ->
+                Expr.Set.union st (E.sub_terms SE.empty a)
+              | LSem _ -> st)
         )SE.empty l
 
     let types_of_subterms st =
@@ -264,13 +269,13 @@ module Main_Default : S = struct
                  print_dbg ~flushed:false ~header:false
                    "( (* %d , %d *) %a "
                    dlvl plvl
-                   E.print a;
+                   L.pp a;
                  List.iter
                    (fun (a, dlvl, plvl) ->
                       print_dbg ~flushed:false ~header:false
                         " and@ (* %d , %d *) %a "
                         dlvl plvl
-                        E.print a
+                        L.pp a
                    ) l;
                  print_dbg ~flushed:false ~header:false ") ->@ "
             ) (List.rev l);
@@ -347,8 +352,9 @@ module Main_Default : S = struct
 
   type t = {
     assumed_set : E.Set.t;
-    assumed : (E.t * int * int) list list;
-    cs_pending_facts : (E.t * Ex.t * int * int) list list;
+    assumed : (L.t * int * int) list list;
+    cs_pending_facts :
+      (L.t * Th_util.lit_origin * Ex.t * int * int) list list;
     terms : Expr.Set.t;
     gamma : CC_X.t;
     gamma_finite : CC_X.t;
@@ -356,14 +362,14 @@ module Main_Default : S = struct
     objectives : Objective.Model.t;
   }
 
-  let add_explanations_to_split ?order (c, is_cs, size) =
+  let add_explanations_to_split (c, is_cs, size) =
     Steps.incr_cs_steps ();
     let exp = Ex.fresh_exp () in
     let ex_c_exp =
       if is_cs then Ex.add_fresh exp Ex.empty else Ex.empty
     in
     (* A new explanation in order to track the choice *)
-    (c, size, CPos exp, ex_c_exp, order)
+    (c, size, CPos exp, ex_c_exp)
 
   let look_for_sat ~for_model env sem_facts new_choices =
     let rec generate_choices env sem_facts acc_choices =
@@ -384,56 +390,6 @@ module Main_Default : S = struct
         in
         aux env sem_facts acc_choices new_choices
 
-    and optimizing_objective env sem_facts acc_choices obj order =
-      let opt_split =
-        Option.get (CC_X.optimizing_objective env.gamma_finite obj)
-      in
-      let objectives =
-        Objective.Model.add obj opt_split.value env.objectives
-      in
-      let env = { env with objectives } in
-      match opt_split.value with
-      | Unknown ->
-        (* In the current implementation of optimization, the function
-           [CC_X.optimizing_objective] cannot fail to optimize the objective
-           function [obj]. First of all, the legacy parser only accepts
-           optimization clauses on expressions of type [Real] or [Int].
-           For the [Real] or [Int] expressions, we have two cases:
-           - If the objective function is a linear functions of variables, the
-             decision procedure implemented in Ocplib-simplex cannot fail to
-             optimize the split. For instance, if we try to maximize the
-             expression:
-               5 * x + 2 * y + 3 where x and y are real variables,
-             the procedure will success to produce the upper bound of [x] and
-             [y] modulo the other constraints on it.
-           - If the objective function isn't linear, the nonlinear part of the
-             expression have seen as uninterpreted term of the arithemic theory.
-             Let's imagine we try to maximize the expression:
-               5 * x * x + 2 * y + 3,
-             The objective function given to Ocplib-simplex looks like:
-               5 * U + 2 * y + 3 where U = x * x
-             and the procedure will optimize the problem in terms of U and y. *)
-        assert false
-
-      | Pinfinity | Minfinity | Limit _ ->
-        (* We stop optimizing the objective function [obj] in this case, but
-           we continue to produce a model if the flag [for_model] is up. *)
-        if for_model then
-          let new_choice =
-            add_explanations_to_split ~order opt_split.case_split
-          in
-          propagate_choices env sem_facts acc_choices [new_choice]
-        else
-          { env with choices = List.rev acc_choices }, sem_facts
-
-      | Value _ ->
-        begin
-          let new_choice =
-            add_explanations_to_split ~order opt_split.case_split
-          in
-          propagate_choices env sem_facts acc_choices [new_choice]
-        end
-
     (* Propagates the choice made by case-splitting to the environment
        [gamma_finite] of the CC(X) algorithm. If there is no more choices
        to propagate, we call the dispatcher [aux] to leave the function.
@@ -446,7 +402,7 @@ module Main_Default : S = struct
       match new_choices with
       | [] -> aux env sem_facts acc_choices new_choices
 
-      | ((c, lit_orig, CNeg, ex_c, _order) as a) :: new_choices ->
+      | ((c, lit_orig, CNeg, ex_c) as a) :: new_choices ->
         let facts = CC_X.empty_facts () in
         CC_X.add_fact facts (LSem c, ex_c, lit_orig);
         let base_env, sem_facts =
@@ -455,7 +411,7 @@ module Main_Default : S = struct
         let env = { env with gamma_finite = base_env } in
         propagate_choices env sem_facts (a :: acc_choices) new_choices
 
-      | ((c, lit_orig, CPos exp, ex_c_exp, order) as a) :: new_choices ->
+      | ((c, lit_orig, CPos exp, ex_c_exp) as a) :: new_choices ->
         try
           Debug.split_assume c ex_c_exp;
           let facts = CC_X.empty_facts () in
@@ -496,33 +452,21 @@ module Main_Default : S = struct
             Printer.print_dbg
               "bottom (case-split):%a"
               Expr.print_tagged_classes classes;
-          let env =
-            match order with
-            | Some i ->
-              { env with
-                objectives = Objective.Model.reset_until env.objectives i }
-            | None -> env
-          in
           propagate_choices env sem_facts acc_choices
-            [neg_c, lit_orig, CNeg, dep, order]
+            [neg_c, lit_orig, CNeg, dep]
 
     and aux env sem_facts acc_choices new_choices =
       Options.tool_req 3 "TR-CCX-CS-Case-Split";
       match new_choices with
       | [] ->
-        begin match Objective.Model.next_unknown env.objectives ~for_model with
-          | Some (obj, order) ->
-            optimizing_objective env sem_facts acc_choices obj order
-          | None ->
-            generate_choices env sem_facts acc_choices
-        end
+        generate_choices env sem_facts acc_choices
       | _ ->
         propagate_choices env sem_facts acc_choices new_choices
     in
     aux env sem_facts (List.rev env.choices) new_choices
 
   (* remove old choices involving fresh variables that are no longer in UF *)
-  let filter_valid_choice uf (ra, _, _, _, _) =
+  let filter_valid_choice uf (ra, _, _, _) =
     let l = match ra with
       | A.Eq (r1, r2) -> [r1; r2]
       | A.Distinct (_, l) -> l
@@ -548,7 +492,7 @@ module Main_Default : S = struct
       List.partition (filter_valid_choice uf) choices in
     let ignored_decisions =
       List.fold_left
-        (fun ex (_, _, ch, _, _) ->
+        (fun ex (_, _, ch, _) ->
            match ch with
            | CPos (Ex.Fresh _ as e) -> Ex.add_fresh e ex
            | CPos _ -> assert false
@@ -556,7 +500,7 @@ module Main_Default : S = struct
         ) Ex.empty to_ignore
     in
     List.filter
-      (fun (_ ,_ ,_ ,ex , _) ->
+      (fun (_ ,_ ,_ ,ex) ->
          try
            Ex.iter_atoms
              (function
@@ -570,7 +514,6 @@ module Main_Default : S = struct
 
   let reset_case_split_env t =
     { t with
-      objectives = Objective.Model.reset_until t.objectives 0;
       cs_pending_facts = []; (* be sure it's always correct when this
                                 function is called *)
       gamma_finite = t.gamma; (* we'll take gamma directly *)
@@ -613,14 +556,6 @@ module Main_Default : S = struct
                  safely ignore the explanation which is not useful. *)
               let uf =  CC_X.get_union_find t.gamma in
               let filt_choices = filter_choices uf t.choices in
-              let filt_choices =
-                if  Objective.Model.is_empty t.objectives ||
-                    Objective.Model.has_no_limit t.objectives
-                    (* otherwise, we may be unsound because infty optims
-                       are not propagated *)
-                then filt_choices
-                else []
-              in
               Debug.split_sat_contradicts_cs filt_choices;
               let t = reset_case_split_env t in
               look_for_sat ~for_model
@@ -640,15 +575,17 @@ module Main_Default : S = struct
          match X.term_extract r with
          | Some t, _ -> SE.add t acc | _ -> acc) acc l
 
-  let extract_terms_from_choices =
+  let extract_terms_from_xliteral acc = function
+    | A.Eq (r1, r2) -> extract_from_semvalues acc [r1; r2]
+    | Distinct (_, l) -> extract_from_semvalues acc l
+    | Pred (p, _) -> extract_from_semvalues acc [p]
+    | _ -> acc
+
+  let extract_terms_from_choices acc choices =
     List.fold_left
-      (fun acc (a, _, _, _, _) ->
-         match a with
-         | A.Eq(r1, r2) -> extract_from_semvalues acc [r1; r2]
-         | A.Distinct (_, l) -> extract_from_semvalues acc l
-         | A.Pred(p, _) -> extract_from_semvalues acc [p]
-         | _ -> acc
-      )
+      (fun acc (a, _, _, _) ->
+         extract_terms_from_xliteral acc a
+      ) acc choices
 
   let extract_terms_from_assumed =
     List.fold_left
@@ -681,8 +618,13 @@ module Main_Default : S = struct
     let facts = CC_X.empty_facts () in
     List.iter
       (List.iter
-         (fun (a,ex,_dlvl,_plvl) ->
-            CC_X.add_fact facts (LTerm a, ex, Th_util.Other))
+         (fun (a, o, ex,_dlvl,_plvl) ->
+            let a =
+              match L.view a with
+              | LTerm _ as a -> a
+              | LSem a -> LSem (LR.view a)
+            in
+            CC_X.add_fact facts (a, ex, o))
       ) in_facts_l;
 
     let t, ch = try_it t facts ~for_model in
@@ -691,32 +633,138 @@ module Main_Default : S = struct
 
     {t with terms = Expr.Set.union t.terms choices_terms}, choices_terms
 
-  let do_case_split t origin =
-    if Options.get_case_split_policy () == origin then
+  let optimize_obj ~for_model add_objective obj t =
+    let opt_split =
+      Option.get (CC_X.optimizing_objective t.gamma obj)
+    in
+    match opt_split.value with
+    | Unknown ->
+      (* In the current implementation of optimization, the function
+         [CC_X.optimizing_objective] cannot fail to optimize the objective
+         function [obj]. First of all, the legacy parser only accepts
+         optimization clauses on expressions of type [Real] or [Int].
+         For the [Real] or [Int] expressions, we have two cases:
+         - If the objective function is a linear functions of variables, the
+           decision procedure implemented in Ocplib-simplex cannot fail to
+           optimize the split. For instance, if we try to maximize the
+           expression:
+             5 * x + 2 * y + 3 where x and y are real variables,
+           the procedure will success to produce the upper bound of [x] and
+           [y] modulo the other constraints on it.
+         - If the objective function isn't linear, the nonlinear part of the
+           expression have seen as uninterpreted term of the arithemic theory.
+           Let's imagine we try to maximize the expression:
+             5 * x * x + 2 * y + 3,
+           The objective function given to Ocplib-simplex looks like:
+             5 * U + 2 * y + 3 where U = x * x
+           and the procedure will optimize the problem in terms of U and y. *)
+      assert false
+
+    | Pinfinity | Minfinity | Limit _ when not for_model ->
+      (* We stop optimizing the objective function [obj] in this case, but
+         we continue to produce a model if the flag [for_model] is up. *)
+      ()
+
+    | Pinfinity | Minfinity | Limit _ | Value _ ->
+      let (lview, is_cs, _) = opt_split.case_split in
+      assert is_cs;
+
+      if Options.get_debug_optimize () then
+        Printer.print_dbg "Objective for %a is %a [split: %a]"
+          Objective.Function.pp obj
+          Objective.Value.pp opt_split.value
+          Shostak.L.print (Shostak.L.make lview);
+
+      add_objective
+        obj opt_split.value
+        (Shostak.(Literal.make @@ LSem (L.make lview)))
+
+  let sat_splits t =
+    if Options.get_enable_sat_cs () then
+      let splits, gamma = CC_X.case_split t.gamma ~for_model:false in
+      let splits =
+        List.filter (fun (_, is_cs, origin) ->
+            is_cs &&
+            match origin with
+            | Th_util.CS (Th_arrays, _) -> true
+            | _ -> false
+          ) splits
+      in
+      splits, { t with gamma }
+    else
+      [], t
+
+  let do_optimize acts objectives t =
+    match Objective.Model.next_unknown objectives with
+    | Some obj ->
+      let add_objective = acts.Th_util.acts_add_objective in
+      optimize_obj ~for_model:false add_objective obj t;
+      t, SE.empty
+    | None ->
+      let splits, t = sat_splits t in
+      match splits with
+      | [] ->
+        do_case_split_aux t ~for_model:false
+      | (lview, _, _) :: _ ->
+        let lit = Shostak.(Literal.make @@ LSem (L.make lview)) in
+        acts.Th_util.acts_add_decision_lit lit;
+        t, SE.empty
+
+  let do_case_split_or_optimize ?acts t =
+    match acts with
+    | Some acts ->
+      do_optimize acts t.objectives t
+    | None ->
       do_case_split_aux t ~for_model:false
+
+
+  let do_case_split ?acts t origin =
+    if Options.get_case_split_policy () == origin then
+      do_case_split_or_optimize ?acts t
     else
       t, SE.empty
 
   (* facts are sorted in decreasing order with respect to (dlvl, plvl) *)
   let assume ordered in_facts t =
     let facts = CC_X.empty_facts () in
-    let assumed, assumed_set, cpt =
+    let assumed, assumed_set, cpt, gamma =
       List.fold_left
-        (fun ((assumed, assumed_set, cpt) as accu) ((a, ex, dlvl, plvl)) ->
-           if E.Set.mem a assumed_set
-           then accu
-           else
-             begin
-               CC_X.add_fact facts (LTerm a, ex, Th_util.Other);
-               (a, dlvl, plvl) :: assumed,
-               E.Set.add a assumed_set,
-               cpt+1
-             end
-        )([], t.assumed_set, 0) in_facts
+        (fun
+          ((assumed, assumed_set, cpt, gamma) as accu)
+          ((a, o, ex, dlvl, plvl))
+          ->
+            match L.view a with
+            | Literal.LTerm a when E.Set.mem a assumed_set -> accu
+            | aview ->
+              let gamma, aview =
+                match aview with
+                | LTerm t -> gamma, Literal.LTerm t
+                | LSem a ->
+                  (* When assuming a semantic literal (typically a case split),
+                     we may end up in cases where they contain terms that have
+                     not been added. *)
+                  let aview = LR.view a in
+                  let trms = extract_terms_from_xliteral SE.empty aview in
+                  let gamma = SE.fold (fun t gamma ->
+                      fst @@ CC_X.add_term gamma facts t Ex.empty
+                    ) trms gamma in
+                  gamma, LSem aview
+              in
+              CC_X.add_fact facts (aview, ex, o);
+              let assumed_set =
+                match aview with
+                | LTerm a -> E.Set.add a assumed_set
+                | _ -> assumed_set
+              in
+              (a, dlvl, plvl) :: assumed,
+              assumed_set,
+              cpt+1,
+              gamma
+        )([], t.assumed_set, 0, t.gamma) in_facts
     in
     if assumed == [] then t, E.Set.empty, 0
     else
-      let t = {t with assumed_set; assumed = assumed :: t.assumed;
+      let t = {t with assumed_set; assumed = assumed :: t.assumed; gamma;
                       cs_pending_facts = in_facts :: t.cs_pending_facts} in
       if Options.get_profiling() then Profiling.assume cpt;
       Debug.assumed t.assumed;
@@ -850,7 +898,9 @@ module Main_Default : S = struct
       }
     in
     let a = E.mk_distinct ~iff:false [E.vrai; E.faux] in
-    let t, _, _ = assume true [a, Ex.empty, 0, -1] t in
+    let t, _, _ =
+      assume true [L.make @@ Literal.LTerm a, Th_util.Other, Ex.empty, 0, -1] t
+    in
     t
 
   let cl_extract env = CC_X.cl_extract env.gamma
@@ -868,7 +918,15 @@ module Main_Default : S = struct
   let get_real_env t = t.gamma
   let get_case_split_env t = t.gamma_finite
 
-  let compute_concrete_model env ~declared_ids =
+  let compute_concrete_model ~acts t =
+    let add_objective = acts.Th_util.acts_add_objective in
+    match Objective.Model.next_unknown t.objectives with
+    | Some obj ->
+      optimize_obj ~for_model:true add_objective obj t
+    | None ->
+      ()
+
+  let extract_concrete_model ~declared_ids env =
     let { gamma_finite; assumed_set; objectives; _ }, _ =
       do_case_split_aux env ~for_model:true
     in
@@ -884,21 +942,16 @@ module Main_Default : S = struct
 
   let get_assumed env = env.assumed_set
 
-  let optimize env ~is_max f =
+  let get_objectives env = env.objectives
+
+  let add_objective env fn value =
     (* We have to add the term [f] and its subterms as the MaxSMT
        syntax allows to optimize expressions that aren't part of
        the current context. *)
-    let env = add_term env ~add_in_cs:false f in
-    let obj = Objective.Function.mk ~is_max f in
-    let objectives =
-      Objective.Model.add obj Objective.Value.Unknown env.objectives
-    in
-    (* As we may do casesplits after each `assume`, we may start
-       model generations before registering all the optimization constraints. *)
-    let env = reset_case_split_env env in
+    let expr = fn.Objective.Function.e in
+    let env = add_term env ~add_in_cs:false expr in
+    let objectives = Objective.Model.add fn value env.objectives in
     { env with objectives }
-
-  let get_objectives env = env.objectives
 
   let reinit_cpt () =
     Debug.reinit_cpt ()
@@ -914,9 +967,10 @@ module Main_Empty : S = struct
   let assume ?ordered:(_=true) in_facts t =
     let assumed_set =
       List.fold_left
-        (fun assumed_set ((a, _, _, _)) ->
-           if E.Set.mem a assumed_set then assumed_set
-           else E.Set.add a assumed_set
+        (fun assumed_set ((a, _, _, _, _)) ->
+           match L.view a with
+           | LTerm a -> E.Set.add a assumed_set
+           | LSem _ -> assumed_set
         ) t.assumed_set in_facts
     in
     {assumed_set}, E.Set.empty, 0
@@ -928,15 +982,16 @@ module Main_Empty : S = struct
 
   let get_real_env _ = CC_X.empty
   let get_case_split_env _ = CC_X.empty
-  let do_case_split env _ = env, E.Set.empty
+  let do_case_split ?acts:_ env _ = env, E.Set.empty
   let add_term env _ ~add_in_cs:_ = env
-  let compute_concrete_model _env ~declared_ids:_ =
+  let compute_concrete_model ~acts:_ _env = ()
+  let extract_concrete_model ~declared_ids:_ _env =
     lazy Models.empty, Objective.Model.empty
 
   let assume_th_elt e _ _ = e
   let theories_instances ~do_syntactic_matching:_ _ e _ _ _ = e, []
   let get_assumed env = env.assumed_set
-  let optimize env ~is_max:_ _obj = env
+  let add_objective env _fn _value = env
   let reinit_cpt () = ()
 
   let get_objectives _env = Objective.Model.empty

--- a/src/lib/reasoners/theory.mli
+++ b/src/lib/reasoners/theory.mli
@@ -38,25 +38,30 @@ module type S = sig
      decreasing order with respect to (dlvl, plvl) *)
   val assume :
     ?ordered:bool ->
-    (Expr.t * Explanation.t * int * int) list -> t ->
-    t * Expr.Set.t * int
+    (Shostak.Literal.t * Th_util.lit_origin * Explanation.t * int * int) list
+    -> t -> t * Expr.Set.t * int
 
-  val optimize : t -> is_max:bool -> Expr.t -> t
-  (** [optimize env ~is_max e] registers the expression [e] to be optimized
-      during the model generation. *)
+  val add_objective :
+    t -> Objective.Function.t -> Objective.Value.t -> t
+  (** [add_objective env fn value] indicates that the objective [fn] has been
+      optimized to [value]. *)
 
   val query : Expr.t -> t -> Th_util.answer
   val cl_extract : t -> Expr.Set.t list
   val extract_ground_terms : t -> Expr.Set.t
   val get_real_env : t -> Ccx.Main.t
   val get_case_split_env : t -> Ccx.Main.t
-  val do_case_split : t -> Util.case_split_policy -> t * Expr.Set.t
+  val do_case_split :
+    ?acts:Shostak.Literal.t Th_util.acts ->
+    t -> Util.case_split_policy -> t * Expr.Set.t
 
   val add_term : t -> Expr.t -> add_in_cs:bool -> t
 
   val compute_concrete_model :
-    t ->
+    acts:Shostak.Literal.t Th_util.acts -> t -> unit
+  val extract_concrete_model :
     declared_ids:Id.typed list ->
+    t ->
     Models.t Lazy.t * Objective.Model.t
 
   val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -37,8 +37,7 @@ module E = Expr
 module ME = Expr.Map
 module SE = Expr.Set
 
-module LX =
-  Xliteral.Make(struct type t = X.r let compare = X.hash_cmp include X end)
+module LX = Shostak.L
 module MapL = Emap.Make(LX)
 
 module MapX = struct

--- a/src/lib/reasoners/uf.mli
+++ b/src/lib/reasoners/uf.mli
@@ -34,7 +34,7 @@ type t
 
 type r = Shostak.Combine.r
 
-module LX : Xliteral.S with type elt = r
+module LX = Shostak.L
 
 val empty : t
 val add : t -> Expr.t -> t * Expr.t list

--- a/src/lib/structures/literal.ml
+++ b/src/lib/structures/literal.ml
@@ -1,0 +1,111 @@
+(**************************************************************************)
+(*                                                                        *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                 *)
+(*     Copyright (C) 2023 --- OCamlPro SAS                                *)
+(*                                                                        *)
+(*     This file is distributed under the terms of OCamlPro               *)
+(*     Non-Commercial Purpose License, version 1.                         *)
+(*                                                                        *)
+(**************************************************************************)
+
+type 'a view = LTerm of Expr.t | LSem of 'a
+(** Literals are represented using either a syntaxic expression or a semantic
+    literal. *)
+
+let pp_view pp ppf = function
+  | LTerm e -> Expr.print ppf e
+  | LSem a -> pp ppf a
+
+let hash_view hash = function
+  | LTerm e -> 2 * Expr.hash e
+  | LSem a -> 2 * hash a + 1
+
+let equal_view equal l1 l2 =
+  match l1, l2 with
+  | LTerm e1, LTerm e2 -> Expr.equal e1 e2
+  | LSem a1, LSem a2 -> equal a1 a2
+  | LTerm _, LSem _ | LSem _, LTerm _ -> false
+
+let compare_view compare l1 l2 =
+  match l1, l2 with
+  | LTerm e1, LTerm e2 -> Expr.compare e1 e2
+  | LTerm _, _ -> -1
+  | _, LTerm _ -> 1
+
+  | LSem a1, LSem a2 -> compare a1 a2
+
+let neg_view neg = function
+  | LTerm e -> LTerm (Expr.neg e)
+  | LSem a -> LSem (neg a)
+
+module type S = sig
+  type elt
+  type t
+
+  val make : elt view -> t
+
+  val view : t -> elt view
+
+  val pp : t Fmt.t
+
+  val hash : t -> int
+
+  val equal : t -> t -> bool
+
+  val compare : t -> t -> int
+
+  val neg : t -> t
+
+  val normal_form : t -> t * bool
+
+  val is_ground : t -> bool
+
+  module Table : Hashtbl.S with type key = t
+
+  module Set : Set.S with type elt = t
+
+  module Map : Map.S with type key = t
+end
+
+module Make(Sem : Xliteral.S) : S with type elt = Sem.t = struct
+  type elt = Sem.t
+  type t = Sem.t view
+
+  let make = Fun.id
+  let view = Fun.id
+  let pp = pp_view Sem.print
+  let hash = hash_view Sem.hash
+  let equal = equal_view Sem.equal
+  let compare = compare_view Sem.compare
+  let neg = neg_view Sem.neg
+
+  let normal_form = function
+    | LTerm e ->
+      (* XXX do better *)
+      (* Note: I don't know what "better" is. *)
+      let is_pos = Expr.is_positive e in
+      LTerm (if is_pos then e else Expr.neg e), not is_pos
+    | LSem a ->
+      let _, is_neg = Sem.atom_view a in
+      LSem (if is_neg then Sem.neg a else a), is_neg
+
+  let is_ground = function
+    | LTerm e -> Expr.is_ground e
+    | LSem _ -> true
+
+  module Table = Hashtbl.Make(struct
+      type t = Sem.t view
+      let hash = hash
+      let equal = equal
+    end)
+
+  module Set = Set.Make(struct
+      type t = Sem.t view
+      let compare = compare
+    end)
+
+  module Map = Map.Make(struct
+      type t = Sem.t view
+      let compare = compare
+    end)
+end

--- a/src/lib/structures/literal.mli
+++ b/src/lib/structures/literal.mli
@@ -63,10 +63,9 @@ module type S = sig
   (** [normal_form l] returns the normal form of [l]. The normal form of [l] is
       a pair [l', is_neg] such that:
 
-      - [l] is [neg l'] if [is_neg] is [true]
-      - [l] is [l'] if [is_neg] is [false]
+      - [l'] is [neg l] if [is_neg] is [true]
+      - [l'] is [l] if [is_neg] is [false]
       - [normal_form l'] is [l', false] *)
-
   val is_ground : t -> bool
   (** [is_ground l] is always [true] if [l] is a semantic literal, and otherwise
       is [true] iff the syntaxic literal is ground (does not contain free

--- a/src/lib/structures/literal.mli
+++ b/src/lib/structures/literal.mli
@@ -1,0 +1,85 @@
+(**************************************************************************)
+(*                                                                        *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                 *)
+(*     Copyright (C) 2023 --- OCamlPro SAS                                *)
+(*                                                                        *)
+(*     This file is distributed under the terms of OCamlPro               *)
+(*     Non-Commercial Purpose License, version 1.                         *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** This module contains a definition of a "combined" literal type that can
+    contain both syntaxic literals (expressions) and semantic literals (that
+    contain semantic values, see also the {!Xliteral} module). *)
+
+type 'a view = LTerm of Expr.t | LSem of 'a
+(** View over literals, parameterized by the type of semantic literals. Used for
+    both pattern-matching and creation of literals (through the [make] and
+    [view] functions). *)
+
+val pp_view : 'a Fmt.t -> 'a view Fmt.t
+(** Pretty-printer for views. *)
+
+val hash_view : ('a -> int) -> 'a view -> int
+(** Hash function for views. *)
+
+val equal_view : ('a -> 'a -> bool) -> 'a view -> 'a view -> bool
+(** Equality function for views. *)
+
+val compare_view : ('a -> 'a -> int) -> 'a view -> 'a view -> int
+(** Comparison function for views. *)
+
+module type S = sig
+  type elt
+  (** The type of semantic elements literals. *)
+
+  type t
+  (** The type of syntaxic or semantic literals. *)
+
+  val make : elt view -> t
+  (** Create a new literal given its view. *)
+
+  val view : t -> elt view
+  (** Extract a view from a literal (for pattern-matching). *)
+
+  val pp : t Fmt.t
+  (** Pretty-printer for literals. *)
+
+  val hash : t -> int
+  (** Hash function for literals. *)
+
+  val equal : t -> t -> bool
+  (** Equality of literals. Note that this does not try to look into the
+      semantic content of syntaxic literals: [x = y] as a term and [x = y] as a
+      semantic literal (where [x] and [y] are semantic values) are distinct. *)
+
+  val compare : t -> t -> int
+  (** Comparison function over literals. The order is unspecified. *)
+
+  val neg : t -> t
+  (** [neg t] is the boolean negation of [t]. *)
+
+  val normal_form : t -> t * bool
+  (** [normal_form l] returns the normal form of [l]. The normal form of [l] is
+      a pair [l', is_neg] such that:
+
+      - [l] is [neg l'] if [is_neg] is [true]
+      - [l] is [l'] if [is_neg] is [false]
+      - [normal_form l'] is [l', false] *)
+
+  val is_ground : t -> bool
+  (** [is_ground l] is always [true] if [l] is a semantic literal, and otherwise
+      is [true] iff the syntaxic literal is ground (does not contain free
+      variables nor free type variables). *)
+
+  module Table : Hashtbl.S with type key = t
+  (** Hash tables over literals. *)
+
+  module Set : Set.S with type elt = t
+  (** Sets of literals. *)
+
+  module Map : Map.S with type key = t
+  (** Maps over literals. *)
+end
+
+module Make(Sem : Xliteral.S) : S with type elt = Sem.t

--- a/src/lib/structures/objective.ml
+++ b/src/lib/structures/objective.ml
@@ -109,14 +109,14 @@ module Model = struct
          | Value _ | Unknown -> true
       ) mdl
 
-  exception Found of Function.t * int
+  exception Found of Function.t
 
-  let next_unknown ~for_model mdl =
+  let next_unknown mdl =
     try
-      M.iter (fun { f; order } v ->
+      M.iter (fun { f; order = _ } v ->
           match (v : Value.t) with
           | Value _ -> ()
-          | Limit _ | Pinfinity | Minfinity when for_model ->
+          | Limit _ | Pinfinity | Minfinity ->
             (* While generating models, keeps optimizing values with
                lower priority even if we see a limit value. *)
             ()
@@ -125,20 +125,10 @@ module Model = struct
                the last result was a limit. As CS can be performed in
                Assert mode, a unboundd problem can become bounded after
                a new assert. *)
-            raise (Found (f, order))
+            raise (Found f)
         ) mdl;
       None
     with
-    | Found (f, order) -> Some (f, order)
+    | Found f -> Some f
     | Exit -> None
-
-  let reset_until mdl o =
-    M.fold
-      (fun { f; order } _v acc ->
-         if order >= o then
-           M.add { f; order } Value.Unknown acc
-         else
-           acc
-      )
-      mdl mdl
 end

--- a/src/lib/structures/objective.ml
+++ b/src/lib/structures/objective.ml
@@ -115,17 +115,8 @@ module Model = struct
     try
       M.iter (fun { f; order = _ } v ->
           match (v : Value.t) with
-          | Value _ -> ()
-          | Limit _ | Pinfinity | Minfinity ->
-            (* While generating models, keeps optimizing values with
-               lower priority even if we see a limit value. *)
-            ()
-          | _ ->
-            (* While doing CS, we try again to optimize a bound even if
-               the last result was a limit. As CS can be performed in
-               Assert mode, a unboundd problem can become bounded after
-               a new assert. *)
-            raise (Found f)
+          | Unknown -> raise (Found f)
+          | Value _ | Limit _ | Pinfinity | Minfinity -> ()
         ) mdl;
       None
     with

--- a/src/lib/structures/objective.mli
+++ b/src/lib/structures/objective.mli
@@ -90,7 +90,7 @@ module Model : sig
   (** [functions mdl] returns the list of objective functions of the model
       [mdl] in decreasing order of priority. *)
 
-  val next_unknown : for_model:bool -> t -> (Function.t * int) option
+  val next_unknown : t -> Function.t option
   (** [next_unknown ~for_model mdl] returns the next optimization in
       decreasing order of priority whose the value is [Unknown].
       The flag [for_model] is [true] when we invoke this function during
@@ -100,8 +100,4 @@ module Model : sig
   val has_no_limit : t -> bool
   (** [has_no_limit mdl] checks if all the objective functions in the model
       [mdl] have a finite value or unknown value. *)
-
-  val reset_until : t -> int -> t
-  (** [reset_until mdl i] sets to [Unknown] the values of the objective
-      functions with priority greater than [i]. *)
 end

--- a/src/lib/structures/objective.mli
+++ b/src/lib/structures/objective.mli
@@ -92,10 +92,7 @@ module Model : sig
 
   val next_unknown : t -> Function.t option
   (** [next_unknown ~for_model mdl] returns the next optimization in
-      decreasing order of priority whose the value is [Unknown].
-      The flag [for_model] is [true] when we invoke this function during
-      model generation only. In this case, the function returns [None]
-      if we see a limit objective values. *)
+      decreasing order of priority whose the value is [Unknown]. *)
 
   val has_no_limit : t -> bool
   (** [has_no_limit mdl] checks if all the objective functions in the model

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -110,9 +110,9 @@ module type ATOM = sig
   val hash_atom  : atom -> int
   val tag_atom   : atom -> int
 
-  val add_lit_atom :
+  val add_atom :
     hcons_env -> Shostak.Literal.t -> var list -> atom * var list
-  val add_atom : hcons_env -> Expr.t -> var list -> atom * var list
+  val add_expr_atom : hcons_env -> Expr.t -> var list -> atom * var list
 
   module Set : Set.S with type elt = atom
   module Map : Map.S with type key = atom

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -28,7 +28,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-
 module type ATOM = sig
 
   type var =
@@ -45,7 +44,7 @@ module type ATOM = sig
 
   and atom =
     { var : var;
-      lit : Expr.t;
+      lit : Shostak.Literal.t;
       neg : atom;
       mutable watched : clause Vec.t;
       mutable is_true : bool;
@@ -76,7 +75,7 @@ module type ATOM = sig
   val pr_clause : Format.formatter -> clause -> unit
   val get_atom : hcons_env -> Expr.t ->  atom
 
-  val literal : atom -> Expr.t
+  val literal : atom -> Shostak.Literal.t
   val weight : atom -> float
   val is_true : atom -> bool
   val neg : atom -> atom
@@ -111,6 +110,8 @@ module type ATOM = sig
   val hash_atom  : atom -> int
   val tag_atom   : atom -> int
 
+  val add_lit_atom :
+    hcons_env -> Shostak.Literal.t -> var list -> atom * var list
   val add_atom : hcons_env -> Expr.t -> var list -> atom * var list
 
   module Set : Set.S with type elt = atom
@@ -150,6 +151,7 @@ module type FLAT_FORMULA = sig
   val empty_hcons_env : unit -> hcons_env
   val nb_made_vars : hcons_env -> int
   val get_atom : hcons_env -> Expr.t -> Atom.atom
+  val atom_hcons_env : hcons_env -> Atom.hcons_env
 
   val simplify :
     hcons_env ->

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -224,18 +224,21 @@ let get_rule () = !rule
 
 let case_split_policy = ref Util.AfterTheoryAssume
 let enable_adts_cs = ref false
+let enable_sat_cs = ref false
 let max_split = ref (Numbers.Q.from_int 1000000)
 
 (* Case split setters *)
 
 let set_case_split_policy p = case_split_policy := p
 let set_enable_adts_cs b = enable_adts_cs := b
+let set_enable_sat_cs b = enable_sat_cs := b
 let set_max_split n = max_split := n
 
 (* Case split getters *)
 
 let get_case_split_policy () = !case_split_policy
 let get_enable_adts_cs () = !enable_adts_cs
+let get_enable_sat_cs () = !enable_sat_cs
 let get_max_split () = !max_split
 
 (** Context options *)

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -321,6 +321,9 @@ val set_case_split_policy : Util.case_split_policy -> unit
 (** Set [enable_adts_cs] accessible with {!val:get_enable_adts_cs} *)
 val set_enable_adts_cs : bool -> unit
 
+(** Set [enable_sat_cs] accessible with {!val:get_enable_sat_cs} *)
+val set_enable_sat_cs : bool -> unit
+
 (** Set [replay] accessible with {!val:get_replay} *)
 val set_replay : bool -> unit
 
@@ -570,6 +573,11 @@ val get_case_split_policy : unit -> Util.case_split_policy
 
 (** [true] if case-split for Algebraic Datatypes theory is enabled. *)
 val get_enable_adts_cs : unit -> bool
+(** Default to [false] *)
+
+(** [true] if case-split are performed in the SAT solver rather than the theory
+    solver (only for CDCL solver and for select theories). *)
+val get_enable_sat_cs : unit -> bool
 (** Default to [false] *)
 
 (** Valuget_e specifying the maximum size of case-split. *)

--- a/tests/models/arith/arith3.optimize.expected
+++ b/tests/models/arith/arith3.optimize.expected
@@ -7,6 +7,6 @@ unknown
 )
 (objectives 
   (x (+ oo))
-  (y 0)
-  (z 0)
+  (y (+ oo))
+  (z (+ oo))
 )


### PR DESCRIPTION
This patch introduces the ability for the CDCL solver to deal with semantic literals. This is part of work towards #901 although it does not (yet) achieves the goals of #901.

More precisely:

 - We add a new `Literal` module in `structures` to represent literals that are either syntaxic (represented by expressions) or semantic (represented using the `Xliteral` module).

 - The new `Literal` module is used to represent the literals associated with the `Atom`s in the CDCL solver [1]

 - The CDCL solver has a special handling of these semantic literals, which are treated as "local" literals: they are not added in the variable ordering, and will not be decided upon by the solver. Instead, a new mechanism inspired by mSAT (and, transitively, mcSAT) is provided, where the theory is able to mark certain literals as "immediate decisions". When literals are marked this way, the solver will decide on one of the marked literals the next time a decision must be made. Literals marked as immediate decisions are part of a transient solver state, and are forgotten upon backtracking.

 - The theory uses this marking mechanism to communicate case splits (and a similar mechanism for optimization objectives, which is separate because the value of the objective is sent back to the theory once the decision is made) to the solver.

This mechanism allows to introduce splits that are, in a way, "local", and do not  pollute other branches of the solver. It can be seen as an intermediate step towards a mcSAT approach, but where we are still deciding on boolean literals and hence try to avoid adding a large number of splits globally into the solver -- although it does mean that the splits are not incorporated into the activity heuristic.

The functionality is currently gated behind a new flag `--enable-sat-cs`.

Note that with `--enable-sat-cs` this change is +46-13 on ae-format (and +8-7 on benchtop-tests) or a net positive of +33 on ae-format, so we might want to enable it by default.

[1] : It could also be used for the `Bj`s in the Tableaux solver, if we
      wanted to suport similar features in the Tableaux solver.