### PR TITLE
Fix MacOS static build

### DIFF
--- a/src/bin/text/gen-link-flags.sh
+++ b/src/bin/text/gen-link-flags.sh
@@ -22,7 +22,7 @@ case "$LINK_MODE" in
     FLAGS="-noautolink"
     # Note: for OCaml 5, use -lcamlstrnat and -lunixnat and mind zlib
     # https://github.com/ocaml/ocaml/issues/12562
-    CCLIB="-lstdcompat_stubs -lcamlzip -lnums -lzarith -lcamlstr -lunix -lz"
+    CCLIB="-lstdcompat_stubs -lcamlzip -lzarith -lcamlstr -lunix -lz"
     LIBS="gmp"
     case "$OS" in
       linux)


### PR DESCRIPTION
We do not install `nums` anymore so we need to update the static build workflow.