### PR TITLE
fix(CP): Remove `ex` parameter from `Domain.intersect`

### DIFF
--- a/src/lib/reasoners/bitlist.ml
+++ b/src/lib/reasoners/bitlist.ml
@@ -80,12 +80,12 @@ let value b = b.bits_set
 let is_fully_known b =
   Z.(equal (shift_right (bits_known b + ~$1) b.width) ~$1)
 
-let intersect ~ex b1 b2 =
+let intersect b1 b2 =
   let width = b1.width in
   let bits_set = Z.logor b1.bits_set b2.bits_set in
   let bits_clr = Z.logor b1.bits_clr b2.bits_clr in
   bitlist ~width ~bits_set ~bits_clr
-    (Ex.union b1.ex (Ex.union ex b2.ex))
+    (Ex.union b1.ex b2.ex)
 
 let concat b1 b2 =
   let bits_set = Z.(logor (b1.bits_set lsl b2.width) b2.bits_set)

--- a/src/lib/reasoners/bitlist.mli
+++ b/src/lib/reasoners/bitlist.mli
@@ -87,14 +87,13 @@ val value : t -> Z.t
     [b] is not fully known, then only the known bits (those that are set in
     [bits_known b]) are meaningful; unknown bits are set to [0]. *)
 
-val intersect : ex:Explanation.t -> t -> t -> t
-(** [intersect ~ex b1 b2] returns a new bitlist [b] that subsumes both [b1] and
-    [b2]. The explanation [ex] justifies that the two bitlists can be merged.
+val intersect : t -> t -> t
+(** [intersect b1 b2] returns a new bitlist [b] that subsumes both [b1] and
+    [b2]. Any explanation justifying that [b1] and [b2] apply to the same
+    value must have been added to [b1] and [b2].
 
     Raises [Inconsistent] if [b1] and [b2] are not compatible (i.e. there are
-    bits set in one bitlist and cleared in the other). The justification
-    includes the justifications of [b1] and [b2], as well as the justification
-    [ex] for the intersection. *)
+    bits set in one bitlist and cleared in the other). *)
 
 val lognot : t -> t
 (** [lognot b] swaps the bits that are set and cleared. *)

--- a/src/lib/reasoners/bitv_rel.ml
+++ b/src/lib/reasoners/bitv_rel.ml
@@ -100,7 +100,7 @@ module Domain : Rel_utils.Domain with type t = Bitlist.t = struct
         match bv with
         | Bitv.Cte z ->
           (* Nothing to update, but still check for consistency! *)
-          ignore @@ intersect ~ex:Ex.empty bl (exact sz z Ex.empty);
+          ignore @@ intersect bl (exact sz z Ex.empty);
           acc, bl_tail
         | Other r -> fold_signed f r bl acc, bl_tail
         | Ext (r, r_size, i, j) ->


### PR DESCRIPTION
Adding an explicit `ex` parameter to the `Domain.intersect` signature was intended to make it behave more like an update and avoid issues such as #479. The other intent was to be a bit more efficient by avoiding additional `add_explanation` calls.

Given that I made this design yet have now introduced the same soundness issue twice because of it, it is now clear that this was not a good idea.

This patch reverts that design decision and the `ex` parameter in the `Domain.intersect` API, replacing it with explicit calls to `add_explanation` instead.