### PR TITLE
feat(BV, CP): Add propagators for bvudiv and bvurem

### DIFF
--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -350,7 +350,7 @@ module Shostak(X : ALIEN) = struct
     | Op (
         Concat | Extract _ | BV2Nat
         | BVnot | BVand | BVor | BVxor
-        | BVadd | BVsub | BVmul)
+        | BVadd | BVsub | BVmul | BVudiv | BVurem)
       -> true
     | _ -> false
 
@@ -408,7 +408,7 @@ module Shostak(X : ALIEN) = struct
         match E.term_view t with
         | { f = Op (
             BVand | BVor | BVxor
-            | BVadd | BVsub | BVmul
+            | BVadd | BVsub | BVmul | BVudiv | BVurem
           ); _ } ->
           X.term_embed t, []
         | _ -> X.make t

--- a/src/lib/reasoners/intervals.ml
+++ b/src/lib/reasoners/intervals.ml
@@ -654,16 +654,19 @@ module Int = struct
                 (* x < y : bvurem is the identity *)
                 interval_set i1
               else if (
-                ZEuclideanType.equal i2.lb ZEuclideanType.zero ||
-                ZEuclideanType.compare i1.ub i2.ub < 0
+                ZEuclideanType.equal i2.lb ZEuclideanType.zero
               ) then
                 (* The range [0, i1.ub] is always valid; it is also the best we
-                   can do if [y] can be either [0] or bigger than [x]. *)
-                interval_set @@ { i1 with lb = ZEuclideanType.zero }
+                   can do if [y] can be [0]. *)
+                interval_set { i1 with lb = ZEuclideanType.zero }
               else
-                (* y is non-zero and smaller than x; use [0, i2.ub[ *)
-                interval_set @@
-                { lb = ZEuclideanType.zero ; ub = ZEuclideanType.pred i2.ub }
+                (* y is non-zero; we have both [x % y < y] and [x % y <= x] so
+                   take the min of these upper bounds. *)
+                let ub =
+                  if ZEuclideanType.compare i1.ub i2.ub < 0 then i1.ub
+                  else ZEuclideanType.pred i2.ub
+                in
+                interval_set { lb = ZEuclideanType.zero ; ub }
             ) u1
       ) u2
 end

--- a/src/lib/reasoners/intervals.ml
+++ b/src/lib/reasoners/intervals.ml
@@ -630,6 +630,36 @@ module Int = struct
 
   let lognot u =
     trace1 "lognot" u @@ map_strict_dec ZEuclideanType.lognot u
+
+  let bvudiv ~size:sz u1 u2 =
+    (* [bvudiv] is euclidean division where division by zero is -1 *)
+    let mone = Z.extract Z.minus_one 0 sz in
+    ediv ~div0:(Interval.of_bounds (Closed mone) (Closed mone)) u1 u2
+
+  let bvurem u1 u2 =
+    of_set_nonempty @@
+    map_to_set (fun i2 ->
+        if ZEuclideanType.equal i2.ub ZEuclideanType.zero then
+          (* [y] is always zero -> identity *)
+          map_to_set interval_set u1
+        else
+          map_to_set (fun i1 ->
+              if ZEuclideanType.compare i1.ub i2.lb < 0 then
+                (* x < y : bvurem is the identity *)
+                interval_set i1
+              else if (
+                ZEuclideanType.equal i2.lb ZEuclideanType.zero ||
+                ZEuclideanType.compare i1.ub i2.ub < 0
+              ) then
+                (* The range [0, i1.ub] is always valid; it is also the best we
+                   can do if [y] can be either [0] or bigger than [x]. *)
+                interval_set @@ { i1 with lb = ZEuclideanType.zero }
+              else
+                (* y is non-zero and smaller than x; use [0, i2.ub[ *)
+                interval_set @@
+                { lb = ZEuclideanType.zero ; ub = ZEuclideanType.pred i2.ub }
+            ) u1
+      ) u2
 end
 
 module Legacy = struct

--- a/src/lib/reasoners/intervals.mli
+++ b/src/lib/reasoners/intervals.mli
@@ -73,6 +73,20 @@ module Int : sig
       {b Note}: The interval [s] must be an integer interval, but is
       allowed to be unbounded (in which case [extract s i j] returns the
       full interval [[0, 2^(j - i + 1) - 1]]). *)
+
+  val bvudiv : size:int -> t -> t -> t
+  (** [bvudiv sz s t] computes an overapproximation of integer division for
+      bit-vectors of width [sz] as defined in the FixedSizeBitVectors SMT-LIB
+      theory, i.e. where [bvudiv n 0] is [2^sz - 1].
+
+      [s] and [t] must be within the [0, 2^sz - 1] range. *)
+
+  val bvurem : t -> t -> t
+  (** [bvurem sz s t] computes an overapproximation of integer remainder for
+      bit-vectors of width [sz] as defined in the FixedSizeBitVectors SMT-LIB
+      theory, i.e. where [bvurem n 0] is [n].
+
+      [s] and [t] must be within the [0, 2^sz - 1] range. *)
 end
 
 module Legacy : sig

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -3143,16 +3143,8 @@ module BV = struct
   let bvsub s t = mk_term (Op BVsub) [s; t] (type_info s)
   let bvneg s = bvsub (of_bigint_like s Z.zero) s
   let bvmul s t = mk_term (Op BVmul) [s; t] (type_info s)
-  let bvudiv s t =
-    let m = size2 s t in
-    ite (eq (bv2nat t) Ints.(~$0))
-      (bvones m)
-      (int2bv m Ints.(bv2nat s / bv2nat t))
-  let bvurem s t =
-    let m = size2 s t in
-    ite (eq (bv2nat t) Ints.(~$0))
-      s
-      (int2bv m Ints.(bv2nat s mod bv2nat t))
+  let bvudiv s t = mk_term (Op BVudiv) [s; t] (type_info s)
+  let bvurem s t = mk_term (Op BVurem) [s; t] (type_info s)
   let bvsdiv s t =
     let m = size2 s t in
     let msb_s = extract (m - 1) (m - 1) s in

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -44,7 +44,7 @@ type operator =
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
   | BVnot | BVand | BVor | BVxor
-  | BVadd | BVsub | BVmul
+  | BVadd | BVsub | BVmul | BVudiv | BVurem
   | Int2BV of int | BV2Nat
   (* FP *)
   | Float
@@ -192,7 +192,7 @@ let compare_operators op1 op2 =
             | Sqrt_real_excess | Min_real | Min_int | Max_real | Max_int
             | Integer_log2 | Pow | Integer_round
             | BVnot | BVand | BVor | BVxor
-            | BVadd | BVsub | BVmul
+            | BVadd | BVsub | BVmul | BVudiv | BVurem
             | Int2BV _ | BV2Nat
             | Not_theory_constant | Is_theory_constant | Linear_dependency
             | Constr _ | Destruct _ | Tite) -> assert false
@@ -354,6 +354,8 @@ module AEPrinter = struct
     | BVadd -> Fmt.pf ppf "bvadd"
     | BVsub -> Fmt.pf ppf "bvsub"
     | BVmul -> Fmt.pf ppf "bvmul"
+    | BVudiv -> Fmt.pf ppf "bvudiv"
+    | BVurem -> Fmt.pf ppf "bvurem"
 
     (* ArraysEx theory *)
     | Get -> Fmt.pf ppf "get"
@@ -457,6 +459,8 @@ module SmtPrinter = struct
     | BVadd -> Fmt.pf ppf "bvadd"
     | BVsub -> Fmt.pf ppf "bvsub"
     | BVmul -> Fmt.pf ppf "bvmul"
+    | BVudiv -> Fmt.pf ppf "bvudiv"
+    | BVurem -> Fmt.pf ppf "bvurem"
 
     (* ArraysEx theory *)
     | Get -> Fmt.pf ppf "select"

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -44,7 +44,7 @@ type operator =
   | Concat
   | Extract of int * int (* lower bound * upper bound *)
   | BVnot | BVand | BVor | BVxor
-  | BVadd | BVsub | BVmul
+  | BVadd | BVsub | BVmul | BVudiv | BVurem
   | Int2BV of int | BV2Nat
   (* FP *)
   | Float

--- a/tests/bitvec_tests.ml
+++ b/tests/bitvec_tests.ml
@@ -254,6 +254,18 @@ let test_bitlist_binop ~count sz zop bop =
          (IntSet.map2 zop (of_bitlist s) (of_bitlist t))
          (of_bitlist u))
 
+let test_interval_binop ~count sz zop iop =
+  Test.make ~count
+    ~print:Print.(
+        pair
+          (Fmt.to_to_string Intervals.Int.pp)
+          (Fmt.to_to_string Intervals.Int.pp))
+    Gen.(pair (intervals sz) (intervals sz))
+    (fun (s, t) ->
+       IntSet.subset
+         (IntSet.map2 zop (of_interval s) (of_interval t))
+         (of_interval (iop s t)))
+
 let zmul sz a b =
   Z.extract (Z.mul a b) 0 sz
 
@@ -263,3 +275,29 @@ let test_bitlist_mul sz =
 
 let () =
   Test.check_exn (test_bitlist_mul 3)
+
+let zudiv sz a b =
+  if Z.equal b Z.zero then
+    Z.extract Z.minus_one 0 sz
+  else
+    Z.div a b
+
+let test_interval_bvudiv sz =
+  test_interval_binop ~count:1_000
+    sz (zudiv sz) (Intervals.Int.bvudiv ~size:sz)
+
+let () =
+  Test.check_exn (test_interval_bvudiv 3)
+
+let zurem a b =
+  if Z.equal b Z.zero then
+    a
+  else
+    Z.rem a b
+
+let test_interval_bvurem sz =
+  test_interval_binop ~count:1_000
+    sz zurem Intervals.Int.bvurem
+
+let () =
+  Test.check_exn (test_interval_bvurem 3)


### PR DESCRIPTION
These are interval propagators only and respect the SMT-LIB semantics
for division by 0. This requires custom operators in the `Intervals`
module that update the bounds appropriately, sincethe existing `div`
operator is undefined on `0`.

**Note**: this requires and currently includes https://github.com/OCamlPro/alt-ergo/pull/1058 and #1083  ; the commit titled "feat(BV, CP): Add propagators for bvudiv and bvurem" is new.