### PR TITLE
feat: Interactive prompt in interactive mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
   - Remove the legacy frontend and AB-Why3 plugin
 
+### User Interface
+
+ - Interactive prompt when using interactive mode (#1310)
+
 ## v2.6.0
 
 ### Command-line interface

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -158,6 +158,13 @@ type solve_res =
 
 exception StopProcessDecl
 
+let interactive_prompt st =
+  match D_loop.State.get D_loop.State.logic_file st with
+  | { source = `Stdin; mode = (None | Some `Incremental); _ }
+    when Compat.In_channel.isatty stdin ->
+    Some "alt-ergo>"
+  | _ -> None
+
 let process_source ?selector_inst ~print_status src =
   let () = Dolmen_loop.Code.init [] in
 
@@ -335,7 +342,7 @@ let process_source ?selector_inst ~print_status src =
           | ext ->
             warning "cannot infer output format from the extension '%s'" ext
         end
-      | `Stdin -> ()
+      | `Stdin -> set_output_format Dl.Logic.(Smtlib2 `Poly)
   in
   let extract_zip_file f =
     let cin = Zip.open_in f in
@@ -394,6 +401,7 @@ let process_source ?selector_inst ~print_status src =
     |> State.init ~debug ~report_style ~reports ~max_warn ~time_limit
       ~size_limit ~response_file
     |> Parser.init
+      ~interactive_prompt
     |> Typer.init
       ~additional_builtins:Translate.builtins
       ~extension_builtins:[Typer.Ext.bv2nat]

--- a/src/lib/util/compat.ml
+++ b/src/lib/util/compat.ml
@@ -153,3 +153,11 @@ module Type = struct
       match A.Id with B.Id -> Some Equal | _ -> None
   end
 end
+
+module In_channel = struct
+  type t = in_channel
+
+  (* Even though this function is only exposed through the [In_channel] module
+     since OCaml 5.1, it has been available in the runtime since OCaml 4.03. *)
+  external isatty : t -> bool = "caml_sys_isatty"
+end

--- a/src/lib/util/compat.mli
+++ b/src/lib/util/compat.mli
@@ -168,3 +168,24 @@ module Type : sig
         to [i1] and [None] otherwise. *)
   end
 end
+
+module In_channel : sig
+  (** Input channels.
+
+      This module provides functions for working with input channels.
+
+      See {{!examples} the example section} below.
+
+      @since OCaml 4.14 *)
+
+  (** {1:channels Channels} *)
+
+  type t = in_channel
+  (** The type of input channel. *)
+
+  val isatty : t -> bool
+  (** [isatty ic] is [true] if [ic] refers to a terminal or console window,
+      [false] otherwise.
+
+      @since OCaml 5.1 *)
+end


### PR DESCRIPTION
This patch adds an interactive prompt when Alt-Ergo is used in interactive mode in a terminal.

Only display the interactive prompt when reading from an incremental stdin session from an interactive device (i.e. `In_channel.isatty stdin` holds). This last part ensures that we don't display the prompt when using redirects (e.g. `alt-ergo < path/to/input.smt2`).