### PR TITLE
chore(dolmen): Use Dolmen builtins for bv2nat and int2bv

### DIFF
--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -88,15 +88,15 @@ conflicts: [
 pin-depends: [
   [
     "dolmen.dev"
-    "git+https://github.com/Gbury/dolmen.git#4637064b98d0af7e42e8a55845ca80cb19fe1f36"
+    "git+https://github.com/Gbury/dolmen.git#5e22e653ec376336bbbed50aca4946db8edbc90f"
   ]
   [
     "dolmen_loop.dev"
-    "git+https://github.com/Gbury/dolmen.git#4637064b98d0af7e42e8a55845ca80cb19fe1f36"
+    "git+https://github.com/Gbury/dolmen.git#5e22e653ec376336bbbed50aca4946db8edbc90f"
   ]
   [
     "dolmen_type.dev"
-    "git+https://github.com/Gbury/dolmen.git#4637064b98d0af7e42e8a55845ca80cb19fe1f36"
+    "git+https://github.com/Gbury/dolmen.git#5e22e653ec376336bbbed50aca4946db8edbc90f"
   ]
   [
     "js_of_ocaml.5.4.0"

--- a/nix/dolmen.nix
+++ b/nix/dolmen.nix
@@ -15,7 +15,7 @@ ocamlPackages.buildDunePackage {
   src = dolmen;
 
   nativeBuildInputs = [ ocamlPackages.menhir ];
-  propagatedBuildInputs = [ ocamlPackages.menhirLib ocamlPackages.fmt ];
+  propagatedBuildInputs = with ocamlPackages; [ hmap menhirLib fmt ];
 
   meta = with lib; {
     inherit (dolmen) homepage description;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "dolmen": {
-        "branch": "4637064b98d0af7e42e8a55845ca80cb19fe1f36",
+        "branch": "5e22e653ec376336bbbed50aca4946db8edbc90f",
         "description": "Dolmen provides a library and a binary to parse, typecheck, and evaluate languages used in automated deduction",
         "homepage": "",
         "owner": "Gbury",
         "repo": "dolmen",
-        "rev": "4637064b98d0af7e42e8a55845ca80cb19fe1f36",
-        "sha256": "0r3p5dfp684xccqz9jm9cf1lr6xzjvrhsk6kb7ydnadls30xdvgw",
+        "rev": "5e22e653ec376336bbbed50aca4946db8edbc90f",
+        "sha256": "1wmmq3x8zcp2zh3xpchjvhyj85qbydrpd2cf9awn4nxxaqi06yjn",
         "type": "tarball",
-        "url": "https://github.com/Gbury/dolmen/archive/4637064b98d0af7e42e8a55845ca80cb19fe1f36.tar.gz",
+        "url": "https://github.com/Gbury/dolmen/archive/5e22e653ec376336bbbed50aca4946db8edbc90f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "dev"
     },

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -523,6 +523,8 @@ let main () =
       ~size_limit ~response_file
     |> Parser.init
     |> Typer.init
+      ~additional_builtins:D_cnf.builtins
+      ~extension_builtins:[Typer.Ext.bv2nat]
     |> Typer_Pipe.init ~type_check
   in
 
@@ -1052,7 +1054,6 @@ let main () =
       let g =
         Parser.parse_logic ~preludes logic_file
       in
-      let st = State.set Typer.additional_builtins D_cnf.builtins st in
       let all_used_context = Frontend.init_all_used_context () in
       let finally = finally ~handle_exn in
       let st =


### PR DESCRIPTION
Use the new "bvconv" typing extension introduced in https://github.com/Gbury/dolmen/pull/208 instead of our own custom builtins.