### PR TITLE
Remove `Expr.mk_binders`

### DIFF
--- a/src/lib/frontend/cnf.ml
+++ b/src/lib/frontend/cnf.ml
@@ -35,7 +35,13 @@ module SE = E.Set
 let varset_of_list =
   List.fold_left
     (fun acc (s,ty) ->
-       SE.add (E.mk_term s [] (Ty.shorten ty)) acc) SE.empty
+       let v =
+         match s with
+         | Sy.Var v -> v
+         | _ -> assert false
+       in
+       Var.Map.add v (Ty.shorten ty) acc
+    ) Var.Map.empty
 
 module ME =
   Map.Make
@@ -263,8 +269,7 @@ and make_form name_base ~toplevel f loc ~decl_kind : E.t =
         else Format.sprintf "#%s#sub-%d" name_base !name_tag
       in
       incr name_tag;
-      let qvars = varset_of_list qf.qf_bvars in
-      let binders = E.mk_binders qvars in
+      let binders = varset_of_list qf.qf_bvars in
       let ff = mk_form ~toplevel:false qf.qf_form.c in
 
       (* S : Formulas are purified afterwards.

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -746,12 +746,6 @@ let [@inline always] symbol_info t = t.f
    | _ -> true (* bool vars are terms *)
 *)
 
-let mk_binders st = TSet.fold (fun t sym ->
-    match t with
-    | { f = Sy.Var v; ty; _ } -> Var.Map.add v ty sym
-    | _ -> assert false
-  ) st Var.Map.empty
-
 let merge_vars acc b =
   Var.Map.merge (fun v a b ->
       match a, b with

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -167,8 +167,6 @@ val compare_quant : quantified -> quantified -> int
 val compare_let : letin -> letin -> int
 
 (** Some auxiliary functions *)
-
-val mk_binders : Set.t -> binders
 val free_vars : t -> (Ty.t * int) Var.Map.t -> (Ty.t * int) Var.Map.t
 val free_type_vars : t -> Ty.Svty.t
 val is_ground : t -> bool


### PR DESCRIPTION
The smart constructor `mk_binders` is useless because we can build directly the set of binders in `D_cnf` and we avoid to embed variables in symbols then extract them in `mk_binders`.