### PR TITLE
feat(CDCL-Tableaux): Do not make irrelevant decisions

### DIFF
--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -374,7 +374,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
           We maintain the following invariants:
 
-          - Any *unknown* variable is either in the [order] heap, or in the
+          - Any *undecided* variable is either in the [order] heap, or in the
              [irrelevants] set
           - Any variable in the [irrelevants] set is not relevant (i.e. neither
              [v.na] nor [v.pa] is in the [lazy_cnf] -- this invariant is locally
@@ -1787,7 +1787,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
          propagated to the theory).
 
          Note that we can only do this if [get_cdcl_tableaux_inst ()] is [true],
-         because otherwise instanciation requires a complete boolean model. *)
+         because otherwise instantiation requires a complete boolean model. *)
       if Matoms.mem v.pa env.lazy_cnf || Matoms.mem v.na env.lazy_cnf then
         make_decision env atom
       else (

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -107,7 +107,9 @@ module type ATOM = sig
 
   (*val made_vars_info : unit -> int * var list*)
 
-  val cmp_var : var -> var -> int
+  val equal_var : var -> var -> bool
+  val compare_var : var -> var -> int
+  val hash_var : var -> int
 
   val cmp_atom : atom -> atom -> int
   val eq_atom   : atom -> atom -> bool
@@ -389,13 +391,9 @@ module Atom : ATOM = struct
 
   let to_int f = int_of_float f
 
-  let cmp_var v1 v2 = v1.vid - v2.vid
-
-  (* unused --
-     let eq_var v1 v2 = v1.vid - v2.vid = 0
-     let tag_var v = v.vid
-     let h_var v = v.vid
-  *)
+  let equal_var v1 v2 = v1.vid = v2.vid
+  let compare_var v1 v2 = v1.vid - v2.vid
+  let hash_var v = Hashtbl.hash v.vid
 
   let cmp_atom a1 a2 = a1.aid - a2.aid
   let eq_atom   a1 a2 = a1.aid - a2.aid = 0

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -103,7 +103,9 @@ module type ATOM = sig
 
   (*val made_vars_info : unit -> int * var list*)
 
-  val cmp_var : var -> var -> int
+  val equal_var : var -> var -> bool
+  val compare_var : var -> var -> int
+  val hash_var : var -> int
 
   val cmp_atom : atom -> atom -> int
   val eq_atom   : atom -> atom -> bool


### PR DESCRIPTION
The CDCL-Tableaux solver uses the structure of the original formula both to limit the literals that are propagated to the theory module and to focus the (sub)-terms of the formula to use for instantiation.

Effectively, it only uses literals that are either asserted directly (possibly as part of a conjunction), or that are the *first* literal that was decided in a disjunction. For instance, if the formula [P \/ Q] is asserted, and we decide that [P] holds, [P] will be propagated to the theory module and used for instantiation -- but if we ever decide or prove that [Q] holds (or does not hold), that information will be ignored by the theory and instantiation modules.

In these conditions, deciding on [Q] is unlikely to help us make any progress, and so this patch prevents the CDCL-Tableaux solver from taking decisions on such irrelevant variables.

**Benchmarks**: This PR is +121-44 (net: +77) and a slight performance boost (around 1.5%) on AE-Format.