### PR TITLE
chore(CI): Disable OCaml 4.08 on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
           - 4.08.1
           - 4.14.1
           - 5.0.0
-      exclude:
-        # No longer seems to be available
-        - os: macos-latest
-          ocaml-compiler: 4.08.1
+        exclude:
+          # No longer seems to be available
+          - os: macos-latest
+            ocaml-compiler: 4.08.1
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
           - 4.08.1
           - 4.14.1
           - 5.0.0
+      exclude:
+        # No longer seems to be available
+        - os: macos-latest
+          ocaml-compiler: 4.08.1
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
It is consistently failing: that version of OCaml no longer seems to be available on macOS.

We are still testing on macOS with other versions of OCaml and this version of OCaml on Linux.