### PR TITLE
feat(BV,CP): Use a FIFO queue for constraint propagation

### DIFF
--- a/src/lib/dune
+++ b/src/lib/dune
@@ -58,7 +58,7 @@
     Expr Var Ty Typed Xliteral ModelMap Id Objective Literal
     ; util
     Emap Gc_debug Hconsing Hstring Heap Lists Loc
-    MyUnix Numbers
+    MyUnix Numbers Uqueue
     Options Timers Util Vec Version Steps Printer My_zip
     Theories
   )

--- a/src/lib/reasoners/bitv_rel.ml
+++ b/src/lib/reasoners/bitv_rel.ml
@@ -398,6 +398,8 @@ let add_eqs =
 type any_constraint =
   | Constraint of Constraint.t Rel_utils.explained
   | Structural of X.r
+  (** Structural constraint associated with [X.r]. See
+      {!Rel_utils.Domains.structural_propagation}. *)
 
 module QC = Uqueue.Make(struct
     type t = any_constraint

--- a/src/lib/reasoners/rel_utils.ml
+++ b/src/lib/reasoners/rel_utils.ml
@@ -544,14 +544,14 @@ module Constraints_make(Constraint : Constraint) : sig
       constraints that applies to semantic values, and remembers the relation
       between constraints and semantic values.
 
-      The constraints associated with specific semantic values can be notified
-      (see [notify]), which is used to only propagate constraints involving
-      semantic values whose domain has changed.
+      The constraints applying to a given semantic value can be recovered using
+      the [iter_pending] functions.
 
-      The constraints that have been notified are called "pending
-      constraints", and the set thereof is the "pending set". These are
-      constraints that need to be propagated, and can be recovered using
-      [next_pending]. *)
+      New constraints are marked as "pending" when added to the constraint set
+      (whether by a call to [add] or following a substitution). These
+      constraints should ultimately be propagated; they can be accessed through
+      the [iter_pending]. Once pending constraints have been propagated, the
+      "pending" constraints should be cleared with [clear_pending]. *)
 
   val pp : t Fmt.t
   (** Pretty-printer for constraint sets. *)
@@ -588,8 +588,9 @@ module Constraints_make(Constraint : Constraint) : sig
 
   val has_pending : t -> bool
   (** [has_pending t] returns [true] if there is any constraint marked as
-      pending, in which case [iter_pending] and [clear_pending] are guaranteed
-      to be no-ops. Should only be used for optimization. *)
+      pending. Hence if [has_pending t] returns [false], [iter_pending] and
+      [clear_pending] are guaranteed to be no-ops. Should only be used for
+      optimization. *)
 
   val fold_args : (X.r -> 'a -> 'a) -> t -> 'a -> 'a
   (** [fold_args f t acc] folds [f] over all the term representatives that are

--- a/src/lib/util/uqueue.ml
+++ b/src/lib/util/uqueue.ml
@@ -1,0 +1,65 @@
+(**************************************************************************)
+(*                                                                        *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                 *)
+(*     Copyright (C) 2024 --- OCamlPro SAS                                *)
+(*                                                                        *)
+(*     This file is distributed under the terms of OCamlPro               *)
+(*     Non-Commercial Purpose License, version 1.                         *)
+(*                                                                        *)
+(*     As an exception, Alt-Ergo Club members at the Gold level can       *)
+(*     use this file under the terms of the Apache Software License       *)
+(*     version 2.0.                                                       *)
+(*                                                                        *)
+(*     More details can be found in the directory licenses/               *)
+(*                                                                        *)
+(**************************************************************************)
+
+module type S = sig
+  type elt
+
+  type t
+
+  val create : int -> t
+
+  val push : t -> elt -> unit
+
+  exception Empty
+
+  val pop : t -> elt
+
+  val peek : t -> elt
+
+  val is_empty : t -> bool
+
+  val clear : t -> unit
+end
+
+module Make(H : Hashtbl.HashedType) : S with type elt = H.t = struct
+  module HT = Hashtbl.Make(H)
+
+  type elt = H.t
+
+  type t = { queue : H.t Queue.t ; elements : unit HT.t}
+
+  let create n =
+    { queue = Queue.create () ; elements = HT.create n }
+
+  let push { queue ; elements } x =
+    if HT.mem elements x then () else (
+      HT.replace elements x ();
+      Queue.push x queue
+    )
+
+  exception Empty = Queue.Empty
+
+  let pop { queue ; elements } =
+    let x = Queue.pop queue in
+    HT.remove elements x; x
+
+  let peek { queue; _ } = Queue.peek queue
+
+  let is_empty { queue; _ } = Queue.is_empty queue
+
+  let clear { queue ; elements } =
+    Queue.clear queue; HT.clear elements
+end

--- a/src/lib/util/uqueue.mli
+++ b/src/lib/util/uqueue.mli
@@ -1,0 +1,60 @@
+(**************************************************************************)
+(*                                                                        *)
+(*     Alt-Ergo: The SMT Solver For Software Verification                 *)
+(*     Copyright (C) 2024 --- OCamlPro SAS                                *)
+(*                                                                        *)
+(*     This file is distributed under the terms of OCamlPro               *)
+(*     Non-Commercial Purpose License, version 1.                         *)
+(*                                                                        *)
+(*     As an exception, Alt-Ergo Club members at the Gold level can       *)
+(*     use this file under the terms of the Apache Software License       *)
+(*     version 2.0.                                                       *)
+(*                                                                        *)
+(*     More details can be found in the directory licenses/               *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** First-in first-out *unique* queues.
+
+    This module implements queues (FIFOs) without duplicates, with in-place
+    modifications. Implemented as a wrapper around the [Queue] and [Hashtbl] (to
+    ensure uniqueness) modules from the stdlib. *)
+
+module type S = sig
+  type elt
+  (** The type of elements in the unique queue. *)
+
+  type t
+  (** The type of unique queues with [elt] elements. *)
+
+  val create : int -> t
+  (** Create a new empty unique queue. The [int] parameter is passed to the
+      backing [Hashtbl] used to ensure uniqueness. *)
+
+  val push : t -> elt -> unit
+  (** [push q x] adds [x] at the end of the queue [q]. Does nothing if [x] is
+      already present in the queue. *)
+
+  exception Empty
+  (** Raised when [pop] or [peek] are applied to an empty queue. *)
+
+  val pop : t -> elt
+  (** [pop q] removes and returns the first element in queue [q], or raises
+      [Empty] if the queue is empty.
+
+      @raise Empty if the queue is empty. *)
+
+  val peek : t -> elt
+  (** [peek q] returns the first element in queue [q] without removing it, or
+      raises [Empty] if the queue is empty.
+
+      @raise Empty if the queue is empty. *)
+
+  val is_empty : t -> bool
+  (** Returns [true] if the queue is empty, [false] otherwise. *)
+
+  val clear : t -> unit
+  (** Discard all elements from the queue. *)
+end
+
+module Make(H : Hashtbl.HashedType) : S with type elt = H.t


### PR DESCRIPTION
This patch changes the bit-vector propagator to use a FIFO queue to select which propagator to run. Using a FIFO queue gives fairness guarantees on the constraints that get propagated, and does not depend on hash-consing shenanigans as in the current implementation.

The implementation is a simple wrapper around the `Queue` module from the stdlib and a hash table to ensure uniqueness of constraints in the queue.

*Note*: This depends on (and includes) #1044; only the last commit titled "feat(BV, CP): Use a FIFO queue for constraint propagation" is new.