### PR TITLE
fix: Break potentially infinite loop with steps counter

### DIFF
--- a/src/lib/reasoners/uf.ml
+++ b/src/lib/reasoners/uf.ml
@@ -474,6 +474,9 @@ module Env = struct
     let rec fixpoint () =
       Options.exec_thread_yield ();
       (try SetRL.iter apply_rule rls with Exit -> ());
+      (* AC(X) bugs can trigger an infinite loop here, so increment a steps
+         counter to be safe. *)
+      Steps.incr Ac;
       if !fp then !r, !ex else (fp := true; fixpoint ())
     in fixpoint()
 

--- a/tests/smtlib/testfile-get-info1.default.expected
+++ b/tests/smtlib/testfile-get-info1.default.expected
@@ -1,7 +1,7 @@
 
 unknown
 (
- :steps 9)
+ :steps 16)
 
 unsupported
 


### PR DESCRIPTION
This is a band-aid to make the steps limit more robust until we switch to memory/allocation limits. See #1314 