### PR TITLE
fix(dolmen): Preserve trigger order

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1578,12 +1578,11 @@ let rec mk_expr
           (*  All the triggers that are encoutered at this level are assumed
               to be user-defined. *)
           let triggers =
-            List.rev_map (
+            List.map (
               fun t ->
                 make_trigger ~loc ~name_base ~decl_kind ~in_theory
                   name hyp (t, true)
             ) trgs
-            (* double reverse to produce expressions with the right tags. *)
           in
 
           let mk = begin match e with


### PR DESCRIPTION
In spite of what the comment says, the Dolmen frontend currently reverses the order in which triggers are considered. This patch ensures that the trigger order is preserved by using `List.map` instead of `List.rev_map` (there is usually only very few triggers and the `mk_expr` itself is not tail-recursive).