### PR TITLE
Use a custom attribute to name lemma

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -1847,7 +1847,7 @@ let make dloc_file acc stmt =
     | { id = DStd.Id.{name = Simple name; _}; contents = `Hyp t; loc; attrs;
         implicit=_ } ->
       let name =
-        match DStd.Tag.get t.term_tags lemma_attr with
+        match DStd.Tag.get t.term_tags lemma_name_attr with
         | Some n -> n
         | None ->
           match DStd.Tag.get t.term_tags DE.Tags.named with

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -464,6 +464,8 @@ let smt_tag_builtins =
           | { term = Symbol { name = Simple name; _ }; _ } ->
             [Type.Set (lemma_name_attr, name)]
           | _ ->
+            (* TODO: add a custom printer as soon as the issue
+               https://github.com/Gbury/dolmen/issues/218 is solved. *)
             Type._error env (Ast ast) Invalid_lemma_name
         )
     | _ -> `Not_found


### PR DESCRIPTION
This PR adds a new attribute ":lemma" to name lemmas instead of using the builin attribute ":named". So the new syntax is:
```smt
(assert (! (forall ...) :lemma my_lemma))

```
Notice that we produce a custom error `Expect_simple_sexpr` if the user gives an inappropriate s-expressions. Currently, we cannot define our own printer for the typechecker but Guillaume will implement this soon.