### PR TITLE
fix(FPA): Do not look for particular substitution in theories

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1065,6 +1065,8 @@ let rec mk_expr
                "main" term of the interval. For instance, [e in [i, ?]]
                becomes `semantic_trigger (let x = e in i ≤ x)`.
             *)
+            if decl_kind != E.Dtheory then
+              Errors.typing_error ThSemTriggerError loc;
             let xs, trigger =
               Option.value ~default:([], trigger) @@ destruct_let trigger
             in

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1437,7 +1437,7 @@ and mk_forall_bis (q : quantified) =
   if SMap.is_empty binders && Ty.Svty.is_empty q.main.vty then q.main
   else
     let q = {q with binders} in
-    match find_particular_subst binders q.user_trs q.main with
+    match find_particular_subst q.kind binders q.user_trs q.main with
     | None -> mk_forall_ter q
 
     | Some sbs ->
@@ -1476,8 +1476,10 @@ and find_particular_subst =
 
       | _ -> ()
   in
-  fun binders trs f ->
-    if not (Ty.Svty.is_empty f.vty) || has_hypotheses trs ||
+  fun decl_kind binders trs f ->
+    (* https://github.com/OCamlPro/alt-ergo/issues/1111 *)
+    let in_theory = decl_kind == Dtheory in
+    if in_theory || not (Ty.Svty.is_empty f.vty) || has_hypotheses trs ||
        has_semantic_triggers trs
     then
       None

--- a/tests/issues/1111.ae
+++ b/tests/issues/1111.ae
@@ -1,0 +1,4 @@
+logic r : real
+
+goal g : r <>
+  float32(NearestTiesToEven, 12960.0087890625 * float32(NearestTiesToEven, 12960.008976179617))

--- a/tests/issues/1111.expected
+++ b/tests/issues/1111.expected
@@ -1,0 +1,2 @@
+
+unknown


### PR DESCRIPTION
Simpler version of the fix from #1113 for the 2.5.x release branch.