### PR TITLE
Unique identifiers

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -647,6 +647,11 @@ let mk_term_decl ({ id_ty; path; tags; _ } as tcst: DE.term_cst) =
       | _ -> Sy.name name
     end
   in
+  let id =
+    match sy with
+    | Sy.Name { hs; _ } -> hs
+    | _ -> assert false
+  in
   Cache.store_sy tcst sy;
   (* Adding polymorphic types to the cache. *)
   Cache.store_ty_vars id_ty;
@@ -656,7 +661,7 @@ let mk_term_decl ({ id_ty; path; tags; _ } as tcst: DE.term_cst) =
       List.map dty_to_ty arg_tys, dty_to_ty ret_ty
     | _ -> [], dty_to_ty id_ty
   in
-  (Hstring.make name, arg_tys, ret_ty)
+  (id, arg_tys, ret_ty)
 
 (** Handles the definitions of a list of mutually recursive types.
     - If one of the types is an ADT, the ADTs that have only one case are

--- a/src/lib/frontend/models.ml
+++ b/src/lib/frontend/models.ml
@@ -193,11 +193,12 @@ module Pp_smtlib_term = struct
       fprintf fmt "(%a in %a, %a)" print t Sy.print_bound lb Sy.print_bound rb
 
     | Sy.Name { hs = n; _ }, l -> begin
-        let constraint_name =
-          try let constraint_name,_,_ =
+        assert false
+        (* let constraint_name =
+           try let constraint_name,_,_ =
                 (MS.find (Hstring.view n) !constraints) in
             constraint_name
-          with _ ->
+           with _ ->
             let constraint_name = "c_"^(Hstring.view n)  in
             constraints := MS.add (Hstring.view n)
                 (constraint_name,
@@ -205,11 +206,11 @@ module Pp_smtlib_term = struct
                  List.map (fun e -> to_string_type (E.type_info e)) l
                 ) !constraints;
             constraint_name
-        in
-        match l with
-        | [] -> fprintf fmt "%s" constraint_name
-        | l ->
-          fprintf fmt "(%s %a)" constraint_name (Printer.pp_list_space print) l;
+           in
+           match l with
+           | [] -> fprintf fmt "%s" constraint_name
+           | l ->
+           fprintf fmt "(%s %a)" constraint_name (Printer.pp_list_space print) l; *)
       end
 
     | _, [] ->

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -2165,7 +2165,7 @@ let axioms_of_rules loc name lf acc env =
       (fun acc f ->
          let name =
            Fmt.str "%s_%s"
-             (Id.Namespace.Internal.fresh ())
+             (Id.show ~full:true (Id.make ""))
              name
          in
          let td = {c = TAxiom(loc,name,Util.Default, f); annot = new_id () } in

--- a/src/lib/reasoners/ac.ml
+++ b/src/lib/reasoners/ac.ml
@@ -205,7 +205,7 @@ module Make (X : Sig.X) = struct
       | Some ac, { f = Name { hs; kind = Ac; _ } ; xs; ty; _ } ->
         (* It should have been abstracted when building [r] *)
         assert (not (Sy.equal sy ac.h));
-        let aro_sy = Sy.name ~ns:Internal ("@" ^ (HS.view hs)) in
+        let aro_sy = Sy.name ~ns:Internal ("@" ^ (Id.show hs)) in
         let aro_t = Expr.mk_term aro_sy xs ty  in
         let eq = Expr.mk_eq ~iff:false aro_t t in
         X.term_embed aro_t, eq::acc

--- a/src/lib/reasoners/ccx.ml
+++ b/src/lib/reasoners/ccx.ml
@@ -245,7 +245,7 @@ module Main : S = struct
   end
   (*BISECT-IGNORE-END*)
 
-  let one, _ = X.make (Expr.mk_term (Sy.name ~ns:Internal "@bottom") [] Ty.Tint)
+  let one = Use.one
 
   let concat_leaves uf l =
     let concat_rec acc t =

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1879,7 +1879,7 @@ module Make (Th : Theory.S) = struct
     clear_instances_cache ();
     Th.reinit_cpt ();
     Symbols.clear_labels ();
-    Id.Namespace.reinit ();
+    Id.reinit ();
     Var.reinit_cnt ();
     Satml_types.Flat_Formula.reinit_cpt ();
     Ty.reinit_decls ();

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1384,7 +1384,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
   let reinit_ctx () =
     Steps.reinit_steps ();
     Th.reinit_cpt ();
-    Id.Namespace.reinit ();
+    Id.reinit ();
     Symbols.clear_labels ();
     Var.reinit_cnt ();
     Satml_types.Flat_Formula.reinit_cpt ();

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -140,7 +140,7 @@ module Main_Default : S = struct
              let xs = List.map E.type_info xs in
              let xs, ty =
                try
-                 let xs', ty', is_ac' = Hstring.Map.find hs mp in
+                 let xs', ty', is_ac' = Id.Map.find hs mp in
                  assert (is_ac == is_ac');
                  let ty = generalize_types ty ty' in
                  let xs =
@@ -149,10 +149,10 @@ module Main_Default : S = struct
                  xs, ty
                with Not_found -> xs, ty
              in
-             Hstring.Map.add hs (xs, ty, is_ac) mp
+             Id.Map.add hs (xs, ty, is_ac) mp
 
            | _ -> mp
-        ) st Hstring.Map.empty
+        ) st Id.Map.empty
 
     let types_of_assumed sty =
       let open Ty in
@@ -232,12 +232,12 @@ module Main_Default : S = struct
 
     let print_logics ?(header=true) logics =
       print_dbg ~header "@[<v 2>(* logics: *)@ ";
-      Hstring.Map.iter
-        (fun hs (xs, ty, is_ac) ->
+      Id.Map.iter
+        (fun id (xs, ty, is_ac) ->
            print_dbg ~flushed:false ~header:false
-             "logic %s%s : %a%a@ "
+             "logic %s%a : %a%a@ "
              (if is_ac == Sy.Ac then "ac " else "")
-             (Hstring.view hs)
+             (Id.pp ~full:true) id
              print_arrow_type xs
              Ty.print ty
         )logics;

--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -1014,14 +1014,14 @@ module MED = Map.Make
         else Expr.compare a b
     end)
 
-let is_suspicious_name hs =
-  match Hstring.view hs with
+let is_suspicious_name s =
+  match s with
   | "@/" | "@%" | "@*" -> true
   | _ -> false
 
 (* The model generation is known to be imcomplete for FPA theory. *)
 let is_suspicious_symbol = function
-  | Symbols.Name { hs; _ } when is_suspicious_name hs -> true
+  | Symbols.Name { hs; _ } when is_suspicious_name (Id.show hs) -> true
   | _ -> false
 
 let terms env =

--- a/src/lib/reasoners/use.mli
+++ b/src/lib/reasoners/use.mli
@@ -33,6 +33,8 @@ module SA : Set.S with type elt = Expr.t * Explanation.t
 type t
 type r = Shostak.Combine.r
 
+val one : r
+
 val empty : t
 val find : r -> t -> Expr.Set.t * SA.t
 val add : r -> Expr.Set.t * SA.t -> t -> t

--- a/src/lib/structures/commands.ml
+++ b/src/lib/structures/commands.ml
@@ -49,7 +49,7 @@ type sat_tdecl = {
 let print_aux fmt = function
   | Decl (id, arg_tys, ret_ty) ->
     Fmt.pf fmt "declare %a with type (%a) -> %a"
-      Id.pp id
+      (Id.pp ~full:false) id
       Fmt.(list ~sep:comma Ty.print) arg_tys
       Ty.print ret_ty
 

--- a/src/lib/structures/errors.ml
+++ b/src/lib/structures/errors.ml
@@ -265,7 +265,7 @@ let report_model_error ppf = function
     Fmt.pf ppf
       "Cannot substitute the identifier %a of type %a by an expression of \
        type %a"
-      Id.pp id
+      (Id.pp ~full:true) id
       Ty.pp_smtlib ty1
       Ty.pp_smtlib ty2
 

--- a/src/lib/structures/id.mli
+++ b/src/lib/structures/id.mli
@@ -28,7 +28,15 @@
 (*                                                                        *)
 (**************************************************************************)
 
-type t = Hstring.t [@@deriving ord]
+type t
+
+val make : string -> t
+val hash : t -> int
+val equal : t -> t -> bool
+val compare : t -> t -> int
+val pp : ?full:bool -> t Fmt.t
+val show : ?full:bool -> t -> string
+val reinit : unit -> unit
 
 type typed = t * Ty.t list * Ty.t
 (** Typed identifier of function. In order:
@@ -37,20 +45,6 @@ type typed = t * Ty.t list * Ty.t
     - The returned type. *)
 
 val compare_typed : typed -> typed -> int
-val equal : t -> t -> bool
-val show : t -> string
-val pp : t Fmt.t
 
-module Namespace : sig
-  module type S = sig
-    val fresh : ?base:string -> unit -> string
-  end
-
-  module Internal : S
-  module Skolem : S
-  module Abstract : S
-
-  val reinit : unit -> unit
-  (** Resets the [fresh_internal_name], [fresh_skolem] and [fresh_abstract]
-      counters. *)
-end
+module Set : Set.S with type elt = t
+module Map : Map.S with type key = t

--- a/src/lib/structures/modelMap.ml
+++ b/src/lib/structures/modelMap.ml
@@ -138,7 +138,7 @@ type t = {
 let add ((id, arg_tys, _) as sy) arg_vals ret_val { values; suspicious } =
   if List.compare_lengths arg_tys arg_vals <> 0 then
     Fmt.invalid_arg "The arity of the symbol %a doesn't agree the number of \
-                     arguments" Id.pp id;
+                     arguments" (Id.pp ~full:false) id;
   let constraints =
     match P.find sy values with
     | C g -> g
@@ -193,7 +193,7 @@ let pp_named_arg_ty ~unused ppf (arg_name, arg_ty) =
 let pp_define_fun ~is_constant pp ppf ((id, arg_tys, ret_ty), a) =
   let named_arg_tys = List.mapi (fun i arg_ty -> (i, arg_ty)) arg_tys in
   Fmt.pf ppf "(@[define-fun %a (%a) %a@ %a)@]"
-    Id.pp id
+    (Id.pp ~full:false) id
     Fmt.(list ~sep:sp (pp_named_arg_ty ~unused:is_constant)) named_arg_tys
     Ty.pp_smtlib ret_ty
     pp a

--- a/src/lib/structures/symbols.mli
+++ b/src/lib/structures/symbols.mli
@@ -188,7 +188,7 @@ val print : t Fmt.t
 val to_string_clean : t -> string
 val print_clean : t Fmt.t
 
-val pp_name : (name_space * string) Fmt.t
+val pp_name : (name_space * Id.t) Fmt.t
 
 val pp_ae_operator : operator Fmt.t
 (* [pp_ae_operator ppf op] prints the operator symbol [op] on the


### PR DESCRIPTION
The current module `Id` uses `Hstring` to compare identifiers. This PR uses a hidden tag in the type `t` of `Id` to compare identifiers. This tag is unique by construction and the `Hstring` field is only used for printing.

In particular, calling twice `Sy.name` with the same input will produce two differents symbols. The full id (that is with the unique tag stored in it) can be print with `Id.pp ~full:true`.

This PR has to be tested a lot because we have to be sure we never store a symbol in a string in order to recreate it later for instance.