### PR TITLE
perf: Improve performance of literal de-duplication

### DIFF
--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -542,19 +542,6 @@ let propagate_domains new_terms domains =
          eqs, new_terms
     ) ([], new_terms) domains
 
-(* Remove duplicate literals in the list [la]. *)
-let remove_redundancies la =
-  let cache = ref SLR.empty in
-  List.filter
-    (fun (a, _, _, _) ->
-       let a = LR.make a in
-       if SLR.mem a !cache then false
-       else begin
-         cache := SLR.add a !cache;
-         true
-       end
-    ) la
-
 (* Update the counter of case split size in [env]. *)
 let count_splits env la =
   List.fold_left
@@ -568,8 +555,6 @@ let assume env uf la =
   let ds = Uf.domains uf in
   let domains = Uf.GlobalDomains.find (module Domains) ds in
   Debug.pp_domains "before assume" domains;
-  (* should be done globally in CCX *)
-  let la = remove_redundancies la in
   let delayed, result = Rel_utils.Delayed.assume env.delayed uf la in
   let domains =
     try


### PR DESCRIPTION
This patch improves the different code paths that are used to ensure literal uniqueness. There are a couple of performance bugs here that are fixed by this patch:

 - In Rel_utils, we use a set of Xliteral *views*, which are converted to actual Xliterals in the comparison function. This means that we hash the literal views repeatedly (each time a comparison is performed).

 - Everywhere, we use sets of literals as temporary caches for uniqueness, where we could use hash maps (with better access times) instead.

 - In Adt_rel, we de-deduplicate input literals, but this is (almost) already done in the Ccx module. Almost, because the Ccx module allows multiple literals as long as they originally come from different expressions in the input problem -- which should occur rarely enough that we don't need the double deduplication.

On a development branch and a specific problem that was creating a lot of literals, the first change was a 3x speedup (from 36s to 12s), and the two second changes combined were an additional 25% speedup (from 12s to 9s).

On our internal dataset, the full patch is a speedup of about 3-4%.