### PR TITLE
`ml_z_extract_small` is available in `zarith_stubs_js` v0.16.1

### DIFF
--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -5,7 +5,7 @@ name: Build Javascript
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.10.0
+  OCAML_DEFAULT_VERSION: 4.14.0
   # Add OPAMYES=true to the environment, this is usefull to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ dev-switch:
 
 js-deps:
 	opam pin add js_of_ocaml 5.4.0
+	opam pin add zarith_stubs_js v0.16.1
 	opam install js_of_ocaml-lwt js_of_ocaml-ppx data-encoding zarith_stubs_js lwt_ppx -y
 
 deps:

--- a/Makefile
+++ b/Makefile
@@ -246,9 +246,13 @@ dev-switch:
 	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 
 js-deps:
-	opam pin add js_of_ocaml 5.4.0
-	opam pin add zarith_stubs_js v0.16.1
-	opam install js_of_ocaml-lwt js_of_ocaml-ppx data-encoding zarith_stubs_js lwt_ppx -y
+	opam install \
+		js_of_ocaml>=5.4.0 \
+		js_of_ocaml-lwt \
+		js_of_ocaml-ppx \
+		data-encoding \
+		zarith_stubs_js>=v0.16.1 \
+		lwt_ppx -y
 
 deps:
 	opam install -y . --locked --deps-only

--- a/src/lib/missing_primitives.js
+++ b/src/lib/missing_primitives.js
@@ -39,11 +39,3 @@ function unix_getpid() {
 function unix_kill() {
   return 0;
 }
-
-// Fast path in ZArith 1.13, not in zarith_stubs_js
-// https://github.com/janestreet/zarith_stubs_js/issues/10
-// Provides: ml_z_extract_small
-// Requires: ml_z_extract
-function ml_z_extract_small(z1, pos, len) {
-  return ml_z_extract(z1, pos, len);
-}


### PR DESCRIPTION
We don't need to define this primitive anymore.