### PR TITLE
Fix issue 1212

### DIFF
--- a/tests/issues/1212.default.expected
+++ b/tests/issues/1212.default.expected
@@ -1,0 +1,6 @@
+
+unknown
+(
+  (define-fun a () (Array Int Int) (as @a3 (Array Int Int)))
+  (define-fun b () (Array Int Int) (as @a2 (Array Int Int)))
+)

--- a/tests/issues/1212.default.smt2
+++ b/tests/issues/1212.default.smt2
@@ -1,0 +1,7 @@
+(set-option :produce-models true)
+(set-logic ALL)
+(declare-const a (Array Int Int))
+(declare-const b (Array Int Int))
+(assert (= (store a 0 0) (store b 0 0)))
+(check-sat)
+(get-model)

--- a/tests/issues/1212.default.smt2
+++ b/tests/issues/1212.default.smt2
@@ -1,3 +1,7 @@
+; The generated model is incorrect. It should ensure that a and b are
+; equal everywhere except on 0. This bug should be resolved
+; after addressing https://github.com/OCamlPro/alt-ergo/issues/929
+
 (set-option :produce-models true)
 (set-logic ALL)
 (declare-const a (Array Int Int))


### PR DESCRIPTION
During model extraction, we only should store accesses to arrays whose the representative elements are names. Indeed, if the representative is not a name, this array cannot appear in a model.

The embedded case is correctly managed because we generate fresh names that will become the representative elements.