### PR TITLE
Do not use lock file for all OCaml versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.1
+  OCAML_DEFAULT_VERSION: 4.14.2
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -27,7 +27,7 @@ jobs:
           - ubuntu-latest
         ocaml-compiler:
           - 4.08.1
-          - 4.14.1
+          - 4.14.2
           - 5.0.0
         exclude:
           # No longer seems to be available

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.2
+  OCAML_DEFAULT_VERSION: 4.14.1
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -59,6 +59,8 @@ jobs:
 
   make:
     name: Make all
+    env:
+      OPAMLOCKED: locked
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -5,7 +5,7 @@ name: Build Javascript
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.0
+  OCAML_DEFAULT_VERSION: 4.14.1
   # Add OPAMYES=true to the environment, this is usefull to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -13,6 +13,7 @@ env:
   #   # The with-test flag is set to true to force installation of deps and
   #   # depext needed to run the alt-ergo tests
   #   OPAMWITHTEST: true
+  OPAMLOCKED: locked
 
 jobs:
   compile_and_test_js:

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -5,7 +5,7 @@ name: Build Javascript
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.1
+  OCAML_DEFAULT_VERSION: 4.14.2
   # Add OPAMYES=true to the environment, this is usefull to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.1
+  OCAML_DEFAULT_VERSION: 4.14.2
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,7 @@ name: Linter
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.1
+  OCAML_DEFAULT_VERSION: 4.14.2
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,7 @@ name: Linter
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.10.0
+  OCAML_DEFAULT_VERSION: 4.14.1
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.1
+  OCAML_DEFAULT_VERSION: 4.14.2
   OPAMYES: true
   OPAMLOCKED: locked
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 env:
   OCAML_DEFAULT_VERSION: 4.14.1
   OPAMYES: true
+  OPAMLOCKED: locked
 
 jobs:
   dune_release:

--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,9 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 lock:
 	dune build ./alt-ergo-lib.opam
 	opam lock ./alt-ergo-lib.opam -w
+	sed -i \
+		'/"ocaml"\|"ocaml-base-compiler"\|"ocaml-system"\|"ocaml-config"\|"base-domains"\|"base-nnp"/d' \
+		./alt-ergo-lib.opam.locked
 
 dev-switch:
 	opam switch create . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers

--- a/Makefile
+++ b/Makefile
@@ -239,11 +239,9 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 lock:
 	dune build ./alt-ergo-lib.opam
 	opam lock ./alt-ergo-lib.opam -w
-	# Remove OCaml compiler constraints
-	sed -i '/"ocaml"\|"ocaml-base-compiler"\|"ocaml-system"\|"ocaml-config"\|"base-domains"\|"base-nnp"/d' ./alt-ergo-lib.opam.locked
 
 dev-switch:
-	opam switch create -y . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
+	opam switch create . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 
 js-deps:
 	opam install \
@@ -255,10 +253,10 @@ js-deps:
 		lwt_ppx -y
 
 deps:
-	opam install -y . --locked --deps-only
+	opam install . --deps-only
 
 test-deps:
-	opam install -y . --locked --deps-only --with-test
+	opam install . --deps-only --with-test
 
 dune-deps:
 	dune-deps . | dot -Tpng -o docs/deps.png

--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,7 @@ archi: $(EXTRA_DIR)/ocamldot/ocamldot
 lock:
 	dune build ./alt-ergo-lib.opam
 	opam lock ./alt-ergo-lib.opam -w
+	# Remove OCaml compiler constraints
 	sed -i \
 		'/"ocaml"\|"ocaml-base-compiler"\|"ocaml-system"\|"ocaml-config"\|"base-domains"\|"base-nnp"/d' \
 		./alt-ergo-lib.opam.locked

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,7 +4,7 @@ import sources.nixpkgs {
   overlays = [
     (_: pkgs: { inherit sources; })
     (_: pkgs: {
-      ocamlPackages = pkgs.ocamlPackages.overrideScope' (self: super: {
+      ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14.overrideScope' (self: super: {
         pp_loc = pkgs.callPackage ./pp_loc.nix { };
         ocplib-simplex = pkgs.callPackage ./ocplib-simplex.nix { };
         dolmen = pkgs.callPackage ./dolmen.nix { };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -31,10 +31,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "544b36d1b4815fd5f187ed00ff7a59fd0323317c",
-        "sha256": "0jh67yjfkv9sj4xldlv9p6whljg0rh96hy7x082061ghsb3kg6q4",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "sha256": "1f5d2g1p6nfwycpmrnnmc2xmcszp804adp16knjvdkj8nz36y1fg",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/544b36d1b4815fd5f187ed00ff7a59fd0323317c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/205fd4226592cc83fd4c0885a3e4c9c400efabb5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ocplib-simplex": {


### PR DESCRIPTION
In the current version of our workflow, we use an opam lock file to ensure that we can reproduce builds. Unfortunately, there are different conflicts depending on the plateform and OCaml version. We use a hack to prevent opam from saving the version of OCaml's toolchain (see the target `lock` in our Makfile). This hack is not sufficient if we want to use the current workflow `build` on Windows.

This PR modifies the workflow `build` and the Makefile as follows:
1. We check the reproducibility only on OCaml 4.14.1. I choose this version because we both develop on this version with Nix.
2. We checked the Makefile on OCaml 4.14.2, which is strange because we check the installation with opam on OCaml 4.14.1. I replace 4.14.1 by 4.14.2.
3. I remove the flag `-y` in the target `dev-switch`, `deps` and `test-deps` because we use `OCAMLYES` in our workflows and Makefile's users want to check dependencies before running a slow task as `opam switch create` or `opam install`.