### PR TITLE
chore: Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,29 @@
+# fix indentation
+aa653f0ac2e6713be204d28d2c18716e74bab606
+
+# patch indentation
+4cfd9703d46f98c4f9d51efda06ab13f949b3664
+
+# passage à ocp-indent le plus récent
+8f05b600233de424dde37545c8f2144b56df8008
+
+# fix indentation issue
+8628b8f8620dcc1f0e47876340975dde98833c88
+
+# fix indentation
+3113d146aa3ab7be21977411fee16041dffe076f
+
+# Fix indent
+59d080bb12e18f54d6bc297338eb1cc86ace4ad0
+
+# Remove tabs and homogeneize opam file indent
+c1acb60faa29e0b43b9690c2d3d1ac3d7027e839
+
+# Fix indent in comment + remove tab
+18ceec92907a3db08717b7f97fbdaf8b6b1a3a0d
+
+# fix indentation
+9b3f6e83446a40d8d00e85aaa1573c93b4e9d73e
+
+# indent files with ocp-indent
+696be94f6b4373e7640d7075b80c872608eeb957


### PR DESCRIPTION
This prevents commits that only change indentation to appear in `git blame` output, which makes it more useable.

The file can be used by setting:

$ git config blame.ignoreRevsFile .git-blame-ignore-revs

or by passing `--ignore-revs-file` to `git blame`.