### PR TITLE
cleanup: Use proper namespacing for names

### DIFF
--- a/src/lib/reasoners/ac.ml
+++ b/src/lib/reasoners/ac.ml
@@ -169,12 +169,12 @@ module Make (X : Sig.X) = struct
     | None -> r, acc
     | Some _ -> match Expr.term_view t with
       | { Expr.f = Sy.Name { hs; kind = Sy.Ac; _ }; xs; ty; _ } ->
-        let aro_sy = Sy.name ("@" ^ (HS.view hs)) in
+        let aro_sy = Sy.name ~ns:Internal ("@" ^ (HS.view hs)) in
         let aro_t = Expr.mk_term aro_sy xs ty  in
         let eq = Expr.mk_eq ~iff:false aro_t t in
         X.term_embed aro_t, eq::acc
       | { Expr.f = Sy.Op Sy.Mult; xs; ty; _ } ->
-        let aro_sy = Sy.name "@*" in
+        let aro_sy = Sy.name ~ns:Internal "@*" in
         let aro_t = Expr.mk_term aro_sy xs ty  in
         let eq = Expr.mk_eq ~iff:false aro_t t in
         X.term_embed aro_t, eq::acc

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -36,7 +36,7 @@ module Z = Numbers.Z
 module Q = Numbers.Q
 
 let is_mult h = Sy.equal (Sy.Op Sy.Mult) h
-let mod_symb = Sy.name "@mod"
+let mod_symb = Sy.name ~ns:Internal "@mod"
 
 let calc_power (c : Q.t) (d : Q.t) (ty : Ty.t) =
   (* d must be integral and if we work on integer exponentation,
@@ -243,7 +243,9 @@ module Shostak
       if Options.get_no_nla() && P.is_const p1 == None && P.is_const p2 == None
       then
         (* becomes uninterpreted *)
-        let tau = E.mk_term (Sy.name ~kind:Sy.Ac "@*") [t1; t2] ty in
+        let tau =
+          E.mk_term (Sy.name ~kind:Sy.Ac ~ns:Internal "@*") [t1; t2] ty
+        in
         let xtau, ctx' = X.make tau in
         P.add p (P.create [coef, xtau] Q.zero ty), List.rev_append ctx' ctx
       else
@@ -256,7 +258,7 @@ module Shostak
          (P.is_const p2 == None ||
           (ty == Ty.Tint && P.is_const p1 == None)) then
         (* becomes uninterpreted *)
-        let tau = E.mk_term (Sy.name "@/") [t1; t2] ty in
+        let tau = E.mk_term (Sy.name ~ns:Internal "@/") [t1; t2] ty in
         let xtau, ctx' = X.make tau in
         P.add p (P.create [coef, xtau] Q.zero ty), List.rev_append ctx' ctx
       else
@@ -283,7 +285,7 @@ module Shostak
          (P.is_const p1 == None || P.is_const p2 == None)
       then
         (* becomes uninterpreted *)
-        let tau = E.mk_term (Sy.name "@%") [t1; t2] ty in
+        let tau = E.mk_term (Sy.name ~ns:Internal "@%") [t1; t2] ty in
         let xtau, ctx' = X.make tau in
         P.add p (P.create [coef, xtau] Q.zero ty), List.rev_append ctx' ctx
       else

--- a/src/lib/reasoners/ccx.ml
+++ b/src/lib/reasoners/ccx.ml
@@ -245,7 +245,7 @@ module Main : S = struct
   end
   (*BISECT-IGNORE-END*)
 
-  let one, _ = X.make (Expr.mk_term (Sy.name "@bottom") [] Ty.Tint)
+  let one, _ = X.make (Expr.mk_term (Sy.name ~ns:Internal "@bottom") [] Ty.Tint)
 
   let concat_leaves uf l =
     let concat_rec acc t =

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -125,6 +125,8 @@ module Main_Default : S = struct
       | _ -> Ty.fresh_tvar ()
 
     let logics_of_assumed st =
+      (* NB: using an [Hstring.Map] here depends on the fact that name mangling
+         is done pre-emptively in [Symbols.name] *)
       SE.fold
         (fun t mp ->
            match E.term_view t with

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -1184,22 +1184,23 @@ let extract_concrete_model cache =
                 Expr.ArraysEx.store arr_val i v
               ) vals abstract
           in
-          let id =
+          let id, is_user =
             let Expr.{ f; _ } = Expr.term_view t in
             match f with
-            | Sy.Name { hs; _ } -> hs
+            | Sy.Name { hs; ns = User; _ } -> hs, true
+            | Sy.Name { hs; _ } -> hs, false
             | _ ->
               (* We only store array declarations as keys in the cache
                  [array_selects]. *)
               assert false
           in
           let mdl =
-            if not @@ Id.Namespace.Internal.is_id (Hstring.view id) then
+            if is_user then
               ModelMap.add (id, [], ty) [] arr_val mdl
             else
               (* Internal identifiers can occur here if we need to generate
                  a model term for an embedded array but this array isn't itself
-                 declared by the user. *)
+                 declared by the user -- see the [embedded-array] test . *)
               mdl
           in
           (* We need to update the model [mdl] in order to substitute all the

--- a/src/lib/reasoners/use.ml
+++ b/src/lib/reasoners/use.ml
@@ -53,7 +53,7 @@ let union_tpl (x1,y1) (x2,y2) =
   Options.exec_thread_yield ();
   SE.union x1 x2, SA.union y1 y2
 
-let one, _ = X.make (E.mk_term (Symbols.name "@bottom") [] Ty.Tint)
+let one, _ = X.make (E.mk_term (Symbols.name ~ns:Internal "@bottom") [] Ty.Tint)
 let leaves r =
   match X.leaves r with [] -> [one] | l -> l
 

--- a/src/lib/structures/id.mli
+++ b/src/lib/structures/id.mli
@@ -36,8 +36,6 @@ type typed = t * Ty.t list * Ty.t
     - Types of its arguments.
     - The returned type. *)
 
-val dummy_typed : typed
-
 val compare_typed : typed -> typed -> int
 val equal : t -> t -> bool
 val show : t -> string
@@ -46,14 +44,11 @@ val pp : t Fmt.t
 module Namespace : sig
   module type S = sig
     val fresh : ?base:string -> unit -> string
-    val is_id : string -> bool
   end
 
   module Internal : S
   module Skolem : S
   module Abstract : S
-
-  val make_as_fresh_skolem : string -> string
 
   val reinit : unit -> unit
   (** Resets the [fresh_internal_name], [fresh_skolem] and [fresh_abstract]

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -921,9 +921,7 @@ module Flat_Formula : FLAT_FORMULA = struct
     if is_neg then a.Atom.neg,l else a,l
 
   let mk_new_proxy n =
-    let hs = Hs.make (".PROXY__" ^ (string_of_int n)) in
-    (* TODO: we should use a smart constructor here. *)
-    let sy = Symbols.Name { hs; kind = Symbols.Other; defined = false } in
+    let sy = Symbols.name ~ns:Internal @@ "PROXY__" ^ string_of_int n in
     E.mk_term sy [] Ty.Tbool
 
   let get_proxy_of f proxies_mp =
@@ -991,7 +989,7 @@ module Proxy_formula = struct
     if is_neg then a.Atom.neg,l else a,l
 
   let mk_new_proxy n =
-    let sy = Symbols.name @@ ".PROXY__" ^ (string_of_int n) in
+    let sy = Symbols.name ~ns:Internal @@ "PROXY__" ^ (string_of_int n) in
     E.mk_term sy [] Ty.Tbool
 
   let rec mk_cnf hcons f ((proxies, inv_proxies, new_vars, cnf) as accu) =

--- a/tests/issues/555.models.expected
+++ b/tests/issues/555.models.expected
@@ -3,6 +3,6 @@ unknown
 (
   (define-fun x () Int 0)
   (define-fun y () Int 0)
-  (define-fun a1 () (Array Int Int) (store (as @a5 (Array Int Int)) 0 0))
-  (define-fun a2 () (Array Int Int) (store (as @a4 (Array Int Int)) 0 0))
+  (define-fun a1 () (Array Int Int) (store (as @a4 (Array Int Int)) 0 0))
+  (define-fun a2 () (Array Int Int) (store (as @a5 (Array Int Int)) 0 0))
 )

--- a/tests/models/array/array1.models.expected
+++ b/tests/models/array/array1.models.expected
@@ -3,6 +3,6 @@ unknown
 (
   (define-fun x () Int 0)
   (define-fun y () Int 0)
-  (define-fun a1 () (Array Int Int) (store (as @a5 (Array Int Int)) 0 0))
-  (define-fun a2 () (Array Int Int) (store (as @a4 (Array Int Int)) 0 0))
+  (define-fun a1 () (Array Int Int) (store (as @a4 (Array Int Int)) 0 0))
+  (define-fun a2 () (Array Int Int) (store (as @a5 (Array Int Int)) 0 0))
 )


### PR DESCRIPTION
This introduces proper namespacing for variable names instead of relying on string prefixes. In order to disturb the ordering as little as possible, names are pre-mangled using their namespace (e.g. "x" in the `Internal` namespace is stored as ".!x") and further operations (hashing, comparison, etc.) are performed on the mangled names.