### PR TITLE
fix(smt-lib): Respect `reproducible-resource-limit` specification

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -611,8 +611,12 @@ let main () =
     | ":reproducible-resource-limit", Symbol { name = Simple level; _ } ->
       begin
         match int_of_string_opt level with
-        | Some i when i > 0 -> Options.set_timelimit_per_goal true
-        | Some 0 -> Options.set_timelimit_per_goal false
+        | Some i when i > 0 ->
+          Options.set_timelimit_per_goal true;
+          Options.set_timelimit (float_of_int i /. 1000.)
+        | Some 0 ->
+          Options.set_timelimit_per_goal false;
+          Options.set_timelimit 0.
         | None | Some _ ->
           print_wrn_opt ~name:":reproducible-resource-limit" st_loc
             "nonnegative integer" value


### PR DESCRIPTION
The SMT-LIB standard documentation for the `reproducible-resource-limit` option states:

> Setting it a non-zero numeral n will cause each subsequent check
> command to terminate within a bounded amount of time dependent on n.

We are currently using this as a boolean toggle to switch to the "timelimit per goal" interpretation of timeouts, but we are *not* respecting the fact that the limit must be dependent on n. Instead, the limit must be fixed by the user on the command line; if no timeout is passed on the command line, the `reproducible-resource-limit` option currently has no effect.

This patch changes it so that setting `reproducible-resource-limit` also sets the timeout (expressed in ms), making the behavior compatible with the specification.

Note that an unfortunate side-effect is that user-provided timeouts passed on the command line are no longer respected, because per-goal and global timeouts are mutually exclusive. This is its own issue that should be tackled separately if needed.