### PR TITLE
fix(UF): Use proper explanation for neqs when initializing leaf

### DIFF
--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -529,7 +529,7 @@ module Env = struct
           else add_to_gamma p rp env.gamma ;
         neqs    =
           if MapX.mem p env.neqs then env.neqs
-          else update_neqs p rp Ex.empty env }
+          else update_neqs p rp ex_rp env }
     in
     Debug.check_invariants "init_leaf" env;
     env


### PR DESCRIPTION
When initializing a leaf, the equality `p = rp` between `p` and its normal form `rp` w.r.t the current environment is justified by `ex_rp`, which is usually but not necessarily `Ex.empty` and needs to be added to a conflict found while adding the equality `p = rp`.