### PR TITLE
fix(BV): Do not build unnormalized values in zero_extend

### DIFF
--- a/src/lib/reasoners/bitv.mli
+++ b/src/lib/reasoners/bitv.mli
@@ -47,11 +47,14 @@ type 'a simple_term = ('a simple_term_aux) alpha_term
 
 type 'a abstract = 'a simple_term list
 
+val extract : int -> int -> int -> 'a abstract -> 'a abstract
 (** [extract size i j x] extracts [i..j] from a composition of size [size].
 
     An element of size [sz] at the head of the composition contains the bits
     [size - 1 .. size - sz] inclusive. *)
-val extract : int -> int -> int -> 'a abstract -> 'a abstract
+
+val zero_extend : int -> 'a abstract -> 'a abstract
+(** [zero_extract sz bv] adds [sz] zeros to the front (high bits) of [bv]. *)
 
 val lognot : 'a abstract -> 'a abstract
 


### PR DESCRIPTION
There is a stupid bug in the [zero_extend] function introduced in #1154: if the high bits of the extended value are known, it can create an unnormalized semantic value, which causes unsoundness.

Fix the [zero_extend] function, which is renamed to [zero_extend_to] since it takes as argument the extended size rather than the number of additional bits to add. Move the implementation to the [Bitv] module.

To prevent similar failures in the future, an heavy assertion is added in [solve] (where unsoundness would otherwise occur). I also tried to make the [Bitv.abstract] type private again, but that was a pain as it is used in several places in [Bitv_rel], so instead I simplified the code to avoid creating [Bitv.abstract] values from outside of the [Bitv] module where it was easy to do so.

No regression tests because I don't believe we can hit the bug with the code in `next`: we are only calling [zero_extend] on variables, so we can never create an unnormalized value this way.