### PR TITLE
Use Unix eof for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Declare files will always have LF line endings on checkout.
-configure eol=lf
+configure text eol=lf
+*.sh text eol=lf
 
 # Hide the file in statistics and pull request diffs.
 tests/dune.inc linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 # Declare files will always have LF line endings on checkout.
-configure text eol=lf
 *.sh text eol=lf
 
 # Hide the file in statistics and pull request diffs.


### PR DESCRIPTION
This modification is mostly motivated by the fact that we cannot test `opam` files on `Windows` if we try to install a git repository with `opam pin https://...`.