### PR TITLE
Fix js-deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,11 +247,11 @@ dev-switch:
 
 js-deps:
 	opam install \
-		js_of_ocaml>=5.4.0 \
+		'js_of_ocaml>=5.4.0' \
 		js_of_ocaml-lwt \
 		js_of_ocaml-ppx \
 		data-encoding \
-		zarith_stubs_js>=v0.16.1 \
+		'zarith_stubs_js>=v0.16.1' \
 		lwt_ppx -y
 
 deps:


### PR DESCRIPTION
Using `opam install package>=version` creates a file `=version` in the pwd. It seems that `opam install 'package>=version'` works better.