### PR TITLE
 feat(BV, CP): Add propagators for bvshl and bvlshr

### DIFF
--- a/src/lib/reasoners/bitlist.mli
+++ b/src/lib/reasoners/bitlist.mli
@@ -121,6 +121,12 @@ val logxor : t -> t -> t
 val mul : t -> t -> t
 (** Integer multiplication. *)
 
+val shl : t -> t -> t
+(** Logical left shift. *)
+
+val lshr : t -> t -> t
+(** Logical right shift. *)
+
 val concat : t -> t -> t
 (** Bit-vector concatenation. *)
 

--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -350,7 +350,8 @@ module Shostak(X : ALIEN) = struct
     | Op (
         Concat | Extract _ | BV2Nat
         | BVnot | BVand | BVor | BVxor
-        | BVadd | BVsub | BVmul | BVudiv | BVurem)
+        | BVadd | BVsub | BVmul | BVudiv | BVurem
+        | BVshl | BVlshr)
       -> true
     | _ -> false
 
@@ -409,6 +410,7 @@ module Shostak(X : ALIEN) = struct
         | { f = Op (
             BVand | BVor | BVxor
             | BVadd | BVsub | BVmul | BVudiv | BVurem
+            | BVshl | BVlshr
           ); _ } ->
           X.term_embed t, []
         | _ -> X.make t

--- a/src/lib/reasoners/intervals.mli
+++ b/src/lib/reasoners/intervals.mli
@@ -87,6 +87,19 @@ module Int : sig
       theory, i.e. where [bvurem n 0] is [n].
 
       [s] and [t] must be within the [0, 2^sz - 1] range. *)
+
+  val bvshl : size:int -> t -> t -> t
+  (** [shl sz s t] computes an overapproximation of the left shift [s lsl t],
+      truncating the result to [sz] bits.
+
+      [s] and [t] must only contain non-negative integers. *)
+
+  val lshr : t -> t -> t
+  (** [lshr s t] computes an approximation of the logical right shift [s lsr t].
+
+      Note that the result of logical right shift is independent of bit width.
+
+      [s] and [t] must only contain non-negative integers. *)
 end
 
 module Legacy : sig

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -3185,8 +3185,8 @@ module BV = struct
       (bvneg u)
 
   (* Shift operations *)
-  let bvshl s t = int2bv (size2 s t) Ints.(bv2nat s * (~$2 ** bv2nat t))
-  let bvlshr s t = int2bv (size2 s t) Ints.(bv2nat s / (~$2 ** bv2nat t))
+  let bvshl s t = mk_term (Op BVshl) [s; t] (type_info s)
+  let bvlshr s t = mk_term (Op BVlshr) [s; t] (type_info s)
   let bvashr s t =
     let m = size2 s t in
     ite (is (extract (m - 1) (m - 1) s) 0)

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -45,6 +45,7 @@ type operator =
   | Extract of int * int (* lower bound * upper bound *)
   | BVnot | BVand | BVor | BVxor
   | BVadd | BVsub | BVmul | BVudiv | BVurem
+  | BVshl | BVlshr
   | Int2BV of int | BV2Nat
   (* FP *)
   | Float
@@ -193,6 +194,7 @@ let compare_operators op1 op2 =
             | Integer_log2 | Pow | Integer_round
             | BVnot | BVand | BVor | BVxor
             | BVadd | BVsub | BVmul | BVudiv | BVurem
+            | BVshl | BVlshr
             | Int2BV _ | BV2Nat
             | Not_theory_constant | Is_theory_constant | Linear_dependency
             | Constr _ | Destruct _ | Tite) -> assert false
@@ -356,6 +358,8 @@ module AEPrinter = struct
     | BVmul -> Fmt.pf ppf "bvmul"
     | BVudiv -> Fmt.pf ppf "bvudiv"
     | BVurem -> Fmt.pf ppf "bvurem"
+    | BVshl -> Fmt.pf ppf "bvshl"
+    | BVlshr -> Fmt.pf ppf "bvlshr"
 
     (* ArraysEx theory *)
     | Get -> Fmt.pf ppf "get"
@@ -461,6 +465,8 @@ module SmtPrinter = struct
     | BVmul -> Fmt.pf ppf "bvmul"
     | BVudiv -> Fmt.pf ppf "bvudiv"
     | BVurem -> Fmt.pf ppf "bvurem"
+    | BVshl -> Fmt.pf ppf "bvshl"
+    | BVlshr -> Fmt.pf ppf "bvlshr"
 
     (* ArraysEx theory *)
     | Get -> Fmt.pf ppf "select"

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -45,6 +45,7 @@ type operator =
   | Extract of int * int (* lower bound * upper bound *)
   | BVnot | BVand | BVor | BVxor
   | BVadd | BVsub | BVmul | BVudiv | BVurem
+  | BVshl | BVlshr
   | Int2BV of int | BV2Nat
   (* FP *)
   | Float

--- a/tests/bitvec_tests.ml
+++ b/tests/bitvec_tests.ml
@@ -276,6 +276,44 @@ let test_bitlist_mul sz =
 let () =
   Test.check_exn (test_bitlist_mul 3)
 
+let zshl sz a b =
+  match Z.to_int b with
+  | b when b < sz -> Z.extract (Z.shift_left a b) 0 sz
+  | _ | exception Z.Overflow -> Z.zero
+
+let test_interval_shl sz =
+  test_interval_binop ~count:1_000
+    sz (zshl sz) (Intervals.Int.bvshl ~size:sz)
+
+let () =
+  Test.check_exn (test_interval_shl 3)
+
+let test_bitlist_shl sz =
+  test_bitlist_binop ~count:1_000
+    sz (zshl sz) Bitlist.shl
+
+let () =
+  Test.check_exn (test_bitlist_shl 3)
+
+let zlshr a b =
+  match Z.to_int b with
+  | b -> Z.shift_right a b
+  | exception Z.Overflow -> Z.zero
+
+let test_interval_lshr sz =
+  test_interval_binop ~count:1_000
+    sz zlshr Intervals.Int.lshr
+
+let () =
+  Test.check_exn (test_interval_lshr 3)
+
+let test_bitlist_lshr sz =
+  test_bitlist_binop ~count:1_000
+    sz zlshr Bitlist.lshr
+
+let () =
+  Test.check_exn (test_bitlist_lshr 3)
+
 let zudiv sz a b =
   if Z.equal b Z.zero then
     Z.extract Z.minus_one 0 sz


### PR DESCRIPTION
This patch adds interval and bitlist propagators for the bvshl (left
shift) and bvlshr (logical right shift) in the intervals and bitlist
domains for bit-vectors.

The interval propagator for left shift needs to be written specially in
order to properly deal with overflow, but the propagator for bvlshr is
written using a generic propagator for (bi)-monotone functions.

The bitlist propagator for bvshl is required because it needs to
propagate information regarding low bits that are not tracked by
intervals. However, I am not sure that the bitlist propagator for bvlshr
is actually needed since it might be subsumed by the interval propagator
for bvlshr (and consistency constraints) entirely, and we might want to
remove it.

**Note**: this requires and currently includes https://github.com/OCamlPro/alt-ergo/pull/1058, https://github.com/OCamlPro/alt-ergo/pull/1083 and #1084 ; the commit titled " feat(BV, CP): Add propagators for bvshl and bvlshr" is new.