### PR TITLE
Fix soudness bug in Enum

### DIFF
--- a/tests/sum/testfile-sum019.ae
+++ b/tests/sum/testfile-sum019.ae
@@ -1,0 +1,15 @@
+type house = H1 | H2 | H3 | H4
+
+logic h1, h2 : house
+
+predicate leftof(h1: house, h2: house) =
+  (h2 = H2 -> h1 <> H2 and h1 <> H3 and h1 <> H4) (* h1 = H1 *)
+  and
+  (h2 = H3 -> h1 <> H1 and h1 <> H3 and h1 <> H4) (* h1 = H2 *)
+  and
+  (h2 = H4 -> h1 <> H1 and h1 <> H2 and h1 <> H4) (* h1 = H3 *)
+  and
+  (h2 = H1 -> h1 <> H1 and h1 <> H2 and h1 <> H3) (* h1 = H4 *)
+
+axiom clue : leftof(h1, h2)
+goal g : false

--- a/tests/sum/testfile-sum019.expected
+++ b/tests/sum/testfile-sum019.expected
@@ -1,0 +1,2 @@
+
+unknown


### PR DESCRIPTION
The PR #1078 introduces a soundness bug in `assume_distinct`. We have to propagate explanations of singleton domains, otherwise we may raise Inconsistency with an empty explanation.

Add a test that caught the bug.