### PR TITLE
Named lemmas in SMT-LIB format

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1816,6 +1816,11 @@ let make dloc_file acc stmt =
     (* Axiom definitions *)
     | { id = DStd.Id.{name = Simple name; _}; contents = `Hyp t; loc; attrs;
         implicit=_ } ->
+      let name =
+        match DStd.Tag.get t.term_tags DE.Tags.named with
+        | Some name -> name
+        | None -> name
+      in
       let dloc = DStd.Loc.(loc dloc_file stmt.loc) in
       let aloc = DStd.Loc.lexing_positions dloc in
       (* Dolmen adds information about theory extensions and case splits in the


### PR DESCRIPTION
For debugging purposes, it is useful to be able to name lemmas as in the native language. By default, `Dolmen` names axioms with a string of the form `hyp_#number` where #number is a counter. It's fine for small files with few axioms but not very convenient for large files.

This PR uses the syntax `(! ... :named ...)` to be able to rename axioms.

Notice that using this feature has a slight effect on the behaviour of Alt-Ergo, which isn't desirable for a debugging tool. The reason is because `Dolmen` uses a mechanism of implicit definitions in presence of `:named`. For instance, the following input file:
```smt2
(set-logic ALL)
(declare-fun f (Int Int) Int)
(assert (! (forall ((x Int)) (>= (f x x) 0)) :named foo))
(assert (< (f 0 0) 0))
(check-sat)
```
will produce a pack of definitions:
1. a definition of `foo`
2. an implicit definition of the underlying axiom

The `foo` variable will appear in the context and the equality `foo = (forall ...)` too.

I don't know how to prevent AE from doing that without breaking the `get-assignment` feature.