### PR TITLE
feat(BV): Do not store width in Bitlist

### DIFF
--- a/src/lib/reasoners/bitlist.ml
+++ b/src/lib/reasoners/bitlist.ml
@@ -29,139 +29,154 @@ module Ex = Explanation
 
 exception Inconsistent of Ex.t
 
-(** A bitlist representing the known bits of a bit-vector of width [width].
+(** A bitlist representing the known bits of an infinite-width bit-vector.
+    Negative numbers are represented in two's complement.
 
     Active bits in [bits_set] are necessarily equal to [1].
-    Active bits in [bits_clr] are necessarily equal to [0].
+    Active bits in [bits_unk] are not known and may be either [0] or [1].
+    Bits that are active in neither [bits_set] nor [bits_unk] are equal to [0].
+
+    The sign is known (and equal to the sign of [bits_set]) if [bits_unk] is
+    positive, and the sign is unknown if [bits_unk] is negative.
+
+    An integer [x] is represented by the bitlist iff the following equality
+    holds: [x & ~bits_unk = bits_set].
 
     The explanation [ex] justifies that the bitlist applies. *)
-type t = { width: int ; bits_set : Z.t ; bits_clr : Z.t ; ex : Ex.t }
+type t = { bits_set : Z.t ; bits_unk : Z.t ; ex : Ex.t }
 
-let unknown width ex =
-  { width ; bits_set = Z.zero ; bits_clr = Z.zero ; ex }
+let constant n ex =
+  { bits_set = n ; bits_unk = Z.zero ; ex }
 
-let empty =
-  { width = 0 ; bits_set = Z.zero ; bits_clr = Z.zero ; ex = Ex.empty }
+let zero ex = constant Z.zero ex
 
-let width { width; _ } = width
+let empty = zero Ex.empty
+
+let unknown = { bits_set = Z.zero ; bits_unk = Z.minus_one ; ex = Ex.empty }
 
 let explanation { ex; _ } = ex
 
-let exact width value ex =
-  { width
-  ; bits_set = Z.extract value 0 width
-  ; bits_clr = Z.extract (Z.lognot value) 0 width
+let exact value ex =
+  { bits_set = value
+  ; bits_unk = Z.zero
   ; ex }
 
 let equal b1 b2 =
-  b1.width = b2.width &&
   Z.equal b1.bits_set b2.bits_set &&
-  Z.equal b1.bits_clr b2.bits_clr
+  Z.equal b1.bits_unk b2.bits_unk
 
-let ones b = { b with bits_clr = Z.zero }
+let ones b = { b with bits_unk = Z.(b.bits_unk lor ~!(b.bits_set)) }
 
-let zeroes b = { b with bits_set = Z.zero }
+let zeroes b =
+  { b with bits_set = Z.zero ; bits_unk = Z.logor b.bits_unk b.bits_set }
 
 let add_explanation ~ex b = { b with ex = Ex.union b.ex ex }
 
-let pp ppf { width; bits_set; bits_clr; ex } =
+let pp ppf { bits_set; bits_unk; ex } =
+  begin if Z.sign bits_unk < 0 then
+      (* Sign is not known *)
+      Fmt.pf ppf "(?)"
+    else if Z.sign bits_set < 0 then
+      Fmt.pf ppf "(1)"
+    else
+      Fmt.pf ppf "(0)"
+  end;
+  let width = max (Z.numbits bits_set) (Z.numbits bits_unk) in
   for i = width - 1 downto 0 do
     if Z.testbit bits_set i then
       Fmt.pf ppf "1"
-    else if Z.testbit bits_clr i then
-      Fmt.pf ppf "0"
-    else
+    else if Z.testbit bits_unk i then
       Fmt.pf ppf "?"
+    else
+      Fmt.pf ppf "0"
   done;
   if Options.(get_verbose () || get_unsat_core ()) then
     Fmt.pf ppf " %a" (Fmt.box Ex.print) ex
 
-let bitlist ~width ~bits_set ~bits_clr ex =
-  if not (Z.equal (Z.logand bits_set bits_clr) Z.zero) then
-    raise @@ Inconsistent ex;
-
-  { width; bits_set; bits_clr ; ex }
-
-let bits_known b = Z.logor b.bits_set b.bits_clr
-
-let num_unknown b = b.width - Z.popcount (bits_known b)
+let unknown_bits b = b.bits_unk
 
 let value b = b.bits_set
 
-let is_fully_known b =
-  Z.(equal (shift_right (bits_known b + ~$1) b.width) ~$1)
+let is_fully_known b = Z.equal b.bits_unk Z.zero
 
 let intersect b1 b2 =
-  let width = b1.width in
   let bits_set = Z.logor b1.bits_set b2.bits_set in
-  let bits_clr = Z.logor b1.bits_clr b2.bits_clr in
-  bitlist ~width ~bits_set ~bits_clr
-    (Ex.union b1.ex b2.ex)
+  let bits_unk = Z.logand b1.bits_unk b2.bits_unk in
+  (* If there is a bit that is known in both bitlists with different values,
+     the intersection is empty. *)
+  let distinct = Z.logxor b1.bits_set b2.bits_set in
+  let known = Z.lognot (Z.logor b1.bits_unk b2.bits_unk) in
+  if not (Z.equal (Z.logand distinct known) Z.zero) then
+    raise @@ Inconsistent (Ex.union b1.ex b2.ex);
 
-let concat b1 b2 =
-  let bits_set = Z.(logor (b1.bits_set lsl b2.width) b2.bits_set)
-  and bits_clr = Z.(logor (b1.bits_clr lsl b2.width) b2.bits_clr)
-  in
-  (* Always consistent *)
-  { width = b1.width + b2.width
-  ; bits_set
-  ; bits_clr
-  ; ex = Ex.union b1.ex b2.ex
-  }
+  { bits_set ; bits_unk ; ex = Ex.union b1.ex b2.ex }
 
-let ( @ ) = concat
-
-let extract b i j =
-  (* Always consistent *)
-  { width = j - i + 1
-  ; bits_set = Z.extract b.bits_set i (j - i + 1)
-  ; bits_clr = Z.extract b.bits_clr i (j - i + 1)
-  ; ex = b.ex
-  }
+let extract b ofs len =
+  if len = 0 then empty
+  else
+    (* Always consistent *)
+    { bits_set = Z.extract b.bits_set ofs len
+    ; bits_unk = Z.extract b.bits_unk ofs len
+    ; ex = b.ex
+    }
 
 let lognot b =
   (* Always consistent *)
-  { b with bits_set = b.bits_clr; bits_clr = b.bits_set }
+  { b with bits_set = Z.(~!(b.bits_set lor b.bits_unk))}
 
-let logand b1 b2 =
-  let width = b1.width in
-  let bits_set = Z.logand b1.bits_set b2.bits_set in
-  let bits_clr = Z.logor b1.bits_clr b2.bits_clr in
-  (* Always consistent *)
-  { width
-  ; bits_set
-  ; bits_clr
-  ; ex = Ex.union b1.ex b2.ex
-  }
+let ( ~! ) = lognot
 
 let logor b1 b2 =
-  let width = b1.width in
+  (* A bit is set in [b1 | b2] if it is set in either [b1] or [b2]. *)
   let bits_set = Z.logor b1.bits_set b2.bits_set in
-  let bits_clr = Z.logand b1.bits_clr b2.bits_clr in
+  (* A bit is unknown in [b1 | b2] if it is unknown in either [b1] or [b2],
+     unless is set to [1] in either [b1] or [b2]. *)
+  let bits_unk =
+    Z.logand (Z.logor b1.bits_unk b2.bits_unk)
+      (Z.lognot bits_set)
+  in
   (* Always consistent *)
-  { width
-  ; bits_set
-  ; bits_clr
+  { bits_set
+  ; bits_unk
   ; ex = Ex.union b1.ex b2.ex
   }
 
-let logxor b1 b2 =
-  let width = b1.width in
-  let bits_set =
-    Z.logor
-      (Z.logand b1.bits_set b2.bits_clr)
-      (Z.logand b1.bits_clr b2.bits_set)
-  and bits_clr =
-    Z.logor
-      (Z.logand b1.bits_set b2.bits_set)
-      (Z.logand b1.bits_clr b2.bits_clr)
+let ( lor ) = logor
+
+let logand b1 b2 =
+  let bits_set = Z.logand b1.bits_set b2.bits_set in
+  (* A bit is unknown in [b1 & b2] if it is unknown in both [b1] and [b2], or if
+     it is equal to [1] in either side and unknown in the other. *)
+  let bits_unk =
+    Z.logor (Z.logand b1.bits_set b2.bits_unk) @@
+    Z.logor (Z.logand b1.bits_unk b2.bits_set) @@
+    Z.logand b1.bits_unk b2.bits_unk
   in
   (* Always consistent *)
-  { width
-  ; bits_set
-  ; bits_clr
+  { bits_set
+  ; bits_unk
   ; ex = Ex.union b1.ex b2.ex
   }
+
+let ( land ) = logand
+
+let logxor b1 b2 =
+  (* A bit is unknown in [b1 ^ b2] if it is unknown in either [b1] or [b2]. *)
+  let bits_unk = Z.logor b1.bits_unk b2.bits_unk in
+  (* Need to mask because [Z.logxor] will compute a bogus value for unknown
+     bits. *)
+  let bits_set =
+    Z.logand
+      (Z.logxor b1.bits_set b2.bits_set)
+      (Z.lognot bits_unk)
+  in
+  (* Always consistent *)
+  { bits_set
+  ; bits_unk
+  ; ex = Ex.union b1.ex b2.ex
+  }
+
+let ( lxor ) = logxor
 
 (* The logic for the [increase_lower_bound] function below is described in
    section 4.1 of
@@ -176,9 +191,12 @@ let logxor b1 b2 =
 (* [left_cl_can_set highest_cleared cleared_can_set] returns the
    least-significant bit that is:
    - More significant than [highest_cleared], strictly;
-   - Set in [cleared_can_set] *)
+   - Set in [cleared_can_set]
+
+   Raises [Not_found] if there are no such bit. *)
 let left_cl_can_set highest_cleared cleared_can_set =
   let can_set = Z.(cleared_can_set asr highest_cleared) in
+  if Z.equal can_set Z.zero then raise Not_found;
   highest_cleared + Z.trailing_zeros can_set
 
 let increase_lower_bound b lb =
@@ -188,7 +206,7 @@ let increase_lower_bound b lb =
      [cleared_bits] contains the bits that were set in [lb] and got cleared in
      [r]; conversely, [set_bits] contains the bits that were cleared in [lb] and
      got set in [r]. *)
-  let r = Z.logor b.bits_set (Z.logand lb (Z.lognot b.bits_clr)) in
+  let r = Z.logor b.bits_set (Z.logand lb b.bits_unk) in
   let cleared_bits = Z.logand lb (Z.lognot r) in
   let set_bits = Z.logand (Z.lognot lb) r in
 
@@ -227,10 +245,10 @@ let increase_lower_bound b lb =
        as when the most-significant changed bit was 0 and is now 1 (see [if]
        case above). *)
     let bit_to_clear = Z.numbits cleared_bits in
-    let cleared_can_set = Z.lognot @@ Z.logor r b.bits_clr in
+    let cleared_can_set =
+      Z.logand (Z.lognot r) (Z.logor b.bits_set b.bits_unk)
+    in
     let bit_to_set = left_cl_can_set bit_to_clear cleared_can_set in
-    if bit_to_set >= b.width then
-      raise Not_found;
     let r = Z.logor r Z.(~$1 lsl bit_to_set) in
     let mask  = Z.(minus_one lsl bit_to_set) in
     Z.logand r @@ Z.logor mask b.bits_set
@@ -238,77 +256,87 @@ let increase_lower_bound b lb =
 
 let decrease_upper_bound b ub =
   (* x <= ub <-> ~ub <= ~x *)
-  let sz = width b in
-  assert (Z.numbits ub <= sz);
-  let nub =
-    increase_lower_bound (lognot b) (Z.extract (Z.lognot ub) 0 sz)
-  in
-  Z.extract (Z.lognot nub) 0 sz
+  Z.lognot @@ increase_lower_bound (lognot b) (Z.lognot ub)
 
 let fold_domain f b acc =
-  if b.width <= 0 then
+  (* If [bits_unk] is negative, the domain is infinite. *)
+  if Z.sign b.bits_unk < 0 then
     invalid_arg "Bitlist.fold_domain";
+  let width = Z.numbits b.bits_unk in
   let rec fold_domain_aux ofs b acc =
-    if ofs >= b.width then (
+    if ofs >= width then (
       assert (is_fully_known b);
       f (value b) acc
-    ) else if Z.testbit b.bits_clr ofs || Z.testbit b.bits_set ofs then
+    ) else if not (Z.testbit b.bits_unk ofs) then
       fold_domain_aux (ofs + 1) b acc
     else
       let mask = Z.(one lsl ofs) in
+      let bits_unk = Z.logand b.bits_unk (Z.lognot mask) in
       let acc =
         fold_domain_aux
-          (ofs + 1) { b with bits_clr = Z.logor b.bits_clr mask } acc
+          (ofs + 1) { b with bits_unk } acc
       in
       fold_domain_aux
-        (ofs + 1) { b with bits_set = Z.logor b.bits_set mask } acc
+        (ofs + 1) { b with bits_unk; bits_set = Z.logor b.bits_set mask } acc
   in
   fold_domain_aux 0 b acc
 
+let shift_left a n =
+  { bits_set = Z.(a.bits_set lsl n)
+  ; bits_unk = Z.(a.bits_unk lsl n)
+  ; ex = a.ex
+  }
+
+let ( lsl ) = shift_left
+
+let shift_right a n =
+  { bits_set = Z.(a.bits_set asr n)
+  ; bits_unk = Z.(a.bits_unk asr n)
+  ; ex = a.ex
+  }
+
+let ( asr ) = shift_right
+
 (* simple propagator: only compute known low bits
 
-   Example: ???100 * ???000 = ?00000 (trailing zeroes accumulate)
+   example: ???100 * ???000 = ?00000 (trailing zeroes accumulate)
             ???111 * ????11 = ????01 (min of low bits known) *)
 let mul a b =
-  let sz = width a in
-  assert (width b = sz);
-
   let ex = Ex.union (explanation a) (explanation b) in
 
   (* (a * 2^n) * (b * 2^m) = (a * b) * 2^(n + m) *)
-  let zeroes_a = Z.trailing_zeros @@ Z.lognot a.bits_clr in
-  let zeroes_b = Z.trailing_zeros @@ Z.lognot b.bits_clr in
-  if zeroes_a + zeroes_b >= sz then
-    exact sz Z.zero ex
+  let zeroes_a = Z.trailing_zeros @@ Z.logor a.bits_set a.bits_unk in
+  let zeroes_b = Z.trailing_zeros @@ Z.logor b.bits_set b.bits_unk in
+  if zeroes_a = max_int || zeroes_b = max_int then
+    zero ex
   else
-    (* Factor out the low zeroes *)
-    let low_bits =
-      if zeroes_a + zeroes_b = 0 then empty
-      else exact (zeroes_a + zeroes_b) Z.zero ex
-    in
-    let a = extract a zeroes_a (zeroes_a + sz - width low_bits - 1) in
-    assert (width a + width low_bits = sz);
-    let b = extract b zeroes_b (zeroes_b + sz - width low_bits - 1) in
-    assert (width b + width low_bits = sz);
+    let a = a asr zeroes_a in
+    let b = b asr zeroes_b in
+    let zeroes = zeroes_a + zeroes_b in
     (* a = ah * 2^n + al (0 <= al < 2^n)
        b = bh * 2^m + bl (0 <= bl < 2^m)
 
        ((ah * 2^n) + al) * ((bh * 2^m) + bl) =
         al * bl  (mod 2^(min n m)) *)
-    let low_a_known = Z.trailing_zeros @@ Z.lognot @@ bits_known a in
-    let low_b_known = Z.trailing_zeros @@ Z.lognot @@ bits_known b in
+    let low_a_known = Z.trailing_zeros @@ a.bits_unk in
+    let low_b_known = Z.trailing_zeros @@ b.bits_unk in
     let low_known = min low_a_known low_b_known in
+    let mid_bits = exact Z.(value a * value b) ex in
     let mid_bits =
-      if low_known = 0 then empty
-      else exact
-          low_known
-          Z.(extract (value a) 0 low_known * extract (value b) 0 low_known)
-          ex
+      if low_known = max_int then mid_bits
+      else extract mid_bits 0 low_known
     in
-    concat (unknown (sz - width mid_bits - width low_bits) Ex.empty) @@
-    concat mid_bits low_bits
+    if low_known = max_int then
+      mid_bits lsl zeroes
+    else
+      let high_bits =
+        { bits_set = Z.zero
+        ; bits_unk = Z.minus_one
+        ; ex = Ex.empty }
+      in
+      ((high_bits lsl low_known) lor mid_bits) lsl zeroes
 
-let shl a b =
+let bvshl ~size:sz a b =
   (* If the minimum value for [b] is larger than the bitwidth, the result is
      zero.
 
@@ -320,19 +348,21 @@ let shl a b =
      matches the bitlist pattern, and so is a lower bound. Ideally we would
      like to use the lower bound from the interval domain for [b] instead. *)
   match Z.to_int (increase_lower_bound b Z.zero) with
-  | n when n < width a ->
-    let low_zeros = Z.trailing_zeros @@ Z.lognot @@ a.bits_clr in
-    if low_zeros + n >= width a then
-      exact (width a) Z.zero (Ex.union (explanation a) (explanation b))
+  | n when n < sz ->
+    let low_zeros = Z.trailing_zeros @@ Z.logor a.bits_set a.bits_unk in
+    if low_zeros + n >= sz then
+      extract (exact Z.zero (Ex.union (explanation a) (explanation b))) 0 sz
     else if low_zeros + n > 0 then
-      concat (unknown (width a - low_zeros - n) Ex.empty) @@
-      exact (low_zeros + n) Z.zero (Ex.union (explanation a) (explanation b))
+      ((extract unknown 0 (sz - low_zeros - n)) lsl (low_zeros + n)) lor
+      extract
+        (exact Z.zero (Ex.union (explanation a) (explanation b)))
+        0 (low_zeros + n)
     else
-      unknown (width a) Ex.empty
+      extract unknown 0 sz
   | _ | exception Z.Overflow ->
-    exact (width a) Z.zero (explanation b)
+    constant Z.zero (explanation b)
 
-let lshr a b =
+let bvlshr ~size:sz a b =
   (* If the minimum value for [b] is larger than the bitwidth, the result is
      zero.
 
@@ -344,24 +374,26 @@ let lshr a b =
      matches the bitlist pattern, and so is a lower bound. Ideally we would
      like to use the lower bound from the interval domain for [b] instead. *)
   match Z.to_int (increase_lower_bound b Z.zero) with
-  | n when n < width a ->
-    let sz = width a in
-    if Z.testbit a.bits_clr (sz - 1) then (* MSB is zero *)
-      let low_msb_zero = Z.numbits @@ Z.extract (Z.lognot a.bits_clr) 0 sz in
+  | n when n < sz ->
+    if not (Z.testbit a.bits_unk (sz - 1) || Z.testbit a.bits_set (sz - 1))
+    then (* MSB is zero *)
+      let low_msb_zero =
+        Z.numbits @@ Z.extract (Z.logor a.bits_set a.bits_unk) 0 sz
+      in
       let nb_msb_zeros = sz - low_msb_zero in
       assert (nb_msb_zeros > 0);
       let nb_zeros = nb_msb_zeros + n in
       if nb_zeros >= sz then
-        exact sz Z.zero (Ex.union (explanation a) (explanation b))
+        constant Z.zero (Ex.union (explanation a) (explanation b))
       else
-        concat
-          (exact nb_zeros Z.zero (Ex.union (explanation a) (explanation b)))
-          (unknown (sz - nb_zeros) Ex.empty)
+        (
+          constant Z.zero (Ex.union (explanation a) (explanation b))
+          lsl (sz - nb_zeros)
+        ) lor (extract unknown 0 (sz - nb_zeros))
     else if n > 0 then
-      concat
-        (exact n Z.zero (explanation b))
-        (unknown (sz - n) Ex.empty)
+      (constant Z.zero (explanation b) lsl (sz - n)) lor
+      extract unknown 0 (sz - n)
     else
-      unknown sz Ex.empty
+      extract unknown 0 sz
   | _ | exception Z.Overflow ->
-    exact (width a) Z.zero (explanation b)
+    constant Z.zero (explanation b)


### PR DESCRIPTION
This patch rewrites the Bitlist module to represent infinite-width
bit-vectors rather than fixed-width bit-vectors, making it able to
represent unbounded integers. This improves the symmetry with the
interval domain (which also applies to unbounded integers) and is
intended to simplify the implementation of BV-to-int and int-to-BV
conversions.

In order to avoid having to use negative numbers in bitlists, the
internal representation is changed from a pair of (bits equal to [1],
bits equal to [0]) masks to a pair (bits equal to [1], unknown bits)
masks. This change should also be good for memory consumption, as we no
longer keep two copies of the value around when all bits are known.

Note: depends on #1108, #1058, #1083, #1084, and #1085. Only the latest commit with title "feat(BV): Do not store width in Bitlist" is included in this PR.