### PR TITLE
Remove the lazy value in `extract_concrete_model`

### DIFF
--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -175,7 +175,7 @@ module Make (Th : Theory.S) = struct
     guards : guards;
     add_inst: E.t -> bool;
     unit_facts_cache : (E.gformula * Ex.t) ME.t ref;
-    last_saved_model : Models.t Lazy.t option ref;
+    last_saved_model : Models.t option ref;
     unknown_reason : Sat_solver_sig.unknown_reason option;
 
     declare_top : Id.typed list ref;
@@ -1847,8 +1847,7 @@ module Make (Th : Theory.S) = struct
     {env with tbox = Th.assume_th_elt env.tbox th_elt dep}
 
   (** returns the latest model stored in the env if any *)
-  let get_model env =
-    Option.map Lazy.force !(env.last_saved_model)
+  let get_model env = !(env.last_saved_model)
 
   let get_unknown_reason env = env.unknown_reason
 

--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -94,7 +94,7 @@ module type SAT_ML = sig
   val compute_concrete_model :
     declared_ids:Id.typed list ->
     t ->
-    Models.t Lazy.t * Objective.Model.t
+    Models.t * Objective.Model.t
 
   val set_new_proxies : t -> FF.proxies -> unit
 

--- a/src/lib/reasoners/satml.mli
+++ b/src/lib/reasoners/satml.mli
@@ -48,7 +48,7 @@ module type SAT_ML = sig
   val compute_concrete_model :
     declared_ids:Id.typed list ->
     t ->
-    Models.t Lazy.t * Objective.Model.t
+    Models.t * Objective.Model.t
 
   val set_new_proxies : t -> Flat_Formula.proxies -> unit
 

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -62,7 +62,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     mutable skolems : E.gformula ME.t; (* key <-> f *)
     add_inst : E.t -> bool;
     guards : guards;
-    mutable last_saved_model : Models.t Lazy.t option;
+    mutable last_saved_model : Models.t option;
     mutable last_saved_objectives : Objective.Model.t option;
     mutable unknown_reason : Sat_solver_sig.unknown_reason option;
     (** The reason why satml raised [I_dont_know] if it does; [None] by
@@ -1383,8 +1383,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
   let optimize env fn = SAT.optimize env.satml fn
 
-  let get_model env =
-    Option.map Lazy.force env.last_saved_model
+  let get_model env = env.last_saved_model
 
   let get_unknown_reason env = env.unknown_reason
 

--- a/src/lib/reasoners/theory.ml
+++ b/src/lib/reasoners/theory.ml
@@ -70,7 +70,7 @@ module type S = sig
   val extract_concrete_model :
     declared_ids:Id.typed list ->
     t ->
-    Models.t Lazy.t * Objective.Model.t
+    Models.t * Objective.Model.t
 
   val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
   val theories_instances :
@@ -894,12 +894,11 @@ module Main_Default : S = struct
     let { gamma_finite; assumed_set; objectives; _ }, _ =
       do_case_split_aux env ~for_model:true
     in
-    lazy (
-      CC_X.extract_concrete_model
-        ~prop_model:assumed_set
-        ~declared_ids
-        gamma_finite
-    ), objectives
+    CC_X.extract_concrete_model
+      ~prop_model:assumed_set
+      ~declared_ids
+      gamma_finite,
+    objectives
 
   let assume_th_elt t th_elt dep =
     { t with gamma = CC_X.assume_th_elt t.gamma th_elt dep }
@@ -953,7 +952,7 @@ module Main_Empty : S = struct
   let add_term env _ ~add_in_cs:_ = env
   let compute_concrete_model ~acts:_ _env = ()
   let extract_concrete_model ~declared_ids:_ _env =
-    lazy Models.empty, Objective.Model.empty
+    Models.empty, Objective.Model.empty
 
   let assume_th_elt e _ _ = e
   let theories_instances ~do_syntactic_matching:_ _ e _ _ _ = e, []

--- a/src/lib/reasoners/theory.mli
+++ b/src/lib/reasoners/theory.mli
@@ -61,7 +61,7 @@ module type S = sig
   val extract_concrete_model :
     declared_ids:Id.typed list ->
     t ->
-    Models.t Lazy.t * Objective.Model.t
+    Models.t * Objective.Model.t
 
   val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
   val theories_instances :

--- a/tests/models/arith/arith11.default.expected
+++ b/tests/models/arith/arith11.default.expected
@@ -2,7 +2,7 @@
 unknown
 (
   (define-fun x () Real 2.0)
-  (define-fun y () Real (as @a0 Real))
+  (define-fun y () Real (as @a4 Real))
   (define-fun p1 () Bool false)
   (define-fun p2 () Bool true)
 )


### PR DESCRIPTION
The code is harder to understand with this lazy value and most of the model generation code does not run if `Options.get_interpretation ()` is not true.