### PR TITLE
fix(CI): Ensure binary releases have proper version number

### DIFF
--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -4,16 +4,18 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    tags:
+      - "v*.*.*"
     branches:
       - next
       - main
 
 jobs:
-  macos-static:
+  build-macos-static:
     name: Build statically linked macOS binaries
     # Only do this when explicitly requested since it takes a long time to
     # build on macOS; no need to waste resources
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') }}
     strategy:
       matrix:
         include:
@@ -22,12 +24,18 @@ jobs:
           - arch: aarch64
             os: macos-14
 
+    permissions:
+      contents: write
+
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Retrieve annotated tags (https://github.com/actions/checkout/issues/290)
+        run: git fetch --tags --force
 
       - uses: ocaml/setup-ocaml@v3
         with:
@@ -49,7 +57,14 @@ jobs:
           name: alt-ergo-${{ matrix.arch }}-macos
           path: _destdir/opt/alt-ergo/bin/alt-ergo
 
-  musl:
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          asset_name: alt-ergo-$tag-${{ matrix.arch }}-macos
+          file: _destdir/opt/alt-ergo/bin/alt-ergo
+
+  build-musl:
     name: Build statically linked binary with musl
 
     runs-on: ubuntu-latest
@@ -59,6 +74,9 @@ jobs:
     container:
       image: ocamlpro/ocaml:4.14-flambda
       options: --user root
+
+    permissions:
+      contents: write
 
     steps:
 
@@ -76,6 +94,9 @@ jobs:
       # the ocaml user do not have rights on it.
       - run: CURRENTDIR=$(basename $(pwd)); git config --global --add safe.directory /__w/$CURRENTDIR/$CURRENTDIR
 
+      - name: Retrieve annotated tags (https://github.com/actions/checkout/issues/290)
+        run: git fetch --tags --force
+
       - name: Install static dependencies
         run: sudo apk add zlib-static
 
@@ -90,7 +111,15 @@ jobs:
 
       - run: opam exec -- dune install -p alt-ergo --create-install-files --prefix opt/alt-ergo --relocatable
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload musl artifact
+        uses: actions/upload-artifact@v4
         with:
           name: alt-ergo-x86_64-linux-musl
           path: _destdir/opt/alt-ergo/bin/alt-ergo
+
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          asset_name: alt-ergo-$tag-x86_64-linux-musl
+          file: _destdir/opt/alt-ergo/bin/alt-ergo


### PR DESCRIPTION
The issue boils down to GitHub not downloading tag information when running the workflow, which means that `dune-build-info` and `dune-subst` see a lightweight tag rather than an annotated tag and ignore it.

In order to facilitate deployment, update the workflow to automatically upload the artifact to the release if applicable.

Fixes #1131