### PR TITLE
cleanup(CP): Simplify constraint handling

### DIFF
--- a/src/lib/reasoners/rel_utils.ml
+++ b/src/lib/reasoners/rel_utils.ml
@@ -371,7 +371,6 @@ end = struct
     match MX.find rr t.leaves_map with
     | cs ->
       CS.fold (fun c t ->
-          let pending = CS.mem c t.pending in
           let t = remove c t  in
           let ex = Explanation.union ex c.explanation in
           add ~ex (Constraint.subst rr nrr c.value) t


### PR DESCRIPTION
This patch rewrites the `Constraints_make` module in order to make it more flexible (this is preparatory step for dealing with arithmetic bit-vector constraints, see #903).

More precisely:

 - Constraints no longer need to keep track of their own explanations, this is now entirely done by the `Constraints_make` functor. This makes it simpler to write `Constraint` modules, and avoid repeating boilerplate code to deal with explanation storage. Instead, the explanations are provided to the `Constraint` module in its `propagate` function.

 - The `Constraints_make` functor no longer need to know about constraint propagation. Instead, it simply keeps track of constraints that need to be propagated (pending constraints), and provides an API to iterate (and remove) the set of constraints to be propagated, letting the user take care of propagation proper.

 - The `Constraints_make` functor now tracks separately the constraint arguments and the leaves of said arguments. The leaves are used to know which constraints need to be updated during a substitution, and the arguments are used to mark as pending all constraints that apply to a given representative when its domain is updated (note that, for the bit-list domains, we actually store the domains at the leaves, so the arguments mapping is not used -- but this still makes the module more flexible in general, and in particular will allow to introduce arithmetic domains that need to be stored for all values, not only leaves, for the purpose of #903 in a future PR)

The new design should make it easier to write `Constraint` modules. It also fixes a bug in the contract between the `Constraint` and `Domain` modules regarding substitution: the `Domain` modules was written under the assumption that constraints applying to `changed` domains would always be marked as pending upon substitution, but that is not true because we use functional representations where such updates are delayed, and hence the `changed` flag needs to be propagated after substitution (if appropriate).