### PR TITLE
Fix the `Dune` rule to generate the manpage

### DIFF
--- a/src/bin/text/dune
+++ b/src/bin/text/dune
@@ -12,8 +12,9 @@
 
 ; Rule to generate a man page for alt-ergo
 (rule
+  (deps (:bin Main_text.exe))
   (target alt-ergo.1)
-  (action (with-stdout-to %{target} (run alt-ergo --help=groff))))
+  (action (with-stdout-to %{target} (run %{bin} --help=groff))))
 
 ; Install the man page
 (install


### PR DESCRIPTION
`Dune 3.13` seems to be stuck if we don't specify explicitly the dependency between the executable `Main_text.exe` and the rule which produces the manpage.

Add an explicit dependency clause to prevent this issue.

This commit has to be backport on `v2.5.x` too.