### PR TITLE
Rename `cstr` into `constr`

### DIFF
--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -193,8 +193,8 @@ let ty (ty_cst : DE.ty_cst) ty =
 let fpa_rounding_mode, rounding_modes, add_rounding_modes =
   match DT.view Fpa_rounding.fpa_rounding_mode_dty with
   | `App ((`Generic ty_cst), []) ->
-    let cstrs = Fpa_rounding.d_cstrs in
-    let add_cstrs map =
+    let constrs = Fpa_rounding.d_constrs in
+    let add_constrs map =
       List.fold_left (fun map ((c : DE.term_cst), _) ->
           let name = get_basename c.path in
           DStd.Id.Map.add { name = DStd.Name.simple name; ns = Term }
@@ -202,15 +202,15 @@ let fpa_rounding_mode, rounding_modes, add_rounding_modes =
                builtin_term @@
                Dolmen_type.Base.term_app_cst
                  (module Dl.Typer.T) env c) map)
-        map cstrs
+        map constrs
     in
     Cache.store_ty ty_cst Fpa_rounding.fpa_rounding_mode;
     Fpa_rounding.fpa_rounding_mode_dty,
-    cstrs,
+    constrs,
     fun map ->
       map
       |> ty ty_cst Fpa_rounding.fpa_rounding_mode_dty
-      |> add_cstrs
+      |> add_constrs
   | _ -> assert false
 
 module Const = struct

--- a/src/lib/frontend/parsed_interface.ml
+++ b/src/lib/frontend/parsed_interface.ml
@@ -331,8 +331,8 @@ let mk_cut loc expr =
 let mk_match loc expr cases =
   mk_localized loc (PPmatch (expr, cases))
 
-let mk_algebraic_test loc expr cstr =
-  mk_localized loc (PPisConstr (expr, cstr))
+let mk_algebraic_test loc expr constr =
+  mk_localized loc (PPisConstr (expr, constr))
 
-let mk_algebraic_project loc expr cstr =
-  mk_localized loc (PPproject (expr, cstr))
+let mk_algebraic_project loc expr constr =
+  mk_localized loc (PPproject (expr, constr))

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -273,7 +273,7 @@ module Env = struct
     match ty with
     | Ty.Tadt (name, []) ->
       let cases = Ty.type_body name [] in
-      let cstrs = List.map (fun Ty.{ constr; _ } -> constr) cases in
+      let constrs = List.map (fun Ty.{ constr; _ } -> constr) cases in
       List.fold_left
         (fun m c ->
            match Fpa_rounding.translate_smt_rounding_mode
@@ -291,16 +291,16 @@ module Env = struct
                m
         )
         map
-        cstrs
+        constrs
     | _ -> (* Fpa_rounding.fpa_rounding_mode is a sum type. *)
       assert false
 
-  let find_builtin_cstr ty n =
+  let find_builtin_constr ty n =
     match ty with
     | Ty.Tadt (name, []) ->
       let cases = Ty.type_body name [] in
-      let cstrs = List.map (fun Ty.{ constr; _ } -> constr) cases in
-      List.find (Uid.equal n) cstrs
+      let constrs = List.map (fun Ty.{ constr; _ } -> constr) cases in
+      List.find (Uid.equal n) constrs
     | _ ->
       assert false
 
@@ -312,7 +312,7 @@ module Env = struct
     } in
     let rm = Fpa_rounding.fpa_rounding_mode in
     let mode m =
-      let h = find_builtin_cstr rm m in
+      let h = find_builtin_constr rm m in
       {
         c = {
           tt_desc = TTapp (Symbols.(Op (Constr h)), []);
@@ -2383,13 +2383,13 @@ let type_user_defined_type_body ~is_recursive env acc (loc, ls, s, body) =
 
   | Algebraic lc ->
     List.fold_left
-      (fun (acc, env) (cstr, lbl_args_ty) ->
+      (fun (acc, env) (constr, lbl_args_ty) ->
          let args_ty = List.map snd lbl_args_ty in
          let tty, env =
-           Env.add_constr ~record:false env cstr args_ty pur_ty loc
+           Env.add_constr ~record:false env constr args_ty pur_ty loc
          in
          let acc =
-           ({c = TLogic(loc, [cstr], tty); annot=new_id ()}, env) :: acc
+           ({c = TLogic(loc, [constr], tty); annot=new_id ()}, env) :: acc
          in
          List.fold_left (* register destructors *)
            (fun (acc, env) (lbl, ty_lbl) ->

--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -173,7 +173,7 @@ module Domains = struct
      the legacy frontend and switching from [Uid.t] to
      [Dolmen.Std.Expr.term_cst] to store the constructors. Indeed, [term_cst]
      contains the type of constructor and in particular its arity. *)
-  let is_enum_cstr r c =
+  let is_enum_constr r c =
     match X.type_info r with
     | Tadt (name, args) ->
       let cases = Ty.type_body name args in
@@ -182,7 +182,7 @@ module Domains = struct
 
   let internal_update r nd t =
     let domains = MX.add r nd t.domains in
-    let is_enum_domain = Domain.for_all (is_enum_cstr r) nd in
+    let is_enum_domain = Domain.for_all (is_enum_constr r) nd in
     let enums = if is_enum_domain then SX.add r t.enums else t.enums in
     let changed = SX.add r t.changed in
     { domains; enums; changed }

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1276,8 +1276,8 @@ let mk_tester cons t =
 let mk_record xs ty = mk_term (Sy.Op Record) xs ty
 
 let void =
-  let cstr = Uid.of_term_cst Dolmen.Std.Expr.Term.Cstr.void in
-  mk_constr cstr [] Ty.tunit
+  let constr = Uid.of_term_cst Dolmen.Std.Expr.Term.Cstr.void in
+  mk_constr constr [] Ty.tunit
 
 (** Substitutions *)
 

--- a/src/lib/structures/fpa_rounding.ml
+++ b/src/lib/structures/fpa_rounding.ml
@@ -41,7 +41,7 @@ type rounding_mode =
   | NearestTiesToAway
 [@@deriving ord]
 
-let cstrs =
+let constrs =
   [
     NearestTiesToEven;
     ToZero;
@@ -76,36 +76,36 @@ let string_of_rounding_mode = to_smt_string
 let hstring_smt_reprs =
   List.map
     (fun c -> to_smt_string c, [])
-    cstrs
+    constrs
 
 let hstring_ae_reprs =
   List.map
     (fun c -> Hs.make (to_ae_string c))
-    cstrs
+    constrs
 
 (* The rounding mode is the enum with the SMT values.
    The Alt-Ergo values are injected in this type. *)
-let fpa_rounding_mode_dty, d_cstrs, fpa_rounding_mode =
+let fpa_rounding_mode_dty, d_constrs, fpa_rounding_mode =
   let module DStd = Dolmen.Std in
   (* We may use the builtin type `DStd.Expr.Ty.roundingMode` here. *)
   let ty_cst = DE.Ty.Const.mk (DStd.Path.global "RoundingMode") 0 in
-  let cstrs =
-    List.map (fun c -> DStd.Path.global @@ to_smt_string c, []) cstrs
+  let constrs =
+    List.map (fun c -> DStd.Path.global @@ to_smt_string c, []) constrs
   in
-  let def, d_cstrs = DE.Term.define_adt ty_cst [] cstrs in
+  let def, d_constrs = DE.Term.define_adt ty_cst [] constrs in
   Nest.attach_orders [def];
   let body =
-    List.map (fun (c, _) -> Uid.of_term_cst c, []) d_cstrs
+    List.map (fun (c, _) -> Uid.of_term_cst c, []) d_constrs
   in
   let ty = Ty.t_adt ~body:(Some body) (Uid.of_ty_cst ty_cst) [] in
-  DE.Ty.apply ty_cst [], d_cstrs, ty
+  DE.Ty.apply ty_cst [], d_constrs, ty
 
 let rounding_mode_of_smt_hs =
   let table = Hashtbl.create 5 in
   List.iter2 (
     fun (key, _) bnd ->
       Hashtbl.add table key bnd
-  ) hstring_smt_reprs cstrs;
+  ) hstring_smt_reprs constrs;
   fun key ->
     try Hashtbl.find table (Hstring.view key) with
     | Not_found ->
@@ -119,7 +119,7 @@ let rounding_mode_of_ae_hs =
   List.iter2 (
     fun key bnd ->
       Hashtbl.add table key bnd
-  ) hstring_ae_reprs cstrs;
+  ) hstring_ae_reprs constrs;
   fun key ->
     try Hashtbl.find table key with
     | Not_found ->

--- a/src/lib/structures/fpa_rounding.mli
+++ b/src/lib/structures/fpa_rounding.mli
@@ -51,7 +51,8 @@ val fpa_rounding_mode_ae_type_name : string
 val fpa_rounding_mode_dty : Dolmen.Std.Expr.Ty.t
 
 (** The Dolmen constructors of [rounding_mode]. *)
-val d_cstrs : (Uid.DE.term_cst * (Uid.DE.ty * Uid.DE.term_cst option) list) list
+val d_constrs :
+  (Uid.DE.term_cst * (Uid.DE.ty * Uid.DE.term_cst option) list) list
 
 (** The rounding mode type. *)
 val fpa_rounding_mode : Ty.t

--- a/src/lib/structures/uid.ml
+++ b/src/lib/structures/uid.ml
@@ -40,8 +40,8 @@ type ty_var = DE.ty_var t
 
 let order_tag : int DStd.Tag.t = DStd.Tag.create ()
 
-let has_order_if_cstr id =
-  let is_cstr DE.{ builtin; _ } =
+let has_order_if_constr id =
+  let is_constr DE.{ builtin; _ } =
     match builtin with
     | DStd.Builtin.Constructor _ -> true
     | _ -> false
@@ -49,14 +49,14 @@ let has_order_if_cstr id =
   let has_attached_order id =
     DE.Term.Const.get_tag id order_tag |> Option.is_some
   in
-  (not (is_cstr id)) || has_attached_order id
+  (not (is_constr id)) || has_attached_order id
 
 let[@inline always] of_term_cst id =
   (* This assertion ensures that the API of the [Nest] module have been
      correctly used, that is [Nest.attach_orders] have been called on
      the nest of [id] if [id] is a constructor of ADT. *)
-  if not @@ has_order_if_cstr id then
-    Fmt.invalid_arg "not order on %a" DE.Id.print id;
+  if not @@ has_order_if_constr id then
+    Fmt.invalid_arg "no order on %a" DE.Id.print id;
   Term_cst id
 
 let[@inline always] of_ty_cst id = Ty_cst id

--- a/src/lib/util/nest.ml
+++ b/src/lib/util/nest.ml
@@ -140,15 +140,15 @@ let build_graph (defs : DE.ty_def list) : Hp.t =
 module H = struct
   include Hashtbl.Make (DE.Ty.Const)
 
-  let add_cstr t (ty : DE.ty_cst) (cstr : DE.term_cst) =
+  let add_constr t (ty : DE.ty_cst) (constr : DE.term_cst) =
     match find t ty with
-    | len, cstrs ->
-      add t ty (len + 1, cstr :: cstrs); len
+    | len, constrs ->
+      add t ty (len + 1, constr :: constrs); len
     | exception Not_found ->
-      add t ty (1, [cstr]); 0
+      add t ty (1, [constr]); 0
 end
 
-let ty_cst_of_cstr DE.{ builtin; _ } =
+let ty_cst_of_constr DE.{ builtin; _ } =
   match builtin with
   | B.Constructor { adt; _ } -> adt
   | _ -> Fmt.failwith "expect an ADT constructor"
@@ -160,8 +160,8 @@ let attach_orders defs =
     (* Loop invariant: the set of nodes in heap [hp] is exactly
        the set of the nodes of the graph without ingoing hyperedge. *)
     let { id; outgoing; in_degree;  _ } = Hp.pop_min hp in
-    let ty = ty_cst_of_cstr id in
-    let o = H.add_cstr r ty id in
+    let ty = ty_cst_of_constr id in
+    let o = H.add_constr r ty id in
     DE.Term.Const.set_tag id Uid.order_tag o;
     assert (in_degree = 0);
     List.iter


### PR DESCRIPTION
We have no convention to abbrevate `constructor` or `destructor`. This commit chooses the convention:
constructor -> constr -> c
destructor -> destr -> d

Notice that `Dolmen` uses the `cstr` and `dstr`, so there are still some places, mainly in `D_cnf`, where these abbreviations appear.