### PR TITLE
Update docs: free releases licensed under Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See [Alt-Ergo @ OCamlPro] or contact us at [alt-ergo@ocamlpro.com] for more deta
 [installing informations]: https://ocamlpro.github.io/alt-ergo/Install/index.html
 [https://alt-ergo.ocamlpro.com]: https://alt-ergo.ocamlpro.com
 [latest]: https://alt-ergo.ocamlpro.com/http/alt-ergo-2.3.2/alt-ergo-2.3.2.tar.gz
-[license section]: https://ocamlpro.github.io/alt-ergo/About/license.html
+[license section]: https://ocamlpro.github.io/alt-ergo/About/licenses/index.html
 [LRI]: https://www.lri.fr
 [OCamlPro]: https://www.ocamlpro.com
 [OCamlPro non-commercial license 1.0]: ./licenses/OCamlPro-Non-Commercial-License.txt

--- a/docs/sphinx_docs/About/licenses/index.rst
+++ b/docs/sphinx_docs/About/licenses/index.rst
@@ -22,7 +22,7 @@ All the files of this project, with the exception of the preludes and plugins, a
 As an exception, Alt-Ergo Club members at the Gold level can use these same files
 under the terms of :download:`Apache Software License version 2.0 <Apache-License-2.0.txt>`.
 
-Note that plugins or preludes may have different licenses. Please referer to
+Note that plugins or preludes may have different licenses. Please refer to
 their directory.
 
 Until 2013, some parts of this code were released under the terms of the
@@ -39,5 +39,5 @@ We publish our releases on GitHub and opam repository under the license
 The same exceptions as above apply to the plugins and preludes.
 
 We also publish a free release of Alt-Ergo under the terms of
-:download:`CeCILL-C License v1 <CeCILL-C-License-v1.txt>`.
+:download:`Apache Software License version 2.0 <Apache-License-2.0.txt>`
 The packages of the free releases are suffixed with `-free` on the opam repository.


### PR DESCRIPTION
None of the versions on opam alt-ergo-free or the branches marked -free in github are licensed under CeCILL-C, but the license section of the documentation did not reflect this.

Additionally the link in the readme to the licenses section of the documentation was out-of-date, and this led to a 404 link to the license section on the main page.

see #1115 for some remaining references to CeCILL-C license that it is not completely obvious how to address.