### PR TITLE
cleanup(CDCL): Get rid of `repush` list

### DIFF
--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -602,8 +602,10 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
         if Options.get_minimal_bj () && a.var.level <= lvl then begin
           assert (a.var.level >= 0);
           assert (a.var.level = 0 || a.var.reason != None);
-          (* bclement: Ported over from the old [enqueue_assigned] -- not sure
-             what this actually does *)
+          (* `timp` is set to `1 by `th_entailed` and we set it to `-1` here
+             when we propagate the atom to earlier levels so that we check in
+             `theory_propagate` whether it is still known by the theory or
+             we need to tell the theory about this fact again *)
           if a.timp = 1 then begin
             a.timp <- -1;
             a.neg.timp <- -1;

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -638,7 +638,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
       (try
          let last_dec =
            if Vec.size env.trail_lim = 0 then 0 else Vec.last env.trail_lim in
-         env.cpt_current_propagations <- (Vec.size env.trail) - last_dec
+         env.cpt_current_propagations <- env.qhead - last_dec
        with _ -> assert false
       );
     end;


### PR DESCRIPTION
When cancelling decisions, we collect literals at a higher decision level than the one we are cancelling to (when the `--minimal-bj` option is enabled) into a list, then replay them at the new decision level (using `enqueue_assigned`).

This method introduces linear space overhead for the intermediate list that gets created to store the literals to repush, aptly named `repush`.

This patch uses a more efficient implementation with no additional memory usage by directly moving the literal towards the start of the vector in a single pass, and removes the `enqueue_assigned` function and `repush` list.