### PR TITLE
Sort trigger patterns before caching

### DIFF
--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -678,6 +678,8 @@ module Make (X : Arg) : S with type theory = X.t = struct
              | Util.Backward -> backward_triggers q, "Backward"
              | Util.Forward  -> forward_triggers q, "Forward"
            in
+           assert (List.for_all
+                     (fun E.{content; _} -> Lists.is_sorted pat_weight content) tgs);
            if Options.get_debug_triggers () then
              Printer.print_dbg
                ~module_name:"Matching" ~function_name:"add_triggers"

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -638,7 +638,10 @@ module Make (X : Arg) : S with type theory = X.t = struct
     let backward_triggers q =
       try HE.find trs_tbl q.E.main
       with Not_found ->
-        let trs = E.resolution_triggers ~is_back:true q in
+        let trs =
+          E.resolution_triggers ~is_back:true q
+          |> List.map sort_pats
+        in
         HE.add trs_tbl q.E.main trs;
         trs
     in
@@ -652,7 +655,10 @@ module Make (X : Arg) : S with type theory = X.t = struct
     let forward_triggers q =
       try HE.find trs_tbl q.E.main
       with Not_found ->
-        let trs = E.resolution_triggers ~is_back:false q in
+        let trs =
+          E.resolution_triggers ~is_back:false q
+          |> List.map sort_pats
+        in
         HE.add trs_tbl q.E.main trs;
         trs
     in

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -679,7 +679,9 @@ module Make (X : Arg) : S with type theory = X.t = struct
              | Util.Forward  -> forward_triggers q, "Forward"
            in
            assert (List.for_all
-                     (fun E.{content; _} -> Lists.is_sorted pat_weight content) tgs);
+                     (fun E.{content; _} ->
+                        Lists.is_sorted pat_weight content
+                     ) tgs);
            if Options.get_debug_triggers () then
              Printer.print_dbg
                ~module_name:"Matching" ~function_name:"add_triggers"

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -494,8 +494,8 @@ module Make (X : Arg) : S with type theory = X.t = struct
     let open Matching_types in
     let pats = pat_info.trigger in
     let pats_list = pats.E.content in
-    if Options.get_enable_assertions () then
-      assert (Lists.is_sorted pat_weight pats_list);
+    assert (not (Options.get_enable_assertions ()) ||
+            Lists.is_sorted pat_weight pats_list);
     Debug.matching pats;
     if List.length pats_list > Options.get_max_multi_triggers_size () then
       pat_info, []

--- a/src/lib/util/lists.ml
+++ b/src/lib/util/lists.ml
@@ -59,3 +59,8 @@ let rec try_map f l =
     Option.bind (f x) @@ fun y ->
     Option.bind (try_map f xs) @@ fun ys ->
     Some (y :: ys)
+
+let rec is_sorted cmp l =
+  match l with
+  | x :: y :: xs -> cmp x y <= 0 && is_sorted cmp (y :: xs)
+  | [_] | [] -> true

--- a/src/lib/util/lists.mli
+++ b/src/lib/util/lists.mli
@@ -51,3 +51,7 @@ val apply_right : ('a -> 'a) -> ('b * 'a) list -> ('b * 'a) list * bool
 val try_map : ('a -> 'b option) -> 'a list -> 'b list option
 (** [try_map f l] is similar to [List.map f l] but the function [f]
     may fail and the iterator shortcuts the computation. *)
+
+val is_sorted : ('a -> 'a -> int) -> 'a list -> bool
+(** [is_sorted cmp l] checks that [l] is sorted for the comparison function
+    [cmp]. *)


### PR DESCRIPTION
As we noticed a long time ago, the `Matching` module of Alt-Ergo sorts patterns of multi-triggers during each iteration of the matching round. It's inefficient as the weight used for sorting doesn't change.

I thought we should perform these sorts during the generation of triggers in `Expr` but actually, Alt-Ergo can generate new triggers later depending on the matching configuration (see `Util.matching_env`).

In this PR, we perform the sorts just before caching the generated triggers in `Matching`.