### PR TITLE
Remove some polymorphic hashtables

### DIFF
--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -3267,3 +3267,10 @@ module ArraysEx = struct
   let store a i v =
     mk_term Sy.(Op Set) [a; i; v] (type_info a)
 end
+
+module Table =
+  Hashtbl.Make (struct
+    type nonrec t = t
+    let hash = hash
+    let equal = equal
+  end)

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -155,8 +155,8 @@ and trigger = private {
   from_user : bool;
 }
 
+module Table : Hashtbl.S with type key = t
 module Set : Set.S with type elt = t
-
 module Map : Map.S with type key = t
 
 type subst = t Var.Map.t * Ty.subst


### PR DESCRIPTION
We should not use polymorphic equality on expressions because they may contain recursive terms producing by Dolmen. This PR removes these dangerous hashtables.