### PR TITLE
Prevent from adding dependencies of OCaml 5 in the lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ lock:
 	dune build ./alt-ergo-lib.opam
 	opam lock ./alt-ergo-lib.opam -w
 	# Remove OCaml compiler constraints
-	sed -i '/"ocaml"\|"ocaml-base-compiler"\|"ocaml-system"\|"ocaml-config"/d' ./alt-ergo-lib.opam.locked
+	sed -i '/"ocaml"\|"ocaml-base-compiler"\|"ocaml-system"\|"ocaml-config"\|"base-domains"\|"base-nnp"/d' ./alt-ergo-lib.opam.locked
 
 dev-switch:
 	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers


### PR DESCRIPTION
If you run `make lock` with an `opam` switch using `OCaml 5`, you got two new packages in the lock files: `base-domains` and `base-nnp`. Not surprisingly, the former requires `OCaml 5`. The latter is an optional dependency for `OCaml 4` so I prevent from adding it too in the lock file.