### PR TITLE
Remove warnings

### DIFF
--- a/src/lib/reasoners/arrays_rel.ml
+++ b/src/lib/reasoners/arrays_rel.ml
@@ -64,7 +64,7 @@ module G :Set.S with type elt = gtype = Set.Make
     (struct type t = gtype let compare t1 t2 = E.compare t1.g t2.g end)
 
 (* ensemble de termes "set" avec leurs arguments et leurs types *)
-type stype = {s:E.t; st:E.t; si:E.t; sv:E.t; sty:Ty.t}
+type stype = {s:E.t; st:E.t; si:E.t; sv:E.t}
 module S :Set.S with type elt = stype = Set.Make
     (struct type t = stype let compare t1 t2 = E.compare t1.s t2.s end)
 
@@ -199,7 +199,7 @@ let rec relevant_terms env t =
   match Sy.is_get f, Sy.is_set f, xs with
   | true , false, [a;i]   -> G.add {g=t; gt=a; gi=i; gty=ty} gets, tbset
   | false, true , [a;i;v] ->
-    gets, TBS.add a {s=t; st=a; si=i; sv=v; sty=ty} tbset
+    gets, TBS.add a {s=t; st=a; si=i; sv=v} tbset
   | false, false, _ -> (gets,tbset)
   | _  -> assert false
 

--- a/src/lib/reasoners/fun_sat.mli
+++ b/src/lib/reasoners/fun_sat.mli
@@ -26,7 +26,7 @@
 (**************************************************************************)
 
 (** A functional SAT solver implementation. *)
-module Make (Th : Theory.S) : sig
+module Make (_ : Theory.S) : sig
   type t
 
   exception Sat of t

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -157,5 +157,5 @@ end
 
 
 module type SatContainer = sig
-  module Make (Th : Theory.S) : S
+  module Make (_ : Theory.S) : S
 end

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -137,5 +137,5 @@ end
 
 
 module type SatContainer = sig
-  module Make (Th : Theory.S) : S
+  module Make (_ : Theory.S) : S
 end

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -46,7 +46,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
   type t = {
     satml : SAT.t;
-    mutable ff_hcons_env : FF.hcons_env;
+    ff_hcons_env : FF.hcons_env;
     mutable nb_mrounds : int;
     mutable last_forced_normal : int;
     mutable last_forced_greedy : int;

--- a/src/lib/reasoners/satml_frontend_hybrid.mli
+++ b/src/lib/reasoners/satml_frontend_hybrid.mli
@@ -25,7 +25,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module Make (Th : Theory.S) : sig
+module Make (_ : Theory.S) : sig
 
   type t
 

--- a/src/lib/util/nest.ml
+++ b/src/lib/util/nest.ml
@@ -47,7 +47,7 @@ type node = {
   (* This weight is used to prioritize constructors with less destructors
      during the sorting (see [add_nest]). *)
 
-  mutable outgoing : edge;
+  outgoing : edge;
   (* Hyperedge from a subset S in S(ty) to a subset G in G(ty) where ty is
      the type of [id]. At the beginning, we have S = S(ty) and G = G(ty).
 


### PR DESCRIPTION
After upgrading Dune, `ocamlc` outputs new warnings (I guess the default warning flags of Dune changed). This PR removes them.

Notice that there is still one warning:
```
record field acts_add_lit_view is never read
```
I guess this field will be used soon, so I do not touch it.