### PR TITLE
Add js_of_ocaml debug flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,20 +183,20 @@ html: doc
 # note that --timeout option is ignored due to the lack of js primitives
 # and the use of input zip file is also unavailable
 js-node:
-	$(DUNE) build $(DUNE_FLAGS) --profile=release $(BJS_DIR)/main_text_js.bc.js
+	$(DUNE) build $(DUNE_FLAGS) $(BJS_DIR)/main_text_js.bc.js
 	ln -sf $(DEFAULT_DIR)/$(BJS_DIR)/main_text_js.bc.js alt-ergo.js
 
 # Build a web worker for alt-ergo
 # zarith_stubs_js, data-encoding, js_of_ocaml and js_of_ocaml-lwt packages are needed for this rule
 js-worker:
-	$(DUNE) build $(DUNE_FLAGS) --profile=release $(BJS_DIR)/worker_js.bc.js
+	$(DUNE) build $(DUNE_FLAGS) $(BJS_DIR)/worker_js.bc.js
 	ln -sf $(DEFAULT_DIR)/$(BJS_DIR)/worker_js.bc.js alt-ergo-worker.js \
 
 # Build a small web example using the alt-ergo web worker
 # This example is available in the www/ directory
 # zarith_stubs_js, data-encoding, js_of_ocaml and js_of_ocaml-lwt js_of_ocaml-ppx lwt_ppx packages are needed for this rule
 js-example: js-worker
-	$(DUNE) build $(DUNE_FLAGS) --profile=release $(BJS_DIR)/worker_example.bc.js
+	$(DUNE) build $(DUNE_FLAGS) $(BJS_DIR)/worker_example.bc.js
 	mkdir -p www
 	cp $(EXTRA_DIR)/worker_example.html www/index.html
 	cd www \

--- a/dune
+++ b/dune
@@ -1,3 +1,12 @@
+(env
+  (dev
+    (js_of_ocaml
+      (flags (:standard --debug-info --no-inline --source-map))
+      (link_flags (:standard --pretty --debug-info --no-inline --source-map))))
+  (release
+    (js_of_ocaml
+      (flags (:standard --no-source-map)))))
+
 (subdir runtest
   (dynamic_include ../gentest/dune.inc))
 

--- a/src/bin/js/dune
+++ b/src/bin/js/dune
@@ -7,7 +7,7 @@
  )
  (modules main_text_js)
  (modes byte js)
- (js_of_ocaml (flags --no-source-map +toplevel.js +dynlink.js))
+ (js_of_ocaml (flags (:standard +toplevel.js +dynlink.js)))
 )
 
 (library
@@ -31,7 +31,7 @@
  )
  (modules worker_js options_interface)
  (modes byte js)
- (js_of_ocaml (flags --no-source-map +toplevel.js +dynlink.js))
+ (js_of_ocaml (flags (:standard +toplevel.js +dynlink.js)))
 )
 
 ; Rule to build a small js example running the Alt-Ergo web worker

--- a/src/dune
+++ b/src/dune
@@ -10,9 +10,7 @@
  (release ;; The release profile has optimizations enabled.
   (flags
    (:standard -bin-annot -w -22))
-  (ocamlopt_flags -O3 -unbox-closures))
-  (js_of_ocaml (flags --no-source-map))
-)
+  (ocamlopt_flags -O3 -unbox-closures)))
 
 (library
  (name alt_ergo_prelude)


### PR DESCRIPTION
Currently, we compile the js worker without debug flags in our makefile.
I got an annoying bug while adapting the worker for Dolmen and without the
dev flags of `dune`, it was impossible to debug. I think it is better to
build it with the profile `dev` by default.

I also add more debugs flags at the toplevel of our worktree.