### PR TITLE
fix: Make sure model generation is complete for more operators

### DIFF
--- a/docs/sphinx_docs/Model_generation.md
+++ b/docs/sphinx_docs/Model_generation.md
@@ -40,9 +40,9 @@ following constructs:
  - Algebraic data types (including records and enumerated types in the native
    language)
 
- - Integer and real primitives (addition, subtraction, multiplication,
-   division, modulo, exponentiation, and comparisons), but not conversion
-   operators between reals and integers
+ - The following integer and real primitives: addition, subtraction,
+   multiplication, division, modulo, comparisons, and exponentiations *with an
+   integer exponent*
 
  - Bit-vector primitives (concatenation, extraction, `bvadd`, `bvand`, `bvule`,
    etc.), including `bv2nat` and `int2bv`
@@ -50,14 +50,15 @@ following constructs:
 Completeness for the following constructs is only guaranteed with certain
 command-line flags:
 
- - Conversions operators between integers and reals require the
-   `--enable-theories ria` flag
+ - Conversions operators from integers to reals `real_of_int` and `real_is_int`
+   require the `--enable-theories ria` flag
 
  - Floating-point primitives (`ae.round`, `ae.float32` etc. in the SMT-LIB
    language; `float`, `float32` and `float64` in the native language) require
    the `--enable-theories fpa` flag
 
-Model generation is known to be sometimes incomplete in the presence of arrays.
+Model generation is known to be sometimes incomplete in the presence of arrays,
+and is incomplete for the `integer_round` function.
 
 ## Examples
 

--- a/src/lib/frontend/d_cnf.ml
+++ b/src/lib/frontend/d_cnf.ml
@@ -164,6 +164,7 @@ type _ DStd.Builtin.t +=
   | Sqrt_real_excess
   | Ceiling_to_int of [ `Real ]
   | Max_real
+  | Min_real
   | Max_int
   | Min_int
   | Integer_log2
@@ -359,6 +360,9 @@ let ae_fpa_builtins =
 
     (* maximum of two reals *)
     |> op "max_real" Max_real ([real; real] ->. real)
+
+    (* minimum of two reals *)
+    |> op "min_real" Min_real ([real; real] ->. real)
 
     (* maximum of two ints *)
     |> op "max_int" Max_int ([int; int] ->. int)
@@ -1349,6 +1353,7 @@ let rec mk_expr
           | B.Is_int `Real, _ -> op Real_is_int
           | Ceiling_to_int `Real, _ -> op Int_ceil
           | Max_real, _ -> op Max_real
+          | Min_real, _ -> op Min_real
           | Max_int, _ -> op Max_int
           | Min_int, _ -> op Min_int
           | Integer_log2, _ -> op Integer_log2

--- a/src/lib/frontend/typechecker.ml
+++ b/src/lib/frontend/typechecker.ml
@@ -404,6 +404,9 @@ module Env = struct
       (* maximum of two reals *)
       |> op "max_real" Max_real ([real; real] ->. real)
 
+      (* minimum of two reals *)
+      |> op "min_real" Min_real ([real; real] ->. real)
+
       (* maximum of two ints *)
       |> op "max_int" Max_int ([int; int] ->. int)
 

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2958,7 +2958,6 @@ let int_view t =
   | _ ->
     Fmt.failwith "The given term %a is not an integer" print t
 
-
 let rounding_mode_view t =
   match const_view t with
   | RoundingMode m -> m


### PR DESCRIPTION
Some RIA operators are not complete even in the presence of the corresponding prelude. Add them as delayed functions to ensure we loop rather than generating an incorrect model.