### PR TITLE
Remove `Lists.is_empty`

### DIFF
--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -149,7 +149,7 @@ module Types = struct
       let ty = Ty.text ty_vars id in
       ty, { env with to_ty = MString.add id ty env.to_ty }
     | Enum lc ->
-      if not (Lists.is_empty ty_vars) then
+      if not (Stdcompat.List.is_empty ty_vars) then
         Errors.typing_error (PolymorphicEnum id) loc;
       let ty = Ty.tsum id lc in
       ty, { env with to_ty = MString.add id ty env.to_ty }

--- a/src/lib/reasoners/bitv.ml
+++ b/src/lib/reasoners/bitv.ml
@@ -1024,7 +1024,7 @@ module Shostak(X : ALIEN) = struct
            a B-variable has been split into parts below.
            Therefore we assert that the variable is indeed a B variable and that
            list of substitutions for B variables is not empty. *)
-        assert (not (Lists.is_empty (fst subs)));
+        assert (not (Stdcompat.List.is_empty (fst subs)));
         assert (
           match st.bv.defn with Droot { sorte = B; _ } -> true | _ -> false
         );
@@ -1152,7 +1152,7 @@ module Shostak(X : ALIEN) = struct
         |[] -> bw
         |(t,vls)::r ->
           let (vls', csub) = uniforme_slice vls in
-          if Lists.is_empty csub then slice_rec ((t,vls')::bw) r
+          if Stdcompat.List.is_empty csub then slice_rec ((t,vls')::bw) r
           else
             begin
               let _bw = apply_subs csub bw in
@@ -1232,7 +1232,7 @@ module Shostak(X : ALIEN) = struct
       else begin
         let varsU = get_vars u in
         let varsV = get_vars v in
-        if Lists.is_empty varsU && Lists.is_empty varsV
+        if Stdcompat.List.(is_empty varsU && is_empty varsV)
         then raise Util.Unsolvable
         else
           begin
@@ -1440,7 +1440,7 @@ module Shostak(X : ALIEN) = struct
       Printer.print_dbg
         ~module_name:"Bitv" ~function_name:"subst"
         "subst %a |-> %a in %a" X.print x X.print subs print biv;
-    if Lists.is_empty biv then is_mine biv
+    if Stdcompat.List.is_empty biv then is_mine biv
     else
       let r = Canon.normalize (subst_rec x subs biv) in
       is_mine r

--- a/src/lib/reasoners/bitv_rel.ml
+++ b/src/lib/reasoners/bitv_rel.ml
@@ -523,7 +523,7 @@ let assume env uf la =
           la
       in
       let eqs, constraints, domain = propagate eqs constraints domain in
-      if Options.get_debug_bitv () && not (Lists.is_empty eqs) then (
+      if Options.get_debug_bitv () && not (Stdcompat.List.is_empty eqs) then (
         Printer.print_dbg
           ~module_name:"Bitv_rel" ~function_name:"assume"
           "bitlist domain: @[%a@]" Domains.pp domain;

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -1781,7 +1781,7 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
   let is_sat env =
     Option.is_none env.next_objective &&
-    Lists.is_empty env.next_decisions &&
+    Stdcompat.List.is_empty env.next_decisions &&
     Option.is_none env.next_split && (
       nb_assigns env = nb_vars env ||
       (Options.get_cdcl_tableaux_inst () &&

--- a/src/lib/util/lists.ml
+++ b/src/lib/util/lists.ml
@@ -28,10 +28,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-let is_empty = function
-  | [] -> true
-  | _ -> false
-
 let apply f l =
   let res, same =
     List.fold_left

--- a/src/lib/util/lists.mli
+++ b/src/lib/util/lists.mli
@@ -35,9 +35,6 @@
 
 (** {3 Misc functions} *)
 
-val is_empty : 'a list -> bool
-(** Is the list empty? *)
-
 val apply : ('a -> 'a) -> 'a list -> 'a list * bool
 (** [apply f [a_1; ...; a_n]] returns a couple [[f a_1; ...; f a_n], same]
     same such that: (1) "same" is true if and only if a_i == a_i for


### PR DESCRIPTION
As we use `Stdcompat`, we don't need to define `List.is_empty` in `Lists` anymore.