### PR TITLE
Fix locales for Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ let
 in
 
 pkgs.mkShell {
+  LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
   nativeBuildInputs = with ocamlPackages; [
     pkgs.ocamlformat
     pkgs.sphinx

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,8 @@ let
 in
 
 pkgs.mkShell {
+  # Required for correct locales on non-NixOS,
+  # see https://nixos.wiki/wiki/Locales
   LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
   nativeBuildInputs = with ocamlPackages; [
     pkgs.ocamlformat


### PR DESCRIPTION
The locales aren't correctly supported by Nix on non-NixOs system. See https://nixos.wiki/wiki/Locales

I cannot compile with Nix the Sphinx documentation without this fix...