### PR TITLE
fix(FPA): Separate semantic triggers upon trigger construction

### DIFF
--- a/src/lib/frontend/cnf.ml
+++ b/src/lib/frontend/cnf.ml
@@ -177,15 +177,9 @@ let rec make_term quant_basename t =
 
 and make_trigger ~in_theory name quant_basename hyp (e, from_user) =
   let content = List.map (make_term quant_basename) e in
-  let t_depth =
-    List.fold_left (fun z t -> max z (E.depth t)) 0 content in
   (* clean trigger:
      remove useless terms in multi-triggers after inlining of lets*)
-  let trigger =
-    { E.content ; t_depth; semantic = []; (* will be set by theories *)
-      hyp; from_user;
-    }
-  in
+  let trigger = E.mk_trigger ~user:from_user ~hyp content in
   E.clean_trigger ~in_theory name trigger
 
 and make_form name_base ~toplevel f loc ~decl_kind : E.t =

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1655,14 +1655,11 @@ and make_trigger ?(loc = Loc.dummy) ~name_base ~decl_kind
     mk_expr ~loc ~name_base ~decl_kind
   in
   let content = List.map mk_expr e in
-  let t_depth =
-    List.fold_left (fun z t -> max z (E.depth t)) 0 content in
   (* clean trigger:
      remove useless terms in multi-triggers after inlining of lets*)
-  let trigger =
-    { E.content; t_depth; semantic = []; (* will be set by theories *)
-      hyp; from_user; }
-  in
+  let trigger = E.mk_trigger ~user:from_user ~hyp content in
+  if not in_theory && not (Lists.is_empty trigger.semantic) then
+    Errors.typing_error ThSemTriggerError loc;
   E.clean_trigger ~in_theory name trigger
 
 (** Preprocesses the body of a goal by:

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -95,6 +95,11 @@ and semantic_trigger =
 
 and trigger = {
   content : t list;
+  (* [content] must be kept sorted in [pat_weight] (see below) order for
+     matching.
+
+     [mk_trigger] enforces this, but functions that modify [content] and must
+     preserve this order. *)
   semantic : semantic_trigger list;
   hyp : t list;
   t_depth : int;

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -93,6 +93,10 @@ and semantic_trigger =
 
 and trigger = private {
   content : t list;
+  (** List of terms that must be present for this trigger to match.
+
+      Sorted using matching heuristics; the first term is estimated as the
+      least likely to match. *)
   semantic : semantic_trigger list;
   hyp : t list;
   t_depth : int;

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -91,10 +91,8 @@ and semantic_trigger =
   | IsTheoryConst of t
   | LinearDependency of t * t
 
-and trigger = (*private*) {
+and trigger = private {
   content : t list;
-  (* this field is filled (with a part of 'content' field) by theories
-     when assume_th_elt is called *)
   semantic : semantic_trigger list;
   hyp : t list;
   t_depth : int;
@@ -192,6 +190,7 @@ val print_tagged_classes : Format.formatter -> Set.t list -> unit
 
 (** smart constructors for terms *)
 
+val mk_trigger : ?user:bool -> ?depth:int -> ?hyp:t list -> t list -> trigger
 val mk_term : Symbols.t -> t list -> Ty.t -> t
 val vrai : t
 val faux : t

--- a/tests/issues/1111.ae
+++ b/tests/issues/1111.ae
@@ -1,0 +1,4 @@
+logic r : real
+
+goal g : r <>
+  float32(NearestTiesToEven, 12960.0087890625 * float32(NearestTiesToEven, 12960.008976179617))

--- a/tests/issues/1111.expected
+++ b/tests/issues/1111.expected
@@ -1,0 +1,2 @@
+
+unknown


### PR DESCRIPTION
Currently, the theories are responsible for populating the `semantic` field of triggers when a lemma with semantic triggers is added to the theory (call to `assume_th_elt`).

This means that such a lemma lives for some time *without* semantic triggers: in particular, it is initially created using `mk_forall` without semantic triggers. During that call, the guard in `find_particular_subst` preventing the "particular substitution" optimization from triggering for lemmas with semantic trigger is ignored; which means that the "particular substitution" optimization is actually applied to lemmas with semantic triggers.

In particular, this optimization makes the lemma
`float_of_pos_pow_of_two` in the FPA theory unsound, because it removes the check that `x` is actually a power of two, and causes #1111.

This patch makes the `Expr` module responsible for separating syntaxic and semantic triggers, rather than the theory. This ensures that a lemma with semantic triggers never appears as having no semantic triggers. In order to make sure this invariant is properly maintained, the `trigger` type is again made private to the `Expr` module. This required moving from sorting code from the `Matching` module to the `Expr` module, also ensuring that triggers are properly sorted for matching purposes at all times.

Fixes #1111