### PR TITLE
fix(CP): Do not add unnecessary explanations to domains

### DIFF
--- a/src/lib/reasoners/rel_utils.ml
+++ b/src/lib/reasoners/rel_utils.ml
@@ -503,8 +503,12 @@ struct
                 The only constraints that need to be notified are those that
                 were applying to [r], and they only need to be notified if the
                 new domain is different from the old domain of [r]. *)
-            let nd = Domain.intersect ~ex d (create_domain nr) in
+            let default = create_domain nr in
+            let nd = Domain.intersect ~ex d default in
             let r_changed = not (Domain.equal nd d) in
+            (* Make sure to not add more constraints than necessary for the
+               representative domain. *)
+            let nd = if Domain.equal nd default then default else nd in
             let domains = MX.add nr nd t.domains in
             let leaves_map = r_add nr t.leaves_map in
             let changed = changed || r_changed in


### PR DESCRIPTION
When performing a substitution that results in rewriting [r] into [nr] with explanation [ex], and [nr] does not yet have a registered domain, explanations from [ex] and the domain of [r] should only be added if they actually shrink the [nr]'s default domain.

Otherwise, we can end up with a constant having a non-empty explanation for why it is equal to itself -- which is wholly unnecessary and can cause irrelevant backtracking.