### PR TITLE
fix(CLI): Do not use psmt2 format for .smt2 file

### DIFF
--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -61,8 +61,10 @@ let formats_list =
   ["native", Native;
    "altergo", Native;
    "alt-ergo", Native;
-   "smtlib2", Smtlib2;
-   "smt-lib2", Smtlib2;
+   "smtlib2", Smtlib2 `Latest;
+   "smt-lib2", Smtlib2 `Latest;
+   "psmt2", Smtlib2 `Poly;
+   "smtlib2-v2.6", Smtlib2 `V2_6;
    "why3", Why3]
 
 let format_parser s =
@@ -75,7 +77,9 @@ let format_parser s =
 
 let format_to_string = function
   | Native -> "native"
-  | Smtlib2 -> "smtlib2"
+  | Smtlib2 `V2_6 -> "smtlib2-v2.6"
+  | Smtlib2 `Poly -> "psmt2"
+  | Smtlib2 `Latest -> "smtlib2"
   | Why3 -> "why3"
   | Unknown s -> Format.sprintf "Unknown %s" s
 

--- a/src/bin/js/options_interface.ml
+++ b/src/bin/js/options_interface.ml
@@ -39,7 +39,7 @@ let get_input_format = function
   | None -> None
   | Some f -> match f with
     | Native -> Some Options.Native
-    | Smtlib2 -> Some Options.Smtlib2
+    | Smtlib2 -> Some (Options.Smtlib2 `Poly)
     | Why3 -> Some Options.Why3
     | Unknown s -> Some (Options.Unknown s)
 
@@ -47,7 +47,7 @@ let get_output_format = function
   | None -> None
   | Some f -> match f with
     | Native -> Some Options.Native
-    | Smtlib2 -> Some Options.Smtlib2
+    | Smtlib2 -> Some (Options.Smtlib2 `Poly)
     | Why3 -> Some Options.Why3
     | Unknown s -> Some (Options.Unknown s)
 

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -68,7 +68,7 @@ let print_status status steps =
   in
   let validity_mode =
     match Options.get_output_format () with
-    | Smtlib2 -> false
+    | Smtlib2 _ -> false
     | Native | Why3 | Unknown _ -> true
   in
   let get_goal_name d =

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -55,14 +55,27 @@ type interpretation =
   | ILast        (** Compute only the last interpretation just before
                      returning SAT/Unknown *)
 
+type smtlib2_version =
+  [ `Latest
+  (** Latest version of the SMT-LIB standard. *)
+  | `V2_6
+  (** The SMT-LIB standard: Version 2.6
+      https://smt-lib.org/papers/smt-lib-reference-v2.6-r2021-05-12.pdf *)
+  | `Poly
+    (** Polymorphic extension of the SMT-LIB standard.
+
+        See https://inria.hal.science/hal-01960203/document *)
+  ]
+(** Version of the SMT-LIB standard used. *)
+
 (** Type used to describe the type of input wanted by
     {!val:set_input_format} *)
 type input_format =
   | Native                     (** Native Alt-Ergo format  *)
-  | Smtlib2
-  (** {{:
-      http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf}
-      Smtlib} default format *)
+  | Smtlib2 of smtlib2_version
+  (** SMT-LIB default format.
+
+      See https://smt-lib.org/language.shtml. *)
   | Why3                       (** Why3 file format *)
   (*   | SZS                        * Not yet implemented SZS format   *)
   | Unknown of string          (** Unknown file format *)

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -59,12 +59,13 @@ type smtlib2_version =
   [ `Latest
   (** Latest version of the SMT-LIB standard. *)
   | `V2_6
-  (** The SMT-LIB standard: Version 2.6
-      https://smt-lib.org/papers/smt-lib-reference-v2.6-r2021-05-12.pdf *)
+  (** {{: https://smt-lib.org/papers/smt-lib-reference-v2.6-r2021-05-12.pdf }
+      The SMT-LIB standard: Version 2.6} *)
   | `Poly
     (** Polymorphic extension of the SMT-LIB standard.
 
-        See https://inria.hal.science/hal-01960203/document *)
+        See the {{: https://inria.hal.science/hal-01960203/document } tool
+        paper} *)
   ]
 (** Version of the SMT-LIB standard used. *)
 
@@ -73,9 +74,7 @@ type smtlib2_version =
 type input_format =
   | Native                     (** Native Alt-Ergo format  *)
   | Smtlib2 of smtlib2_version
-  (** SMT-LIB default format.
-
-      See https://smt-lib.org/language.shtml. *)
+  (** {{: https://smt-lib.org/language.shtml} SMT-LIB} default format. *)
   | Why3                       (** Why3 file format *)
   (*   | SZS                        * Not yet implemented SZS format   *)
   | Unknown of string          (** Unknown file format *)

--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -151,7 +151,7 @@ let clean_wrn_print = ref true
 
 let pp_smt clean_print =
   let smt = match Options.get_output_format () with
-    | Smtlib2 -> true
+    | Smtlib2 _ -> true
     | Native | Why3 | Unknown _ -> false
   in Format.sprintf
     (if smt && !clean_print then
@@ -198,7 +198,7 @@ let force_new_line formatter =
 
 let init_output_format () =
   match Options.get_output_format () with
-  | Smtlib2 ->
+  | Smtlib2 _ ->
     add_smt (Options.Output.get_fmt_diagnostic ())
   | Native | Why3 | Unknown _ -> ()
 

--- a/src/parsers/parsers.ml
+++ b/src/parsers/parsers.ml
@@ -74,7 +74,9 @@ let get_input_parser fmt =
   set_output_format fmt;
   match fmt with
   | Options.Native -> find_parser ".ae" "native"
-  | Options.Smtlib2 -> find_parser ".smt2" "smtlib2"
+  | Options.Smtlib2 _ ->
+    (* NB: the legacy frontend is always using psmt2 *)
+    find_parser ".smt2" "smtlib2"
   | Options.Why3 -> find_parser ".why" "why3"
   | Options.Unknown s -> find_parser s s
 

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -117,4 +117,4 @@ Some errors are unescapable though. It its the case of syntax error in commands.
 
 Let us check that we can parse psmt2 files with a .smt2 extension. No output,
 no errors expected.
-  $ alt-ergo poly.smt2 --type-only
+  $ alt-ergo poly.smt2 -i psmt2 --type-only


### PR DESCRIPTION
Following discussions at the Alt-Ergo Club meeting last week, it was agreed that it was better to support SMT-LIB2 format by default for ".smt2" files and to only enable the polymorphic extensions for ".psmt2" files.

This patch performs that change, partially reverting #948 / 42e9ef10dca19490b502db3b5f323aeb0417100e and uses the same polymorphic variant type as Dolmen for the same purpose.

In order to accomodate #933, introduce a new "psmt2" input mode.