### PR TITLE
packaging: Avoid Cmdliner 2.0

### DIFF
--- a/alt-ergo.opam
+++ b/alt-ergo.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "3.14"}
   "alt-ergo-lib" {= version}
   "dune-site"
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0"}
   "odoc" {with-doc}
   "camlzip" {>= "1.07"}
 ]

--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@ See more details on https://alt-ergo.ocamlpro.com/")
   dune
   (alt-ergo-lib (= :version))
   dune-site
-  (cmdliner (>= 1.1.0))
+  (cmdliner (and (>= 1.1.0) (< 2.0)))
   (odoc :with-doc)
   (camlzip (>= 1.07))
  )


### PR DESCRIPTION
Cmdliner is planning to drop parsing of options using prefixes [1] in version 2.0. This is a change that can potentially impact our users in unpredicted and unwanted ways, so let's make sure we only move to cmdliner 2.0 after deciding we are OK with dropping this feature and a review of potential uses in Alt-Ergo. In the meantime, add 2.0 as an upper bound for cmdliner.

We should backport this to the 2.6 branch and cut a release quickly.

[1] : https://github.com/dbuenzli/cmdliner/issues/200