### PR TITLE
feat(BV): Display BV constants using hexadecimal

### DIFF
--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -462,7 +462,10 @@ module SmtPrinter = struct
       pp_rational ppf q
 
     | Sy.Bitv (n, s), [] ->
-      Fmt.pf ppf "#b%s" (Z.format (Fmt.str "%%0%db" n) s)
+      if n mod 4 = 0 then
+        Fmt.pf ppf "#x%s" (Z.format (Fmt.str "%%0%dx" (n / 4)) s)
+      else
+        Fmt.pf ppf "#b%s" (Z.format (Fmt.str "%%0%db" n) s)
 
     | Sy.MapsTo v, [t] ->
       Fmt.pf ppf "@[<2>(ae.mapsto %a %a@])" Var.print v pp t

--- a/tests/bitv/testfile-bv2nat-models.dolmen.expected
+++ b/tests/bitv/testfile-bv2nat-models.dolmen.expected
@@ -1,5 +1,5 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 4) #b0111)
+  (define-fun x () (_ BitVec 4) #x7)
 )

--- a/tests/models/bitv/bvand-1.models.expected
+++ b/tests/models/bitv/bvand-1.models.expected
@@ -1,6 +1,6 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 8) #b10100101)
-  (define-fun y () (_ BitVec 8) #b01011010)
+  (define-fun x () (_ BitVec 8) #xa5)
+  (define-fun y () (_ BitVec 8) #x5a)
 )

--- a/tests/models/bitv/bvand-2.models.expected
+++ b/tests/models/bitv/bvand-2.models.expected
@@ -1,5 +1,5 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 8) #b00000101)
+  (define-fun x () (_ BitVec 8) #x05)
 )

--- a/tests/models/bitv/bvor-1.models.expected
+++ b/tests/models/bitv/bvor-1.models.expected
@@ -1,6 +1,6 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 8) #b11111111)
-  (define-fun y () (_ BitVec 8) #b11111111)
+  (define-fun x () (_ BitVec 8) #xff)
+  (define-fun y () (_ BitVec 8) #xff)
 )

--- a/tests/models/bitv/bvor-2.models.expected
+++ b/tests/models/bitv/bvor-2.models.expected
@@ -1,5 +1,5 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 8) #b11110101)
+  (define-fun x () (_ BitVec 8) #xf5)
 )

--- a/tests/models/bitv/bvxor-1.models.expected
+++ b/tests/models/bitv/bvxor-1.models.expected
@@ -1,6 +1,6 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 8) #b00000000)
-  (define-fun y () (_ BitVec 8) #b10100101)
+  (define-fun x () (_ BitVec 8) #x00)
+  (define-fun y () (_ BitVec 8) #xa5)
 )

--- a/tests/models/bitv/bvxor-2.models.expected
+++ b/tests/models/bitv/bvxor-2.models.expected
@@ -1,5 +1,5 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 8) #b11110000)
+  (define-fun x () (_ BitVec 8) #xf0)
 )

--- a/tests/models/bitv/specified.models.expected
+++ b/tests/models/bitv/specified.models.expected
@@ -1,5 +1,5 @@
 
 unknown
 (
-  (define-fun x () (_ BitVec 4) #b0101)
+  (define-fun x () (_ BitVec 4) #x5)
 )


### PR DESCRIPTION
We currently always print bit-vector constants using binary representation. This can lead to quite large values in models when using 32- or 64-bit values that are essentially unreadable. When the bit-vector width is a multiple of 4, this patch uses hexadecimal notation instead, as allowed by the SMT-LIB specification.

Note that this only applies to bit-vector terms; bit-vector semantic values are always printed in their binary representation for debugging purposes.