### PR TITLE
Add zarith_stubs_js v0.17.0 in nix-shell

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,6 +12,7 @@ import sources.nixpkgs {
         dolmen_loop = pkgs.callPackage ./dolmen_loop.nix { };
         landmarks = pkgs.callPackage ./landmarks.nix { };
         landmarks-ppx = pkgs.callPackage ./landmarks-ppx.nix { };
+        zarith_stubs_js = pkgs.callPackage ./zarith_stubs_js.nix { };
       });
     })
   ];

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -62,5 +62,13 @@
         "url": "https://github.com/Armael/pp_loc/archive/d8162fd289849ea2f4125054ab88540416bdaa25.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "2.1.0"
+    },
+    "zarith_stubs_js": {
+        "branch": "v0.17.0",
+        "sha256": "07anr6r4chbpgd7c5ixfqgqr99kb202bd7q350hdqynrn7v6rn20",
+        "type": "tarball",
+        "url": "https://github.com/janestreet/zarith_stubs_js/archive/refs/tags/v0.17.0.tar.gz",
+        "url_template": "https://github.com/janestreet/zarith_stubs_js/archive/refs/tags/v0.17.0.tar.gz",
+        "version": "0.17.0"
     }
 }

--- a/nix/zarith_stubs_js.nix
+++ b/nix/zarith_stubs_js.nix
@@ -1,0 +1,16 @@
+{ sources, lib, ocamlPackages }:
+
+let
+  zarith_stubs_js = sources.zarith_stubs_js;
+in
+
+ocamlPackages.buildDunePackage {
+  strictDeps = true;
+  pname = "zarith_stubs_js";
+  inherit (zarith_stubs_js) version;
+
+  minimalOCamlVersion = "4.08";
+  duneVersion = "3";
+
+  src = zarith_stubs_js;
+}


### PR DESCRIPTION
Some primitives have been added in the latest version of `zarith_stubs_js` and we need them for the js version of Alt-Ergo.