### PR TITLE
Fix dependencies and `dune utop`

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -27,7 +27,6 @@ depends: [
   "stdlib-shims"
   "ppx_blob" {>= "0.7.2"}
   "ppx_deriving"
-  "camlzip" {>= "1.07"}
   "odoc" {with-doc}
   "ppx_deriving"
   "qcheck" {with-test & = "0.22"}

--- a/alt-ergo.opam
+++ b/alt-ergo.opam
@@ -15,10 +15,10 @@ depends: [
   "ocaml" {>= "4.08.1"}
   "dune" {>= "3.14"}
   "alt-ergo-lib" {= version}
-  "menhir"
   "dune-site"
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
+  "camlzip" {>= "1.07"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/dune-project
+++ b/dune-project
@@ -28,10 +28,10 @@ See more details on https://alt-ergo.ocamlpro.com/")
   (ocaml (>= 4.08.1))
   dune
   (alt-ergo-lib (= :version))
-  menhir
   dune-site
   (cmdliner (>= 1.1.0))
   (odoc :with-doc)
+  (camlzip (>= 1.07))
  )
 
  (sites (share preludes) (lib plugins))
@@ -63,7 +63,6 @@ See more details on http://alt-ergo.ocamlpro.com/"
   stdlib-shims
   (ppx_blob (>= 0.7.2))
   ppx_deriving
-  (camlzip (>= 1.07))
   (odoc :with-doc)
   ppx_deriving
   (qcheck (and :with-test (= 0.22)))

--- a/shell.nix
+++ b/shell.nix
@@ -42,5 +42,6 @@ pkgs.mkShell {
     landmarks
     landmarks-ppx
     qcheck
+    utop
   ];
 }

--- a/src/bin/common/dune
+++ b/src/bin/common/dune
@@ -12,6 +12,7 @@
    cmdliner
    dune-site
    dune-site.plugins
+   camlzip
  )
  (modules
    Config

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -17,7 +17,6 @@
     dynlink
     ocplib-simplex
     stdlib-shims
-    camlzip
     dolmen
     dolmen_type
     dolmen_loop


### PR DESCRIPTION
- The camlzip is not a dependency of `alt-ergo-lib` but the alt-ergo binary.
- Menhir is no longer a dependency, as the legacy frontend has been removed.
- `dune utop` failed for two reasons:
  1. camlzip is not compatible with the toplevel.
  2. js_of_ocaml library contains toplevel expressions whose the evaluation requires a JavaScript runtime. 
  
After this PR, `dune utop src/lib` works as expected.