### PR TITLE
chore(CI): Bump GitHub Actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Checkout the code of the current branch
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Switch to ocaml user
       - run: su ocaml

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Checkout the code of the current branch
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Update apt-get database
       - name: Update apt-get database
@@ -35,7 +35,7 @@ jobs:
       # if we use another ocaml version
       # This action only retrieve de .opam/ directory
       - name: Retrieve opam cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-opam
         with:
           path: ~/.opam
@@ -58,7 +58,7 @@ jobs:
         run: opam exec -- make js-node
 
       # Use Node Js actions
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '14'
 
@@ -71,7 +71,7 @@ jobs:
       # the artifact name contains the system is builded on and the ocaml
       # compiler version used
       - name: Upload alt-ergo.js
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next'
         with:
           name: alt-ergo-js-${{ runner.os }}-${{ env.OCAML_DEFAULT_VERSION }}
@@ -85,7 +85,7 @@ jobs:
       # the artifact name contains the system is builded on and the ocaml
       # compiler version used
       - name: Upload alt-ergo-worker.js
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next'
         with:
           name: alt-ergo-worker-js-${{ runner.os }}-${{ env.OCAML_DEFAULT_VERSION }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # Checkout the code of the current branch
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Update apt-get database
       - name: Update apt-get database
@@ -43,7 +43,7 @@ jobs:
       # if we use another ocaml version
       # This action only retrieve de .opam/ directory
       - name: Retrieve opam cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-opam
         with:
           path: ~/.opam
@@ -86,7 +86,7 @@ jobs:
       # This is only done if this workflow is triggered in a PR or on the
       # following branches : next, main
       - name: Upload ocaml documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: github.event_name == 'pull_request' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/main'
         with:
           name: ocaml_doc
@@ -111,7 +111,7 @@ jobs:
     steps:
       # Checkout the code of the current branch
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Build the sphinx documentation
       # and automatically print any error or warning
@@ -124,7 +124,7 @@ jobs:
       # Create and upload an artifact `sphinx_doc` that contains the sphinx
       # documentation in html format.
       - name: Upload sphinx documentation
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sphinx_doc
           path: docs/sphinx_docs/_build
@@ -145,14 +145,14 @@ jobs:
     steps:
       # Retrieve ocaml documentation artifact
       - name: Download ocaml documentation
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ocaml_doc
           path: _build/odoc/dev
 
       # Retrieve sphinx documentation artifact
       - name: Download sphinx documentation
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: sphinx_doc
           path: _build

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,14 +25,14 @@ jobs:
     steps:
       # Checkout the code of the current branch
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Retrieve the opam cache with unique key
       # A new cache is created/used if the `.opam` files changes or
       # if we use another ocaml version
       # This action only retrieve de .opam/ directory
       - name: Retrieve opam cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-opam
         with:
           path: ~/.opam
@@ -65,14 +65,14 @@ jobs:
     steps:
       # Checkout the code of the current branch
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Retrieve the opam cache with unique key
       # A new cache is created/used if the `.opam` files changes or
       # if we use another ocaml version
       # This action only retrieve de .opam/ directory
       - name: Retrieve opam cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-opam
         with:
           path: ~/.opam

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
         run: opam exec -- dune-release distrib
 
       - name: Upload the artefact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: alt-ergo-${{github.sha}}.tbz
           path: _build/alt-ergo-*.tbz


### PR DESCRIPTION
See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/