### PR TITLE
fix(CI): Use lockfile for all workflows

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,23 +38,14 @@ jobs:
       - name: Update apt-get database
         run: sudo apt-get update
 
-      # Retrieve the opam cache with unique key
-      # A new cache is created/used if the `.opam` files changes or
-      # if we use another ocaml version
-      # This action only retrieve de .opam/ directory
-      - name: Retrieve opam cache
-        uses: actions/cache@v4
-        id: cache-opam
-        with:
-          path: ~/.opam
-          key: v1-${{ runner.os }}-alt-ergo-odoc-${{ env.OCAML_DEFAULT_VERSION }}-${{ hashFiles('*.opam') }}
-
       # Get an OCaml environment with opam installed and the proper ocaml version
       # opam will used opam cache environment if retrieved
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
+          allow-prerelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
+          dune-cache: true
 
       # Pin the packages, this is needed for opam depext
       # remove this step when opam 2.1 will be used

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,23 +27,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Retrieve the opam cache with unique key
-      # A new cache is created/used if the `.opam` files changes or
-      # if we use another ocaml version
-      # This action only retrieve de .opam/ directory
-      - name: Retrieve opam cache
-        uses: actions/cache@v4
-        id: cache-opam
-        with:
-          path: ~/.opam
-          key: v1-${{ runner.os }}-alt-ergo-indentation-${{ env.OCAML_DEFAULT_VERSION }}-${{ hashFiles('*.opam') }}
-
       # Get an OCaml environment with opam installed and the proper ocaml version
       # opam will used opam cache environment if retrieved
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
+          allow-prerelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
+          dune-cache: true
 
       # Install ocp-indent with the fixed version
       # Do nothing if ocp-indent is already installed
@@ -67,23 +58,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Retrieve the opam cache with unique key
-      # A new cache is created/used if the `.opam` files changes or
-      # if we use another ocaml version
-      # This action only retrieve de .opam/ directory
-      - name: Retrieve opam cache
-        uses: actions/cache@v4
-        id: cache-opam
-        with:
-          path: ~/.opam
-          key: v1-${{ runner.os }}-alt-ergo-style-${{ env.OCAML_DEFAULT_VERSION }}-${{ hashFiles('*.opam') }}
-
       # Get an OCaml environment with opam installed and the proper ocaml version
       # opam will used opam cache environment if retrieved
       - name: Use OCaml ${{ env.OCAML_DEFAULT_VERSION }}
         uses: ocaml/setup-ocaml@v2
         with:
+          allow-prerelease-opam: true
           ocaml-compiler: ${{ env.OCAML_DEFAULT_VERSION }}
+          dune-cache: true
 
       # Install dependencies of the ocpchecker executable
       # Dune and stdlib-shims is needed to build the executable


### PR DESCRIPTION
The lockfile is only used with the allow-prerelease-opam flag, but that flag is not used for some of the workflows. This patch makes sure we are using the lockfile in all workflows.

While here, it unifies the use of the `dune-cache` from setup-ocaml rather than our custom cache.