### PR TITLE
Use a wrapper to set timers

### DIFF
--- a/src/lib/reasoners/ac.ml
+++ b/src/lib/reasoners/ac.ml
@@ -200,10 +200,6 @@ module Make (X : Sig.X) = struct
          got %i (%a)." (List.length xs) Expr.print_list xs;
       assert false
 
-  let make t =
-    Timers.with_timer Timers.M_AC Timers.F_make @@ fun () ->
-    make t
-
   let is_mine_symb sy _ = (not @@ Options.get_no_ac ()) && Sy.is_ac sy
 
   let type_info { t = ty; _ } = ty

--- a/src/lib/reasoners/adt.ml
+++ b/src/lib/reasoners/adt.ml
@@ -80,6 +80,8 @@ module Shostak (X : ALIEN) = struct
 
   let name = "Adt"
 
+  let timer = Timers.M_Adt
+
   [@@ocaml.ppwarning "XXX: IsConstr not interpreted currently. Maybe \
                       it's OK"]
   let is_mine_symb sy ty =

--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -853,5 +853,12 @@ let query env uf (ra, _, ex, _) =
     with
     | Ex.Inconsistent (expl, classes) -> Some (expl, classes)
 
-
 (* ################################################################ *)
+
+include Rel_utils.Instrumentation (struct
+    type nonrec t = t
+
+    let mod_ = Timers.M_Adt
+    let assume = assume
+    let query = query
+  end)

--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -46,6 +46,8 @@ module LR = Uf.LX
 module SLR = Set.Make(LR)
 module MHs = Hs.Map
 
+let timer = Timers.M_Adt
+
 type t =
   {
     classes : E.Set.t list;
@@ -854,11 +856,3 @@ let query env uf (ra, _, ex, _) =
     | Ex.Inconsistent (expl, classes) -> Some (expl, classes)
 
 (* ################################################################ *)
-
-include Rel_utils.Instrumentation (struct
-    type nonrec t = t
-
-    let mod_ = Timers.M_Adt
-    let assume = assume
-    let query = query
-  end)

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -743,28 +743,12 @@ module Shostak
       assert false
 
   let make t =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Arith Timers.F_make;
-        let res = make t in
-        Timers.exec_timer_pause Timers.M_Arith Timers.F_make;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Arith Timers.F_make;
-        raise e
-    else make t
+    Timers.with_timer Timers.M_Arith Timers.F_make @@ fun () ->
+    make t
 
   let solve r1 r2 pb =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Arith Timers.F_solve;
-        let res = solve r1 r2 pb in
-        Timers.exec_timer_pause Timers.M_Arith Timers.F_solve;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Arith Timers.F_solve;
-        raise e
-    else solve r1 r2 pb
+    Timers.with_timer Timers.M_Arith Timers.F_solve @@ fun () ->
+    solve r1 r2 pb
 
   let print = P.print
 

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -87,6 +87,8 @@ module Shostak
 
   let name = "arith"
 
+  let timer = Timers.M_Arith
+
   (*BISECT-IGNORE-BEGIN*)
   module Debug = struct
 
@@ -741,14 +743,6 @@ module Shostak
       solve_one pb r1 r2 lvs false (* false == safe mode *)
     with Unsafe ->
       assert false
-
-  let make t =
-    Timers.with_timer Timers.M_Arith Timers.F_make @@ fun () ->
-    make t
-
-  let solve r1 r2 pb =
-    Timers.with_timer Timers.M_Arith Timers.F_solve @@ fun () ->
-    solve r1 r2 pb
 
   let print = P.print
 

--- a/src/lib/reasoners/arrays_rel.ml
+++ b/src/lib/reasoners/arrays_rel.ml
@@ -428,19 +428,6 @@ let assume env uf la =
   in
   env, { Sig_rel.assume = l; remove = [] }
 
-
-let assume env uf la =
-  if Options.get_timers() then
-    try
-      Timers.exec_timer_start Timers.M_Arrays Timers.F_assume;
-      let res =assume env uf la in
-      Timers.exec_timer_pause Timers.M_Arrays Timers.F_assume;
-      res
-    with e ->
-      Timers.exec_timer_pause Timers.M_Arrays Timers.F_assume;
-      raise e
-  else assume env uf la
-
 let query _ _ _ = None
 let add env _ _ _ = env, []
 
@@ -452,3 +439,11 @@ let assume_th_elt t th_elt _ =
   | Util.Arrays ->
     failwith "This Theory does not support theories extension"
   | _ -> t
+
+include Rel_utils.Instrumentation (struct
+    type nonrec t = t
+
+    let mod_ = Timers.M_Arrays
+    let assume = assume
+    let query = query
+  end)

--- a/src/lib/reasoners/arrays_rel.ml
+++ b/src/lib/reasoners/arrays_rel.ml
@@ -81,6 +81,8 @@ module TBS = struct
   let add k v mp = add k (S.add v (find k mp)) mp
 end
 
+let timer = Timers.M_Arrays
+
 type t =
   {gets  : G.t;               (* l'ensemble des "get" croises*)
    tbset : S.t TBS.t ;        (* map t |-> set(t,-,-) *)
@@ -439,11 +441,3 @@ let assume_th_elt t th_elt _ =
   | Util.Arrays ->
     failwith "This Theory does not support theories extension"
   | _ -> t
-
-include Rel_utils.Instrumentation (struct
-    type nonrec t = t
-
-    let mod_ = Timers.M_Arrays
-    let assume = assume
-    let query = query
-  end)

--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -343,6 +343,8 @@ module Shostak(X : ALIEN) = struct
 
   let name = "bitv"
 
+  let timer = Timers.M_Bitv
+
   let is_mine_symb sy _ =
     match sy with
     | Sy.Bitv _

--- a/src/lib/reasoners/bitv_rel.ml
+++ b/src/lib/reasoners/bitv_rel.ml
@@ -34,6 +34,8 @@ module Sy = Symbols
 module X = Shostak.Combine
 module L = Xliteral
 
+let timer = Timers.M_Bitv
+
 (* Currently we only compute, but in the future we may want to perform the same
    simplifications as in [Bitv.make]. We currently don't, because we don't
    really have a way to share code that uses polynome between the theory and the
@@ -715,11 +717,3 @@ let assume_th_elt t th_elt _ =
   | Util.Bitv ->
     failwith "This Theory does not support theories extension"
   | _ -> t
-
-include Rel_utils.Instrumentation (struct
-    type nonrec t = t
-
-    let mod_ = Timers.M_Bitv
-    let assume = assume
-    let query = query
-  end)

--- a/src/lib/reasoners/bitv_rel.ml
+++ b/src/lib/reasoners/bitv_rel.ml
@@ -715,3 +715,11 @@ let assume_th_elt t th_elt _ =
   | Util.Bitv ->
     failwith "This Theory does not support theories extension"
   | _ -> t
+
+include Rel_utils.Instrumentation (struct
+    type nonrec t = t
+
+    let mod_ = Timers.M_Bitv
+    let assume = assume
+    let query = query
+  end)

--- a/src/lib/reasoners/enum.ml
+++ b/src/lib/reasoners/enum.ml
@@ -178,16 +178,8 @@ module Shostak (X : ALIEN) = struct
     Sig.{pb with sbt = List.rev_append (solve_bis r1 r2) pb.sbt}
 
   let solve r1 r2 pb =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Sum Timers.F_solve;
-        let res = solve r1 r2 pb in
-        Timers.exec_timer_pause Timers.M_Sum Timers.F_solve;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Sum Timers.F_solve;
-        raise e
-    else solve r1 r2 pb
+    Timers.with_timer Timers.M_Sum Timers.F_solve @@ fun () ->
+    solve r1 r2 pb
 
   let assign_value _ _ _ =
     (* As the models of this theory are finite, the case-split

--- a/src/lib/reasoners/enum.ml
+++ b/src/lib/reasoners/enum.ml
@@ -52,6 +52,8 @@ module Shostak (X : ALIEN) = struct
 
   let name = "Sum"
 
+  let timer = Timers.M_Sum
+
   let is_mine_symb sy ty =
     match sy, ty with
     | Sy.Op (Sy.Constr _), Ty.Tsum _ -> true
@@ -176,10 +178,6 @@ module Shostak (X : ALIEN) = struct
 
   let solve r1 r2 pb =
     Sig.{pb with sbt = List.rev_append (solve_bis r1 r2) pb.sbt}
-
-  let solve r1 r2 pb =
-    Timers.with_timer Timers.M_Sum Timers.F_solve @@ fun () ->
-    solve r1 r2 pb
 
   let assign_value _ _ _ =
     (* As the models of this theory are finite, the case-split

--- a/src/lib/reasoners/enum_rel.ml
+++ b/src/lib/reasoners/enum_rel.ml
@@ -337,31 +337,6 @@ let query env uf a_ex =
   try ignore(assume env uf [a_ex]); None
   with Ex.Inconsistent (expl, classes) -> Some (expl, classes)
 
-let assume env uf la =
-  if Options.get_timers() then
-    try
-      Timers.exec_timer_start Timers.M_Sum Timers.F_assume;
-      let res =assume env uf la in
-      Timers.exec_timer_pause Timers.M_Sum Timers.F_assume;
-      res
-    with e ->
-      Timers.exec_timer_pause Timers.M_Sum Timers.F_assume;
-      raise e
-  else assume env uf la
-
-let query env uf la =
-  if Options.get_timers() then
-    try
-      Timers.exec_timer_start Timers.M_Sum Timers.F_query;
-      let res = query env uf la  in
-      Timers.exec_timer_pause Timers.M_Sum Timers.F_query;
-      res
-    with e ->
-      Timers.exec_timer_pause Timers.M_Sum Timers.F_query;
-      raise e
-  else query env uf la
-
-
 let new_terms _ = Expr.Set.empty
 
 let instantiate ~do_syntactic_matching:_ _ env _ _  = env, []
@@ -371,3 +346,11 @@ let assume_th_elt t th_elt _ =
   | Util.Sum ->
     failwith "This Theory does not support theories extension"
   | _ -> t
+
+include Rel_utils.Instrumentation (struct
+    type nonrec t = t
+
+    let mod_ = Timers.M_Sum
+    let assume = assume
+    let query = query
+  end)

--- a/src/lib/reasoners/enum_rel.ml
+++ b/src/lib/reasoners/enum_rel.ml
@@ -32,6 +32,8 @@ module A  = Xliteral
 module L  = List
 module Hs = Hstring
 
+let timer = Timers.M_Sum
+
 type 'a abstract = 'a Enum.abstract =
   | Cons of Hs.t * Ty.t
   | Alien of 'a
@@ -346,11 +348,3 @@ let assume_th_elt t th_elt _ =
   | Util.Sum ->
     failwith "This Theory does not support theories extension"
   | _ -> t
-
-include Rel_utils.Instrumentation (struct
-    type nonrec t = t
-
-    let mod_ = Timers.M_Sum
-    let assume = assume
-    let query = query
-  end)

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1787,28 +1787,12 @@ module Make (Th : Theory.S) = struct
         Inst.add_predicate env.inst ~guard ~name gf dep }
 
   let unsat env fg =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Sat Timers.F_unsat;
-        let env = unsat env fg in
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_unsat;
-        env
-      with e ->
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_unsat;
-        raise e
-    else unsat env fg
+    Timers.with_timer Timers.M_Sat Timers.F_unsat @@ fun () ->
+    unsat env fg
 
   let assume env fg =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Sat Timers.F_assume;
-        let env = assume env fg in
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_assume;
-        env
-      with e ->
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_assume;
-        raise e
-    else assume env fg
+    Timers.with_timer Timers.M_Sat Timers.F_assume @@ fun () ->
+    assume env fg
 
   let empty_guards () = {
     current_guard = Expr.vrai;

--- a/src/lib/reasoners/instances.ml
+++ b/src/lib/reasoners/instances.ml
@@ -363,16 +363,8 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
         ) lf
 
   let new_facts env tbox selector substs =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Match Timers.F_new_facts;
-        let res = new_facts env tbox selector substs in
-        Timers.exec_timer_pause Timers.M_Match Timers.F_new_facts;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Match Timers.F_new_facts;
-        raise e
-    else new_facts env tbox selector substs
+    Timers.with_timer Timers.M_Match Timers.F_new_facts @@ fun () ->
+    new_facts env tbox selector substs
 
   let mround env axs tbox selector ilvl kind mconf =
     Debug.new_mround ilvl kind;
@@ -406,70 +398,30 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     in
     { env with lemmas = ME.add orig (guard, age,dep) env.lemmas }
 
-  (*** add wrappers to profile exported functions ***)
-
-  let add_terms env s gf =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Match Timers.F_add_terms;
-        let res = add_terms env s gf in
-        Timers.exec_timer_pause Timers.M_Match Timers.F_add_terms;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Match Timers.F_add_terms;
-        raise e
-    else add_terms env s gf
-
-  let add_lemma env gf dep =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Match Timers.F_add_lemma;
-        let res = add_lemma env gf dep in
-        Timers.exec_timer_pause Timers.M_Match Timers.F_add_lemma;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Match Timers.F_add_lemma;
-        raise e
-    else add_lemma env gf dep
-
-  let add_predicate env ~guard ~name gf =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Match Timers.F_add_predicate;
-        let res = add_predicate env ~guard ~name gf in
-        Timers.exec_timer_pause Timers.M_Match Timers.F_add_predicate;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Match Timers.F_add_predicate;
-        raise e
-    else add_predicate env ~guard ~name gf
-
-  let m_lemmas mconf env tbox selector ilvl =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Match Timers.F_m_lemmas;
-        let res = m_lemmas env tbox selector ilvl mconf in
-        Timers.exec_timer_pause Timers.M_Match Timers.F_m_lemmas;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Match Timers.F_m_lemmas;
-        raise e
-    else m_lemmas env tbox selector ilvl mconf
-
-  let m_predicates mconf env tbox selector ilvl =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Match Timers.F_m_predicates;
-        let res = m_predicates env tbox selector ilvl mconf in
-        Timers.exec_timer_pause Timers.M_Match Timers.F_m_predicates;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Match Timers.F_m_predicates;
-        raise e
-    else m_predicates env tbox selector ilvl mconf
-
   let matching_terms_info env = EM.terms_info env.matching
 
   let reinit_em_cache () = EM.reinit_caches ()
+
+  (*** add wrappers to profile exported functions ***)
+
+  let add_terms env s gf =
+    Timers.with_timer Timers.M_Match Timers.F_add_terms @@ fun () ->
+    add_terms env s gf
+
+  let add_lemma env gf dep =
+    Timers.with_timer Timers.M_Match Timers.F_add_lemma @@ fun () ->
+    add_lemma env gf dep
+
+  let add_predicate env ~guard ~name gf =
+    Timers.with_timer Timers.M_Match Timers.F_add_predicate @@ fun () ->
+    add_predicate env ~guard ~name gf
+
+  let m_lemmas mconf env tbox selector ilvl =
+    Timers.with_timer Timers.M_Match Timers.F_m_lemmas @@ fun () ->
+    m_lemmas env tbox selector ilvl mconf
+
+  let m_predicates mconf env tbox selector ilvl =
+    Timers.with_timer Timers.M_Match Timers.F_m_predicates @@ fun () ->
+    m_predicates env tbox selector ilvl mconf
 
 end

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -100,6 +100,8 @@ end
 
 module Sim = OcplibSimplex.Basic.Make(SimVar)(Numbers.Q)(Explanation)
 
+let timer = Timers.M_Arith
+
 type t = {
   inequations : P.t Inequalities.t MPL.t;
   monomes: (I.t * SX.t) MX0.t;
@@ -2535,19 +2537,13 @@ let assume_th_elt t th_elt dep =
 
   | _ -> t
 
+let assume = assume ~query:false
+
 let instantiate ~do_syntactic_matching env uf selector =
-  Timers.with_timer Timers.M_Arith Timers.F_instantiate @@ fun () ->
+  Timers.with_timer timer Timers.F_instantiate @@ fun () ->
   instantiate ~do_syntactic_matching env uf selector
 
 let reinit_cache () =
   let module Oracle = (val get_oracle ()) in
   Oracle.reset_age_cpt ();
   EM.reinit_caches ()
-
-include Rel_utils.Instrumentation (struct
-    type nonrec t = t
-
-    let mod_ = Timers.M_Arith
-    let assume = assume ~query:false
-    let query = query
-  end)

--- a/src/lib/reasoners/ite_rel.ml
+++ b/src/lib/reasoners/ite_rel.ml
@@ -54,6 +54,8 @@ module TB =
         if c <> 0 then c else Stdlib.compare b1 b2
     end)
 
+let timer = Timers.M_Ite
+
 (* The present theory simplifies the ite terms t of the form
     ite(pred, t1, t2)
    where pred is an assumed predicate by introducing the equation
@@ -219,11 +221,3 @@ let new_terms _ = E.Set.empty
 let instantiate ~do_syntactic_matching:_ _ env _ _ = env, []
 
 let assume_th_elt t _ _ = t
-
-include Rel_utils.Instrumentation (struct
-    type nonrec t = t
-
-    let mod_ = Timers.M_Ite
-    let assume = assume
-    let query = query
-  end)

--- a/src/lib/reasoners/ite_rel.ml
+++ b/src/lib/reasoners/ite_rel.ml
@@ -209,18 +209,6 @@ let assume env _ la =
     let env, deds = extract_pending_deductions env in
     env, { Sig_rel.assume = deds; remove = [] }
 
-let assume env uf la =
-  if Options.get_timers() then
-    try
-      Timers.exec_timer_start Timers.M_Ite Timers.F_assume;
-      let res =assume env uf la in
-      Timers.exec_timer_pause Timers.M_Ite Timers.F_assume;
-      res
-    with e ->
-      Timers.exec_timer_pause Timers.M_Ite Timers.F_assume;
-      raise e
-  else assume env uf la
-
 let case_split _env _uf ~for_model:_ = []
 
 let optimizing_objective _env _uf _o = None
@@ -231,3 +219,11 @@ let new_terms _ = E.Set.empty
 let instantiate ~do_syntactic_matching:_ _ env _ _ = env, []
 
 let assume_th_elt t _ _ = t
+
+include Rel_utils.Instrumentation (struct
+    type nonrec t = t
+
+    let mod_ = Timers.M_Ite
+    let assume = assume
+    let query = query
+  end)

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -552,16 +552,8 @@ module Make (X : Arg) : S with type theory = X.t = struct
       raise e
 
   let query env tbox =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Match Timers.F_query;
-        let res = query env tbox in
-        Timers.exec_timer_pause Timers.M_Match Timers.F_query;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Match Timers.F_query;
-        raise e
-    else query env tbox
+    Timers.with_timer Timers.M_Match Timers.F_query @@ fun () ->
+    query env tbox
 
   let max_term_depth env mx = {env with max_t_depth = max env.max_t_depth mx}
 

--- a/src/lib/reasoners/records.ml
+++ b/src/lib/reasoners/records.ml
@@ -49,6 +49,8 @@ module Shostak (X : ALIEN) = struct
 
   let name = "records"
 
+  let timer = Timers.M_Records
+
   type t = X.r abstract
   type r = X.r
 
@@ -385,14 +387,6 @@ module Shostak (X : ALIEN) = struct
     | Record _, Other _  -> orient_solved r2 r1 pb
     | Access _ , _ -> assert false
     | _ , Access _ -> assert false
-
-  let make t =
-    Timers.with_timer Timers.M_Records Timers.F_make @@ fun () ->
-    make t
-
-  let solve r1 r2 pb =
-    Timers.with_timer Timers.M_Records Timers.F_solve @@ fun () ->
-    solve r1 r2 pb
 
   let assign_value t _ eq =
     match embed t with

--- a/src/lib/reasoners/records.ml
+++ b/src/lib/reasoners/records.ml
@@ -387,28 +387,12 @@ module Shostak (X : ALIEN) = struct
     | _ , Access _ -> assert false
 
   let make t =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Records Timers.F_make;
-        let res = make t in
-        Timers.exec_timer_pause Timers.M_Records Timers.F_make;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Records Timers.F_make;
-        raise e
-    else make t
+    Timers.with_timer Timers.M_Records Timers.F_make @@ fun () ->
+    make t
 
   let solve r1 r2 pb =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_Records Timers.F_solve;
-        let res = solve r1 r2 pb in
-        Timers.exec_timer_pause Timers.M_Records Timers.F_solve;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_Records Timers.F_solve;
-        raise e
-    else solve r1 r2 pb
+    Timers.with_timer Timers.M_Records Timers.F_solve @@ fun () ->
+    solve r1 r2 pb
 
   let assign_value t _ eq =
     match embed t with

--- a/src/lib/reasoners/records_rel.ml
+++ b/src/lib/reasoners/records_rel.ml
@@ -30,6 +30,8 @@
 
 type t = unit
 
+let timer = Timers.M_Records
+
 let empty _ = ()
 let assume _ _ _ =
   (), { Sig_rel.assume = []; remove = []}

--- a/src/lib/reasoners/rel_utils.ml
+++ b/src/lib/reasoners/rel_utils.ml
@@ -376,23 +376,3 @@ end = struct
     let dom = CS.fold Constraint.propagate bcs.fresh dom in
     { bcs with fresh = CS.empty }, dom
 end
-
-module Instrumentation (R : sig
-    open Sig_rel
-    type t
-
-    val mod_ : Timers.ty_module
-
-    val assume : t ->
-      Uf.t -> (Shostak.Combine.r input) list -> t * Shostak.Combine.r result
-
-    val query  : t -> Uf.t -> Shostak.Combine.r input -> Th_util.answer
-  end) = struct
-  let assume env uf la =
-    Timers.with_timer R.mod_ Timers.F_assume @@ fun () ->
-    R.assume env uf la
-
-  let query env uf la =
-    Timers.with_timer R.mod_ Timers.F_query @@ fun () ->
-    R.query env uf la
-end

--- a/src/lib/reasoners/rel_utils.ml
+++ b/src/lib/reasoners/rel_utils.ml
@@ -376,3 +376,23 @@ end = struct
     let dom = CS.fold Constraint.propagate bcs.fresh dom in
     { bcs with fresh = CS.empty }, dom
 end
+
+module Instrumentation (R : sig
+    open Sig_rel
+    type t
+
+    val mod_ : Timers.ty_module
+
+    val assume : t ->
+      Uf.t -> (Shostak.Combine.r input) list -> t * Shostak.Combine.r result
+
+    val query  : t -> Uf.t -> Shostak.Combine.r input -> Th_util.answer
+  end) = struct
+  let assume env uf la =
+    Timers.with_timer R.mod_ Timers.F_assume @@ fun () ->
+    R.assume env uf la
+
+  let query env uf la =
+    Timers.with_timer R.mod_ Timers.F_query @@ fun () ->
+    R.query env uf la
+end

--- a/src/lib/reasoners/relation.ml
+++ b/src/lib/reasoners/relation.ml
@@ -127,6 +127,7 @@ let try_query (type a) (module R : Sig_rel.RELATION with type t = a) env uf a
   | None -> k ()
 
 let query env uf a =
+  Options.exec_thread_yield ();
   try_query (module Rel1) env.r1 uf a @@ fun () ->
   try_query (module Rel2) env.r2 uf a @@ fun () ->
   try_query (module Rel3) env.r3 uf a @@ fun () ->

--- a/src/lib/reasoners/relation.ml
+++ b/src/lib/reasoners/relation.ml
@@ -46,6 +46,8 @@ module Rel6 : Sig_rel.RELATION = Adt_rel
 
 module Rel7 : Sig_rel.RELATION = Ite_rel
 
+let timer = Timers.M_None
+
 type t = {
   r1: Rel1.t;
   r2: Rel2.t;
@@ -74,19 +76,33 @@ let (|@|) l1 l2 =
 let assume env uf sa =
   Options.exec_thread_yield ();
   let env1, ({ assume = a1; remove = rm1}:_ Sig_rel.result) =
-    Rel1.assume env.r1 uf sa in
+    Timers.with_timer Rel1.timer Timers.F_assume @@ fun () ->
+    Rel1.assume env.r1 uf sa
+  in
   let env2, ({ assume = a2; remove = rm2}:_ Sig_rel.result) =
-    Rel2.assume env.r2 uf sa in
+    Timers.with_timer Rel2.timer Timers.F_assume @@ fun () ->
+    Rel2.assume env.r2 uf sa
+  in
   let env3, ({ assume = a3; remove = rm3}:_ Sig_rel.result) =
-    Rel3.assume env.r3 uf sa in
+    Timers.with_timer Rel3.timer Timers.F_assume @@ fun () ->
+    Rel3.assume env.r3 uf sa
+  in
   let env4, ({ assume = a4; remove = rm4}:_ Sig_rel.result) =
-    Rel4.assume env.r4 uf sa in
+    Timers.with_timer Rel4.timer Timers.F_assume @@ fun () ->
+    Rel4.assume env.r4 uf sa
+  in
   let env5, ({ assume = a5; remove = rm5}:_ Sig_rel.result) =
-    Rel5.assume env.r5 uf sa in
+    Timers.with_timer Rel5.timer Timers.F_assume @@ fun () ->
+    Rel5.assume env.r5 uf sa
+  in
   let env6, ({ assume = a6; remove = rm6}:_ Sig_rel.result) =
-    Rel6.assume env.r6 uf sa in
+    Timers.with_timer Rel6.timer Timers.F_assume @@ fun () ->
+    Rel6.assume env.r6 uf sa
+  in
   let env7, ({ assume = a7; remove = rm7}:_ Sig_rel.result) =
-    Rel7.assume env.r7 uf sa in
+    Timers.with_timer Rel7.timer Timers.F_assume @@ fun () ->
+    Rel7.assume env.r7 uf sa
+  in
   {r1=env1; r2=env2; r3=env3; r4=env4; r5=env5; r6=env6; r7=env7},
   ({ assume = a1 |@| a2 |@| a3 |@| a4 |@| a5 |@| a6 |@| a7;
      remove = rm1 |@| rm2 |@| rm3 |@| rm4 |@| rm5 |@| rm6 |@| rm7}
@@ -103,26 +119,21 @@ let assume_th_elt env th_elt dep =
   let env7 = Rel7.assume_th_elt env.r7 th_elt dep in
   {r1=env1; r2=env2; r3=env3; r4=env4; r5=env5; r6=env6; r7=env7}
 
+let try_query (type a) (module R : Sig_rel.RELATION with type t = a) env uf a
+    k =
+  match Timers.with_timer R.timer Timers.F_query
+    @@ fun () -> R.query env uf a with
+  | Some r -> Some r
+  | None -> k ()
+
 let query env uf a =
-  Options.exec_thread_yield ();
-  match Rel1.query env.r1 uf a with
-  | Some _ as ans -> ans
-  | None ->
-    match Rel2.query env.r2 uf a with
-    | Some _ as ans -> ans
-    | None ->
-      match Rel3.query env.r3 uf a with
-      | Some _ as ans -> ans
-      | None ->
-        match Rel4.query env.r4 uf a with
-        | Some _ as ans -> ans
-        | None ->
-          match Rel5.query env.r5 uf a with
-          | Some _ as ans -> ans
-          | None ->
-            match Rel6.query env.r6 uf a with
-            | Some _ as ans -> ans
-            | None -> Rel7.query env.r7 uf a
+  try_query (module Rel1) env.r1 uf a @@ fun () ->
+  try_query (module Rel2) env.r2 uf a @@ fun () ->
+  try_query (module Rel3) env.r3 uf a @@ fun () ->
+  try_query (module Rel4) env.r4 uf a @@ fun () ->
+  try_query (module Rel5) env.r5 uf a @@ fun () ->
+  try_query (module Rel6) env.r6 uf a @@ fun () ->
+  try_query (module Rel7) env.r7 uf a @@ fun () -> None
 
 let case_split env uf ~for_model =
   Options.exec_thread_yield ();

--- a/src/lib/reasoners/relation.ml
+++ b/src/lib/reasoners/relation.ml
@@ -46,6 +46,7 @@ module Rel6 : Sig_rel.RELATION = Adt_rel
 
 module Rel7 : Sig_rel.RELATION = Ite_rel
 
+(* This value is unused. *)
 let timer = Timers.M_None
 
 type t = {

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1308,27 +1308,12 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
   (* instrumentation of relevant exported functions for profiling *)
   let assume t ff dep =
-    if not (Options.get_timers ()) then assume t ff dep
-    else
-      try
-        Timers.exec_timer_start Timers.M_Sat Timers.F_assume;
-        assume t ff dep;
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_assume;
-      with exn ->
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_assume;
-        raise exn
+    Timers.with_timer Timers.M_Sat Timers.F_assume @@ fun () ->
+    assume t ff dep
 
   let unsat t ff =
-    if not (Options.get_timers()) then unsat t ff
-    else
-      try
-        Timers.exec_timer_start Timers.M_Sat Timers.F_unsat;
-        let t = unsat t ff in
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_unsat;
-        t
-      with exn ->
-        Timers.exec_timer_pause Timers.M_Sat Timers.F_unsat;
-        raise exn
+    Timers.with_timer Timers.M_Sat Timers.F_unsat @@ fun () ->
+    unsat t ff
 
   let assume_th_elt env th_elt dep =
     SAT.assume_th_elt env.satml th_elt dep

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -383,19 +383,33 @@ struct
       AC.is_mine_symb sb ty
     with
     | true  , false , false, false, false, false ->
+      Timers.with_timer Timers.M_Arith Timers.F_make @@ fun () ->
       ARITH.make t
+
     | false , true  , false, false, false, false ->
+      Timers.with_timer Timers.M_Records Timers.F_make @@ fun () ->
       RECORDS.make t
+
     | false , false , true  , false, false, false ->
+      Timers.with_timer Timers.M_Bitv Timers.F_make @@ fun () ->
       BITV.make t
+
     | false , false , false , true , false, false ->
+      Timers.with_timer Timers.M_Sum Timers.F_make @@ fun () ->
       ENUM.make t
+
     | false , false , false , false, true , false ->
+      Timers.with_timer Timers.M_Adt Timers.F_make @@ fun () ->
       ADT.make t
+
     | false , false , false , false, false, true  ->
+      Timers.with_timer Timers.M_AC Timers.F_make @@ fun () ->
       AC.make t
+
     | false , false , false , false, false, false ->
+      Timers.with_timer Timers.M_None Timers.F_make @@ fun () ->
       term_embed t, []
+
     | _ -> assert false
 
   let fully_interpreted sb ty =
@@ -544,14 +558,31 @@ struct
         let tyb = CX.type_info rb in
         Debug.assert_have_mem_types tya tyb;
         let pb = match tya with
-          | Ty.Tint | Ty.Treal -> ARITH.solve ra rb pb
-          | Ty.Trecord _       -> RECORDS.solve ra rb pb
-          | Ty.Tbitv _         -> BITV.solve ra rb pb
-          | Ty.Tsum _          -> ENUM.solve ra rb pb
+          | Ty.Tint | Ty.Treal ->
+            Timers.with_timer ARITH.timer Timers.F_solve @@ fun () ->
+            ARITH.solve ra rb pb
+
+          | Ty.Trecord _       ->
+            Timers.with_timer RECORDS.timer Timers.F_solve @@ fun () ->
+            RECORDS.solve ra rb pb
+
+          | Ty.Tbitv _         ->
+            Timers.with_timer BITV.timer Timers.F_solve @@ fun () ->
+            BITV.solve ra rb pb
+
+          | Ty.Tsum _          ->
+            Timers.with_timer ENUM.timer Timers.F_solve @@ fun () ->
+            ENUM.solve ra rb pb
+
           (*| Ty.Tunit           -> pb *)
+
           | Ty.Tadt _ when not (Options.get_disable_adts()) ->
+            Timers.with_timer ADT.timer Timers.F_solve @@ fun () ->
             ADT.solve ra rb pb
-          | _                  -> solve_uninterpreted ra rb pb
+
+          | _                  ->
+            Timers.with_timer Timers.M_None Timers.F_solve @@ fun () ->
+            solve_uninterpreted ra rb pb
         in
         solve_list pb
         [@ocaml.ppwarning "TODO: a simple way of handling equalities \

--- a/src/lib/reasoners/shostak.ml
+++ b/src/lib/reasoners/shostak.ml
@@ -407,7 +407,6 @@ struct
       AC.make t
 
     | false , false , false , false, false, false ->
-      Timers.with_timer Timers.M_None Timers.F_make @@ fun () ->
       term_embed t, []
 
     | _ -> assert false
@@ -581,7 +580,7 @@ struct
             ADT.solve ra rb pb
 
           | _                  ->
-            Timers.with_timer Timers.M_None Timers.F_solve @@ fun () ->
+            Timers.with_timer Timers.M_Combine Timers.F_solve @@ fun () ->
             solve_uninterpreted ra rb pb
         in
         solve_list pb

--- a/src/lib/reasoners/sig.mli
+++ b/src/lib/reasoners/sig.mli
@@ -44,6 +44,8 @@ module type SHOSTAK = sig
   (** Name of the theory*)
   val name : string
 
+  val timer : Timers.ty_module
+
   (** return true if the symbol and the type are owned by the theory*)
   val is_mine_symb : Symbols.t -> Ty.t -> bool
 

--- a/src/lib/reasoners/sig_rel.mli
+++ b/src/lib/reasoners/sig_rel.mli
@@ -52,6 +52,8 @@ type 'a result = {
 module type RELATION = sig
   type t
 
+  val timer : Timers.ty_module
+
   val empty : Expr.Set.t list -> t
 
   val assume : t ->

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -856,28 +856,12 @@ module Main_Default : S = struct
   let cl_extract env = CC_X.cl_extract env.gamma
 
   let assume ?(ordered=true) facts t =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_CC Timers.F_assume;
-        let res = assume ordered facts t in
-        Timers.exec_timer_pause Timers.M_CC Timers.F_assume;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_CC Timers.F_assume;
-        raise e
-    else assume ordered facts t
+    Timers.with_timer Timers.M_CC Timers.F_assume @@ fun () ->
+    assume ordered facts t
 
   let query a t =
-    if Options.get_timers() then
-      try
-        Timers.exec_timer_start Timers.M_CC Timers.F_query;
-        let res = query a t in
-        Timers.exec_timer_pause Timers.M_CC Timers.F_query;
-        res
-      with e ->
-        Timers.exec_timer_pause Timers.M_CC Timers.F_query;
-        raise e
-    else query a t
+    Timers.with_timer Timers.M_CC Timers.F_query @@ fun () ->
+    query a t
 
   let extract_ground_terms env = env.terms
 

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -777,17 +777,8 @@ let union env r1 r2 dep =
   env, res
 
 let union env r1 r2 dep =
-  if Options.get_timers() then
-    try
-      Timers.exec_timer_start Timers.M_UF Timers.F_union;
-      let res = union env r1 r2 dep in
-      Timers.exec_timer_pause Timers.M_UF Timers.F_union;
-      res
-    with e ->
-      Timers.exec_timer_pause Timers.M_UF Timers.F_union;
-      raise e
-  else union env r1 r2 dep
-
+  Timers.with_timer Timers.M_UF Timers.F_union @@ fun () ->
+  union env r1 r2 dep
 
 let rec distinct env rl dep =
   Debug.all env;
@@ -918,17 +909,8 @@ let make uf t = ME.find t uf.make
 (*** add wrappers to profile exported functions ***)
 
 let add env t =
-  if Options.get_timers() then
-    try
-      Timers.exec_timer_start Timers.M_UF Timers.F_add_terms;
-      let res = add env t  in
-      Timers.exec_timer_pause Timers.M_UF Timers.F_add_terms;
-      res
-    with e ->
-      Timers.exec_timer_pause Timers.M_UF Timers.F_add_terms;
-      raise e
-  else add env t
-
+  Timers.with_timer Timers.M_UF Timers.F_add_terms @@ fun () ->
+  add env t
 
 let is_normalized env r =
   List.for_all

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1512,17 +1512,8 @@ let apply_subst, clear_subst_cache =
   apply_subst, clear_subst_cache
 
 let apply_subst s t =
-  if Options.get_timers() then
-    try
-      Timers.exec_timer_start Timers.M_Expr Timers.F_apply_subst;
-      let res = apply_subst s t in
-      Timers.exec_timer_pause Timers.M_Expr Timers.F_apply_subst;
-      res
-    with e ->
-      Timers.exec_timer_pause Timers.M_Expr Timers.F_apply_subst;
-      raise e
-  else apply_subst s t
-
+  Timers.with_timer Timers.M_Expr Timers.F_apply_subst @@ fun () ->
+  apply_subst s t
 
 (** Subterms, and related stuff *)
 

--- a/src/lib/util/timers.ml
+++ b/src/lib/util/timers.ml
@@ -43,6 +43,8 @@ type ty_module =
   | M_Arrays
   | M_Sum
   | M_Records
+  | M_Adt
+  | M_Bitv
   | M_AC
   | M_Expr
   | M_Triggers
@@ -62,6 +64,8 @@ let all_modules =
     M_Arrays;
     M_Sum;
     M_Records;
+    M_Adt;
+    M_Bitv;
     M_AC;
     M_Expr;
     M_Triggers;
@@ -134,6 +138,8 @@ let string_of_ty_module k = match k with
   | M_Arrays   -> "Arrays"
   | M_Sum      -> "Sum"
   | M_Records  -> "Records"
+  | M_Adt      -> "Adt"
+  | M_Bitv     -> "Bitv"
   | M_AC       -> "AC"
   | M_Expr     -> "Expr"
   | M_Triggers -> "Triggers"
@@ -312,5 +318,9 @@ let (timer_pause : (ty_module -> ty_function -> unit) ref) =
 let set_timer_start f = assert (Options.get_timers ()); timer_start := f
 let set_timer_pause f = assert (Options.get_timers ()); timer_pause := f
 
-let exec_timer_start kd msg = !timer_start kd msg
-let exec_timer_pause kd = !timer_pause kd
+let with_timer mod_ fun_ f =
+  if not @@ Options.get_timers () then f ()
+  else begin
+    !timer_start mod_ fun_;
+    Fun.protect ~finally:(fun _ -> !timer_pause mod_ fun_) f
+  end

--- a/src/lib/util/timers.ml
+++ b/src/lib/util/timers.ml
@@ -34,6 +34,7 @@
 (* The type of modules, followed by the list of every element. *)
 type ty_module =
   | M_None
+  | M_Combine
   | M_Typing
   | M_Sat
   | M_Match
@@ -55,6 +56,7 @@ type ty_module =
 let all_modules =
   let l = [
     M_None;
+    M_Combine;
     M_Typing;
     M_Sat;
     M_Match;
@@ -129,6 +131,7 @@ let all_functions =
 
 let string_of_ty_module k = match k with
   | M_None     -> "None"
+  | M_Combine  -> "Combine"
   | M_Typing   -> "Typing"
   | M_Sat      -> "Sat"
   | M_Match    -> "Match"

--- a/src/lib/util/timers.mli
+++ b/src/lib/util/timers.mli
@@ -39,6 +39,8 @@ type ty_module =
   | M_Arrays
   | M_Sum
   | M_Records
+  | M_Adt
+  | M_Bitv
   | M_AC
   | M_Expr
   | M_Triggers
@@ -109,5 +111,6 @@ val set_timer_start : (ty_module -> ty_function -> unit) -> unit
 (** This functions assumes (asserts) that timers() yields true **)
 val set_timer_pause : (ty_module -> ty_function -> unit) -> unit
 
-val exec_timer_start : ty_module -> ty_function -> unit
-val exec_timer_pause : ty_module -> ty_function -> unit
+val with_timer : ty_module -> ty_function -> (unit -> 'a) -> 'a
+(** [with_timer mod_ fun_ f] wraps the call [f ()] with the timer
+    [(mod_, fun_)]. *)

--- a/src/lib/util/timers.mli
+++ b/src/lib/util/timers.mli
@@ -30,6 +30,7 @@
 
 type ty_module =
   | M_None
+  | M_Combine
   | M_Typing
   | M_Sat
   | M_Match


### PR DESCRIPTION
We wrap some important functions with timers in order to profile their calls but we don't use a dedicated function to do this job everywhere in the codebase. In particular, there is some places where we don't ensure the timer is correctly paused even if the wrapped function raises an exception.

This PR adds a new wrapper `with_timer` to perform this job correctly.

Add timers for the ADT and Bitv theories too.