### PR TITLE
Fix documentation of `make_triggers`

### DIFF
--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2134,16 +2134,14 @@ module Triggers = struct
              else Var.Map.add v (mk_term (Sy.var Var.underscore) [] ty) sbt
           )t.vars Var.Map.empty
       in
-      (* TODO: remove the useless returned boolean value. *)
-      if Var.Map.is_empty sbt then t, true
-      else
-        apply_subst (sbt, Ty.esubst) t, false
+      if Var.Map.is_empty sbt then t
+      else apply_subst (sbt, Ty.esubst) t
     in
     fun bv ((t,vt,vty) as e) ->
       let s = Var.Set.diff vt bv in
       if Var.Set.is_empty s then e
       else
-        let t,_ = aux t s in
+        let t = aux t s in
         let vt = Var.Set.add Var.underscore (Var.Set.inter vt bv) in
         t,vt,vty
 

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1493,7 +1493,7 @@ and mk_forall_bis (q : quantified) =
    Notice that formulas [x = a -> P(x)] are represented by
    [Clause (x <> a, P(x), _)] or [Clause (P(x), x <> a, _)].
 
-   {b Note}: this heuristic isn't used if the user has defined filters.
+   {b Note}: this heuristic is not used if the user has defined filters.
 
    @return [None] if the formula hasn't the right form. *)
 and find_particular_subst =
@@ -2117,7 +2117,7 @@ module Triggers = struct
     end)
 
   (* [underscore bv e] replaces all the free term variables in [e] that
-     aren't in [bv] by the underscore term.
+     are not in [bv] by the underscore term.
 
      For instance with [bv = {x, y}] and [e = g(x, y, z)] where [{x, y, z}]
      is the set of free term variables of [e], this functions returns the term
@@ -2147,8 +2147,8 @@ module Triggers = struct
      that their patterns lie in [l] and they cover all the free variables [bv]
      and [vty].
 
-     If [escaped_vars] is [true], replace the free term variables of these
-     patterns that do not lie in [bv]. *)
+     If [escaped_vars] is [true], replace with the [underscore] variable the
+     free term variables of these patterns that do not lie in [bv]. *)
   let parties mconf bv vty l escaped_vars =
     let l =
       if mconf.Util.triggers_var then l
@@ -2184,12 +2184,12 @@ module Triggers = struct
     let l = STRS.elements s in (* remove redundancies in old l *)
     SLLT.elements (parties_rec (SLLT.empty, SLLT.empty) l)
 
-  (* Simplify the multi-trigger [l] by removing a pattern [p] in [l] if
-     its set of free (term and type) variables:
-     - isn't maximal (for the inclusion) among the set of free variables of
-         patterns in [l];
-     - contains the union of [bv_a] and [vty_a];
-     - is disjoint with the union of [bv_a] and [vty_a]. *)
+  (* Remove patterns in the list of multi-triggers [l] whose the set S of free
+     (term and type) variables satisfies one of these conditions:
+     - S is not maximal (for the inclusion order) among the set of free
+       variables of patterns in [l];
+     - S contains the union of [bv_a] and [vty_a];
+     - S is disjoint with the union of [bv_a] and [vty_a]. *)
   let simplification =
     (* Check if there is a pattern in [l] whose the set of free variables
        contains strictly the union of [bv] and [vty]. *)
@@ -2214,7 +2214,7 @@ module Triggers = struct
       simpl_rec [] l
 
   let multi_triggers menv bv vty trs escaped_vars =
-    (* The simplification removed all the patterns of the multi-trigger [trs]
+    (* The simplification removes all the patterns of the multi-trigger [trs]
        that cover all the free variables [bv] and [vty]. Indeed, such patterns
        have already been generated as mono-trigger before. *)
     let terms = simplification bv vty trs in
@@ -2315,9 +2315,8 @@ module Triggers = struct
   let free_vars_as_set e =
     Var.Map.fold (fun v _ s -> Var.Set.add v s) e.vars Var.Set.empty
 
-  (* Collect all the subterms of the expression [e] that
-     are pure and contain at least one free (term or type) variables in
-     [vars]. *)
+  (* Collect all the subterms of the expression [e] that are pure and contain
+     at least one free (term or type) variables in [vars]. *)
   let potential_triggers =
     let has_bvar bv_lf bv =
       Var.Map.exists (fun e _ -> Var.Set.mem e bv) bv_lf
@@ -2357,7 +2356,7 @@ module Triggers = struct
     e.ty == Ty.Tbool &&
     match e.f with Sy.Form _ -> false | _ -> true
 
-  (* Keep only patterns in [full_trs] whose all the free term
+  (* Keep only patterns in [full_trs] for which all the free term
      variables are free in [f] with the same type. *)
   let trs_in_scope full_trs f =
     STRS.filter

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2115,6 +2115,16 @@ module Triggers = struct
         if c <> 0 then c else Var.Set.compare y1 y2
     end)
 
+  (* let's [e] be a subterm of a quantified formula [f] and [bv] the set
+     of quantified variables of [f]. Then [underscore bv e] returns the term
+     obtained by substituting all the free term variables in [e] that aren't
+     in [bv] by the underscore term.
+
+     For instance, if [f] is the formula:
+       forall x:int, forall y:int, g(x, y, z) = 0.
+     where the free variable of [g(x, y, z)] are exactly [{x, y, z}],
+     and [e = g(x, y, z)], then this function returns the term [g(x, y, _)]. *)
+  (* TODO: rename this function. *)
   let underscore =
     let aux t s =
       let sbt =
@@ -2124,6 +2134,7 @@ module Triggers = struct
              else Var.Map.add v (mk_term (Sy.var Var.underscore) [] ty) sbt
           )t.vars Var.Map.empty
       in
+      (* TODO: remove the useless returned boolean value. *)
       if Var.Map.is_empty sbt then t, true
       else
         apply_subst (sbt, Ty.esubst) t, false
@@ -2195,6 +2206,7 @@ module Triggers = struct
     let l_parties = parties menv bv vty terms escaped_vars in
     let lm = List.map (fun (lt, _, _) -> lt) l_parties in
     let mv , mt = List.partition (List.exists is_var) lm in
+    (* TODO: use List.compare_lengths *)
     let mv = List.sort (fun l1 l2 -> List.length l1 - List.length l2) mv in
     let mt = List.sort (fun l1 l2 -> List.length l1 - List.length l2) mt in
     let lm = if menv.Util.triggers_var then mt@mv else mt in
@@ -2232,6 +2244,9 @@ module Triggers = struct
     let mono = filter_interpreted_arith mono in
     if menv.Util.greedy then
       (* merge directly multi in mono if greedy is set *)
+      (* TODO: it's a really bad idea to merge these lists here because
+         the meaning of the returned pair depends of the current generation
+         mode. *)
       mono @ multi_triggers menv vterm vtype trs escaped_vars, []
     else
       mono,

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -309,28 +309,25 @@ val make_triggers:
 (** [make_triggers f binders decl menv] generate multi-triggers for the
     formula [f] and binders [binders].
 
-    The following documentation describes the strategies used by SatML
-    to generate multi-triggers.
+    We can escape unbounded variables in patterns of multi-triggers, that
+    is replaced them by the underscore term. For instance, if [binders] is
+    the set [{x, y}] and [g(x, y, z)] is a pattern where [{(x, y, z)}] are
+    free term variables, we can replace [z] by [_].
 
-    Assuming that [Options.get_triggers_var ()] is [true] (the default),
-    we do not allow trigger variables in frugal, normal and greedy mode
-    but we allow them in greedier mode.
+    Our strategy for multi-trigger generations depends on the matching
+    environment [menv] as follows:
 
-    While generating multi-triggers (with at least two patterns), we can
-    escape free variables of their patterns that aren't bound in the quantified
-    formula.
-
-    The strategies of multi-trigger generations are:
-      1. In frugal and normal modes, we try in order:
+    If [menv.greedy] is [false], we try to generate in order:
     - Mono-triggers;
-    - Multi-triggers without escaping variables;
     - Multi-triggers with escaping variables.
-      2. In greedy mode, we try in order:
+
+    If [menv.greedy] is [true], we try to generate in order:
     - Mono and multi-triggers without escaping variables.
     - Mono and multi-triggers with escaping variables;
-      3. In greedier mode: same as greedy mode.
 
-    Mono-trigger with `Sy.Plus` or `Sy.Minus` top symbols are ignored
+    If [menv.triggers_var] is [true], we allow variables as valid triggers.
+
+    {b Note}: Mono-trigger with `Sy.Plus` or `Sy.Minus` top symbols are ignored
     if other mono-triggers have been generated.
 
     The matching environment [env] is used to limit the number of

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -309,10 +309,12 @@ val make_triggers:
 (** [make_triggers f binders decl menv] generate multi-triggers for the
     formula [f] and binders [binders].
 
-    We can escape unbounded variables in patterns of multi-triggers, that
-    is replaced them by the underscore term. For instance, if [binders] is
-    the set [{x, y}] and [g(x, y, z)] is a pattern where [{(x, y, z)}] are
-    free term variables, we can replace [z] by [_].
+    We can escape in generated patterns variables that are not bound in
+    [binders], that is replace them by the underscore variable [Var.underscore].
+
+    For instance, if [binders] is the set [{x, y}] and [g(x, y, z)] is a
+    pattern where [{(x, y, z)}] are free term variables, we can replace [z]
+    by [_].
 
     Our strategy for multi-trigger generations depends on the matching
     environment [menv] as follows:

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -309,17 +309,26 @@ val make_triggers:
 (** [make_triggers f binders decl menv] generate multi-triggers for the
     formula [f] and binders [binders].
 
-    For axioms, we try to produce multi-triggers in the following order
-    (if we succeed to produce at least one multi-trigger, we don't try other
-    strategies):
-    1. In greedy mode:
-    - Mono-triggers without variables;
-    - Mono-triggers with variables;
-    - Multi-triggers without variables;
-    - Multi-triggers with variables.
-      2. Otherwise:
-    - Mono and multi-triggers without variables;
-    - Mono and multi-triggers with variables.
+    The following documentation describes the strategies used by SatML
+    to generate multi-triggers.
+
+    Assuming that [Options.get_triggers_var ()] is [true] (the default),
+    we do not allow trigger variables in frugal, normal and greedy mode
+    but we allow them in greedier mode.
+
+    While generating multi-triggers (with at least two patterns), we can
+    escape free variables of their patterns that aren't bound in the quantified
+    formula.
+
+    The strategies of multi-trigger generations are:
+      1. In frugal and normal modes, we try in order:
+    - Mono-triggers;
+    - Multi-triggers without escaping variables;
+    - Multi-triggers with escaping variables.
+      2. In greedy mode, we try in order:
+    - Mono and multi-triggers without escaping variables.
+    - Mono and multi-triggers with escaping variables;
+      3. In greedier mode: same as greedy mode.
 
     Mono-trigger with `Sy.Plus` or `Sy.Minus` top symbols are ignored
     if other mono-triggers have been generated.

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -309,8 +309,9 @@ val make_triggers:
 (** [make_triggers f binders decl menv] generate multi-triggers for the
     formula [f] and binders [binders].
 
-    We can escape in generated patterns variables that are not bound in
-    [binders], that is replace them by the underscore variable [Var.underscore].
+    An {e escaped variable} of a pattern is a variable that is not in [binders]
+    (but the variable is bound by an inner quantified formula). We can
+    replace escaped variables by the underscore variable [Var.underscore].
 
     For instance, if [binders] is the set [{x, y}] and [g(x, y, z)] is a
     pattern where [{(x, y, z)}] are free term variables, we can replace [z]
@@ -321,11 +322,11 @@ val make_triggers:
 
     If [menv.greedy] is [false], we try to generate in order:
     - Mono-triggers;
-    - Multi-triggers with escaping variables.
+    - Multi-triggers without escaped variables.
 
     If [menv.greedy] is [true], we try to generate in order:
-    - Mono and multi-triggers without escaping variables.
-    - Mono and multi-triggers with escaping variables;
+    - Mono and multi-triggers with escaped variables.
+    - Mono and multi-triggers without escaped variables;
 
     If [menv.triggers_var] is [true], we allow variables as valid triggers.
 

--- a/src/lib/util/util.mli
+++ b/src/lib/util/util.mli
@@ -102,7 +102,11 @@ val [@inline always] cmp_lists: 'a list -> 'a list -> ('a -> 'a -> int) -> int
 type matching_env =
   {
     nb_triggers : int;
+    (** Limit the number of trigger generated per axiom. *)
+
     triggers_var : bool;
+    (** If [true], we allow trigger variables during the trigger generation. *)
+
     no_ematching: bool;
     greedy : bool;
     use_cs : bool;


### PR DESCRIPTION
While trying to understand the issue 1139, I realized that my documentation of `make_triggers` in `Expr` was completely wrong. I misunderstood the meaning of the flag `escaped_vars` in the module `Triggers`. This PR fixes and clarifies this documentation.