### PR TITLE
fix(BV): Do not lose explanations in bvmul

### DIFF
--- a/tests/issues/1170.expected
+++ b/tests/issues/1170.expected
@@ -1,0 +1,2 @@
+
+unknown

--- a/tests/issues/1170.smt2
+++ b/tests/issues/1170.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_BV)
+(declare-const A (_ BitVec 2))
+(declare-const B (_ BitVec 1))
+(declare-const C (_ BitVec 3))
+(assert (= (bvmul (_ bv3 4) (concat A (concat #b0 B))) (concat C #b1)))
+(check-sat)


### PR DESCRIPTION
The implementation of bvmul from #1144 introduced a soundness bug: when we do not know anything about the result, the explanation is dropped.

This is because the implementation was performing mixing bitlist computation and creation of raw bitlist values. This patch fixes the implementation by performing all computations in [Z] and only adding the explanation at the end.