### PR TITLE
Move guard creation from Satml_frontend to Satml

### DIFF
--- a/src/lib/reasoners/satml.ml
+++ b/src/lib/reasoners/satml.ml
@@ -133,7 +133,7 @@ module type SAT_ML = sig
 
   val conflict_analyze_and_fix : t -> conflict_origin -> unit
 
-  val push : t -> Satml_types.Atom.atom -> unit
+  val push : t -> E.t
   val pop : t -> unit
 
   val optimize : t -> Objective.Function.t -> unit
@@ -2175,13 +2175,18 @@ module Make (Th : Theory.S) : SAT_ML with type th = Th.t = struct
 
   let known_lazy_formulas env = env.ff_lvl
 
-  let push env guard =
-    assert (not (is_assigned guard));
-    guard.is_guard <- true;
-    guard.neg.is_guard <- false;
+  let push env =
+    let expr_guard, var_guard = Atom.fresh_var env.hcons_env in
+    let nbv = Atom.nb_made_vars env.hcons_env in
+    let unit, nunit = new_vars env ~nbv [var_guard] [] [] in
+    assert (unit == [] && nunit == []);
+    assert (not (is_assigned var_guard.pa));
+    var_guard.pa.is_guard <- true;
+    var_guard.na.is_guard <- false;
     cancel_until env env.next_dec_guard;
-    Vec.push env.increm_guards guard;
-    Vec.push env.objectives []
+    Vec.push env.increm_guards var_guard.pa;
+    Vec.push env.objectives [];
+    expr_guard
 
   let pop env =
     assert (not (Vec.is_empty env.increm_guards));

--- a/src/lib/reasoners/satml.mli
+++ b/src/lib/reasoners/satml.mli
@@ -92,9 +92,9 @@ module type SAT_ML = sig
 
   val conflict_analyze_and_fix : t -> conflict_origin -> unit
 
-  val push : t -> Satml_types.Atom.atom -> unit
-  (** [push env g] adds a new assertion level. The formula [g] is used in
-      [Satml_frontend] to guard all formulas asserted at this level. *)
+  val push : t -> Expr.t
+  (** [push env] adds a new assertion level and returns a guard [g] that must be
+      used to guard all formulas asserted at this level. *)
 
   val pop : t -> unit
   (** [pop env] pops the latest assertion level. *)

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1248,32 +1248,13 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     if get_save_used_context () then fails "save_used_context";
     if get_unsat_core () then fails "unsat_core"
 
-  let create_guard env =
-    let expr_guard = E.fresh_name Ty.Tbool in
-    let ff, axs, new_vars =
-      FF.simplify env.ff_hcons_env expr_guard
-        (fun f -> ME.find f env.abstr_of_axs) []
-    in
-    assert (axs == []);
-    match FF.view ff, new_vars with
-    | FF.UNIT atom_guard, [v] ->
-      assert (Atom.eq_atom atom_guard v.pa);
-      let nbv = FF.nb_made_vars env.ff_hcons_env in
-      (* Need to use new_vars function to add the new_var corresponding to
-         the atom atom_guard in the satml env *)
-      let u, nu = SAT.new_vars env.satml ~nbv new_vars [] [] in
-      assert (u == [] && nu == []);
-      expr_guard, atom_guard
-    | _ -> assert false
-
   let declare env id =
     env.declare_top <- id :: env.declare_top
 
   let push env to_push =
     Util.loop ~f:(fun _n () () ->
         try
-          let expr_guard, atom_guard = create_guard env in
-          SAT.push env.satml atom_guard;
+          let expr_guard = SAT.push env.satml in
           Stack.push expr_guard env.guards.stack_guard;
           Steps.push_steps ();
           env.guards.current_guard <- expr_guard;

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -116,6 +116,7 @@ module type ATOM = sig
   val add_atom :
     hcons_env -> Shostak.Literal.t -> var list -> atom * var list
   val add_expr_atom : hcons_env -> E.t -> var list -> atom * var list
+  val fresh_var : hcons_env -> E.t * var
 
   module Set : Set.S with type elt = atom
   module Map : Map.S with type key = atom
@@ -288,45 +289,49 @@ module Atom : ATOM = struct
 
   type hcons_env = { tbl : var HT.t ; cpt : int ref }
 
+  let replace_var hcons lit =
+    let cpt = !(hcons.cpt) in
+    let cpt_fois_2 = cpt * 2 in
+    let rec var  =
+      { vid = cpt;
+        pa = pa;
+        na = na;
+        level = -1;
+        index = -1;
+        hindex = -1;
+        reason = None;
+        weight = 0.;
+        seen = false;
+        vpremise = [];
+      }
+    and pa =
+      { var = var;
+        lit = lit;
+        watched = Vec.make 10 ~dummy:dummy_clause;
+        neg = na;
+        is_true = false;
+        is_guard = false;
+        timp = 0;
+        aid = cpt_fois_2 (* aid = vid*2 *) }
+    and na =
+      { var = var;
+        lit = Shostak.Literal.neg lit;
+        watched = Vec.make ~dummy:dummy_clause 10;
+        neg = pa;
+        is_true = false;
+        is_guard = false;
+        timp = 0;
+        aid = cpt_fois_2 + 1 (* aid = vid*2+1 *) } in
+    HT.add hcons.tbl lit var;
+    incr hcons.cpt;
+    var
+
   let make_var =
     fun hcons lit acc ->
     let lit, negated = Shostak.Literal.normal_form lit in
     try HT.find hcons.tbl lit, negated, acc
     with Not_found ->
-      let cpt = !(hcons.cpt) in
-      let cpt_fois_2 = cpt * 2 in
-      let rec var  =
-        { vid = cpt;
-          pa = pa;
-          na = na;
-          level = -1;
-          index = -1;
-          hindex = -1;
-          reason = None;
-          weight = 0.;
-          seen = false;
-          vpremise = [];
-        }
-      and pa =
-        { var = var;
-          lit = lit;
-          watched = Vec.make 10 ~dummy:dummy_clause;
-          neg = na;
-          is_true = false;
-          is_guard = false;
-          timp = 0;
-          aid = cpt_fois_2 (* aid = vid*2 *) }
-      and na =
-        { var = var;
-          lit = Shostak.Literal.neg lit;
-          watched = Vec.make ~dummy:dummy_clause 10;
-          neg = pa;
-          is_true = false;
-          is_guard = false;
-          timp = 0;
-          aid = cpt_fois_2 + 1 (* aid = vid*2+1 *) } in
-      HT.add hcons.tbl lit var;
-      incr hcons.cpt;
+      let var = replace_var hcons lit in
       var, negated, var :: acc
 
   let add_atom hcons lit acc =
@@ -335,6 +340,10 @@ module Atom : ATOM = struct
 
   let add_expr_atom hcons lit acc =
     add_atom hcons (Shostak.Literal.make @@ LTerm lit) acc
+
+  let fresh_var hcons =
+    let expr = E.fresh_name Tbool in
+    expr, replace_var hcons (Shostak.Literal.make @@ LTerm expr)
 
   (* with this code, all envs created with empty_hcons_env () will be
      initialized with the good reference to "vrai" *)

--- a/src/lib/structures/satml_types.mli
+++ b/src/lib/structures/satml_types.mli
@@ -112,6 +112,7 @@ module type ATOM = sig
   val add_atom :
     hcons_env -> Shostak.Literal.t -> var list -> atom * var list
   val add_expr_atom : hcons_env -> Expr.t -> var list -> atom * var list
+  val fresh_var : hcons_env -> Expr.t * var
 
   module Set : Set.S with type elt = atom
   module Map : Map.S with type key = atom


### PR DESCRIPTION
This reduces the amount of calls to `new_vars` from outside the `Satml` module to 1, making it easier to get rid of that function and fold it into `assume` for a simpler and more robust API.