### PR TITLE
Update `Lib_usage.ml`

### DIFF
--- a/dune
+++ b/dune
@@ -1,1 +1,0 @@
-(data_only_dirs examples)

--- a/examples/dune
+++ b/examples/dune
@@ -6,6 +6,7 @@
 
 (rule
  (alias runtest)
+ (package alt-ergo-lib)
  (action
   (ignore-stdout
    (ignore-stderr


### PR DESCRIPTION
We have changed a bit the API of the AE library but the `Lib_usage.ml` isn't up to date. 

I don't know why I prevented `Dune` from compiling this file, so I restore the compilation and the test of this file.