### PR TITLE
Add back the `Loc` module

### DIFF
--- a/src/bin/js/worker_js.ml
+++ b/src/bin/js/worker_js.ml
@@ -102,7 +102,7 @@ let main worker_id filename filecontent =
           | None -> begin
               match Expr.form_view f with
               | Lemma {name=name;loc=loc;_} ->
-                let b,e = Dolmen.Std.Loc.lexing_positions loc in
+                let b,e = Loc.lexing_positions loc in
                 let used =
                   if Options.get_unsat_core () then Worker_interface.Unused
                   else Worker_interface.Unknown in
@@ -110,7 +110,7 @@ let main worker_id filename filecontent =
               | _ -> acc
             end
           | Some r ->
-            let b,e = Dolmen.Std.Loc.lexing_positions r.loc in
+            let b,e = Loc.lexing_positions r.loc in
             (r.name,b.Lexing.pos_lnum,e.Lexing.pos_lnum,
              !nb,Worker_interface.Used)
             :: acc

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -60,7 +60,7 @@
     ; util
     Emap Gc_debug Hconsing Hstring Heap Numbers Uqueue
     Options Timers Util Vec Version Steps Printer
-    My_list Theories Nest Compat
+    My_list Theories Nest Compat Loc
   )
 
  (js_of_ocaml

--- a/src/lib/frontend/frontend.ml
+++ b/src/lib/frontend/frontend.ml
@@ -135,7 +135,7 @@ module type S = sig
     mutable expl : Explanation.t
   }
 
-  type 'a process = ?loc : Dolmen.Std.Loc.loc -> 'a -> env -> unit
+  type 'a process = ?loc : Loc.t -> 'a -> env -> unit
 
   val init_env : ?selector_inst:(Expr.t -> bool) -> used_context -> env
 
@@ -221,7 +221,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     mutable expl : Explanation.t
   }
 
-  type 'a process = ?loc : DStd.Loc.loc -> 'a -> env -> unit
+  type 'a process = ?loc : Loc.t -> 'a -> env -> unit
 
   let init_env ?selector_inst used_context =
     {
@@ -294,20 +294,20 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     else Ex.empty
 
   let internal_decl
-      ?(loc = DStd.Loc.dummy) (id : Id.typed) (env : env) : unit =
+      ?(loc = Loc.dummy) (id : Id.typed) (env : env) : unit =
     ignore loc;
     match env.res with
     | `Sat | `Unknown ->
       SAT.declare env.sat_env id
     | `Unsat -> ()
 
-  let internal_push ?(loc = DStd.Loc.dummy) (n : int) (env : env) : unit =
+  let internal_push ?(loc = Loc.dummy) (n : int) (env : env) : unit =
     ignore loc;
     Util.loop ~f:(fun _ res () -> Stack.push res env.consistent_dep_stack)
       ~max:n ~elt:(env.res, env.expl) ~init:();
     Steps.apply_without_step_limit (fun () -> SAT.push env.sat_env n)
 
-  let internal_pop ?(loc = DStd.Loc.dummy) (n : int) (env : env) : unit =
+  let internal_pop ?(loc = Loc.dummy) (n : int) (env : env) : unit =
     ignore loc;
     let res, expl =
       Util.loop ~f:(fun _n () _env -> Stack.pop env.consistent_dep_stack)
@@ -318,7 +318,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     env.expl <- expl
 
   let internal_assume
-      ?(loc = DStd.Loc.dummy)
+      ?(loc = Loc.dummy)
       ((name, f, mf) : string * E.t * bool)
       (env : env) =
     let is_hyp = try (Char.equal '@' name.[0]) with _ -> false in
@@ -350,13 +350,13 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
       | `Unsat ->
         env.expl <- expl
 
-  let internal_pred_def ?(loc = DStd.Loc.dummy) (name, f) env =
+  let internal_pred_def ?(loc = Loc.dummy) (name, f) env =
     if not (unused_context name env.used_context) then
       let expl = mk_root_dep name f loc in
       SAT.pred_def env.sat_env f name expl loc;
       env.expl <- expl
 
-  let internal_query ?(loc = DStd.Loc.dummy) (n, f, sort) env =
+  let internal_query ?(loc = Loc.dummy) (n, f, sort) env =
     ignore loc;
     let expl =
       match env.res with
@@ -385,7 +385,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
     env.expl <- expl
 
   let internal_th_assume
-      ?(loc = DStd.Loc.dummy)
+      ?(loc = Loc.dummy)
       ({ Expr.ax_name; Expr.ax_form ; _ } as th_elt)
       env =
     if not (unused_context ax_name env.used_context) then
@@ -396,7 +396,7 @@ module Make(SAT : Sat_solver_sig.S) : S with type sat_env = SAT.t = struct
         env.expl <- expl
       | `Unsat -> ()
 
-  let internal_optimize ?(loc = DStd.Loc.dummy) fn env =
+  let internal_optimize ?(loc = Loc.dummy) fn env =
     ignore loc;
     match env.res with
     | `Sat | `Unknown ->

--- a/src/lib/frontend/frontend.mli
+++ b/src/lib/frontend/frontend.mli
@@ -64,7 +64,7 @@ module type S = sig
       They catch the [Sat], [Unsat] and [I_dont_know] exceptions to update the
       frontend environment, but not the [Timeout] exception which is raised to
       the user. *)
-  type 'a process = ?loc:Dolmen.Std.Loc.loc -> 'a -> env -> unit
+  type 'a process = ?loc:Loc.t -> 'a -> env -> unit
 
   val push : int process
 

--- a/src/lib/frontend/translate.ml
+++ b/src/lib/frontend/translate.ml
@@ -495,7 +495,7 @@ let rec dty_to_ty ?(update = false) ?(is_var = false) dty =
     let vty = aux vty in
     Ty.Tfarray (ity, vty)
   | `Bitv n ->
-    if n <= 0 then Errors.typing_error (NonPositiveBitvType n) DStd.Loc.dummy;
+    if n <= 0 then Errors.typing_error (NonPositiveBitvType n) Loc.dummy;
     Ty.Tbitv n
 
   | `App (`Builtin B.Unit, []) -> Ty.tunit
@@ -763,7 +763,7 @@ let arith_ty = function
    - [lb] is the (optional) lower bound for the variable [var]
    - [ub] is the (optional) upper bound for the variable [var]
 *)
-let parse_semantic_bound ?(loc = DStd.Loc.dummy) ~var b x y =
+let parse_semantic_bound ?(loc = Loc.dummy) ~var b x y =
   let is_main_var { DE.term_descr; _ } =
     match term_descr with
     | DE.Var v -> DE.Id.equal v var
@@ -779,7 +779,7 @@ let parse_semantic_bound ?(loc = DStd.Loc.dummy) ~var b x y =
     | _ ->
       Fmt.failwith
         "%aInternal error: invalid semantic bound"
-        DStd.Loc.fmt loc
+        Loc.report loc
   in
   let sort = arith_ty t in
   let parse_bound_kind { DE.term_descr; _ } =
@@ -790,7 +790,7 @@ let parse_semantic_bound ?(loc = DStd.Loc.dummy) ~var b x y =
     | _ ->
       Fmt.failwith
         "%aInternal error: invalid semantic bound"
-        DStd.Loc.fmt loc
+        Loc.report loc
   in
   (* Parse [main_var `op` b] *)
   let parse_bound ?(flip = false) b =
@@ -869,7 +869,7 @@ let mk_rounding fpar =
     Builds an Alt-Ergo hashconsed expression from a dolmen term
 *)
 let rec mk_expr
-    ?(loc = DStd.Loc.dummy) ?(name_base = "") ?(toplevel = false)
+    ?(loc = Loc.dummy) ?(name_base = "") ?(toplevel = false)
     ~decl_kind dt =
   let name_tag = ref 0 in
   let rec aux_mk_expr ?(toplevel = false)
@@ -984,7 +984,7 @@ let rec mk_expr
               | _ ->
                 Fmt.failwith
                   "%asemantic trigger should have at most one bound variable"
-                  DStd.Loc.fmt loc
+                  Loc.report loc
             in
             semantic_trigger ~loc ?var trigger
 
@@ -1400,7 +1400,7 @@ let rec mk_expr
       res
     | _ -> res
 
-  and semantic_trigger ?var ?(loc = DStd.Loc.dummy) t =
+  and semantic_trigger ?var ?(loc = Loc.dummy) t =
     let cst, args =
       match destruct_app t with
       | Some (cst, args) -> cst, args
@@ -1424,7 +1424,7 @@ let rec mk_expr
         | _ ->
           Fmt.failwith
             "%aMaps_to: expected a variable but got: %a"
-            DStd.Loc.fmt loc DE.Term.print x
+            Loc.report loc DE.Term.print x
       end
 
     (* open-ended in interval *)
@@ -1467,16 +1467,16 @@ let rec mk_expr
           E.mk_term (Sy.mk_in lb ub) [aux_mk_expr main_expr] Ty.Tbool
         | _ ->
           Fmt.failwith "%aInvalid semantic trigger: %a"
-            DStd.Loc.fmt loc DE.Term.print t
+            Loc.report loc DE.Term.print t
       end
 
     | _ ->
       Fmt.failwith "%aInvalid semantic trigger: %a"
-        DStd.Loc.fmt loc DE.Term.print t
+        Loc.report loc DE.Term.print t
 
   in aux_mk_expr ~toplevel dt
 
-and make_trigger ?(loc = DStd.Loc.dummy) ~name_base ~decl_kind
+and make_trigger ?(loc = Loc.dummy) ~name_base ~decl_kind
     ~(in_theory: bool) (name: string) (hyp: E.t list)
     (e, from_user: DE.term * bool) =
   (* Dolmen adds an existential quantifier to bind the '?xxx' variables *)
@@ -1618,11 +1618,12 @@ let rec is_pure_term t =
 
 let make file acc stmt =
   let rec aux acc (stmt: _ Typer_Pipe.stmt) =
-    let st_loc = Dolmen.Std.Loc.loc file stmt.loc in
+    let loc = Dolmen.Std.Loc.loc file stmt.loc in
+    let st_loc = Loc.from_dolmen_loc loc in
     match stmt with
     (* Optimize terms *)
     | { contents = `Optimize (t, is_max); _ } ->
-      let e = mk_expr ~loc:st_loc ~toplevel:true ~decl_kind:Dobjective t in
+      let e = mk_expr t ~loc:st_loc ~toplevel:true ~decl_kind:Dobjective in
       let fn = Objective.Function.mk ~is_max e in
       if not @@ is_pure_term e then
         begin
@@ -1760,7 +1761,7 @@ let make file acc stmt =
         | _ ->
           Fmt.failwith
             "%a: Internal error: multiple theories."
-            DStd.Loc.fmt st_loc
+            DStd.Loc.fmt loc
       in
       let decl_kind, assume =
         match theory with
@@ -1837,7 +1838,7 @@ let make file acc stmt =
                 in
                 let qb = E.mk_eq ~iff:true defn ff in
                 let ff =
-                  E.mk_forall name_base DStd.Loc.dummy binders [] qb
+                  E.mk_forall name_base Loc.dummy binders [] qb
                     ~toplevel:true ~decl_kind
                 in
                 assert (Var.Map.is_empty (E.free_vars ff Var.Map.empty));
@@ -1858,7 +1859,7 @@ let make file acc stmt =
                 let iff = Ty.equal (Expr.type_info defn) (Ty.Tbool) in
                 let qb = E.mk_eq ~iff defn ff in
                 let ff =
-                  E.mk_forall name_base DStd.Loc.dummy binders [] qb
+                  E.mk_forall name_base Loc.dummy binders [] qb
                     ~toplevel:true ~decl_kind
                 in
                 assert (Var.Map.is_empty (E.free_vars ff Var.Map.empty));

--- a/src/lib/frontend/translate.mli
+++ b/src/lib/frontend/translate.mli
@@ -35,7 +35,7 @@ val dty_to_ty : ?update:bool -> ?is_var:bool -> D_loop.DStd.Expr.ty -> Ty.t
 val make_form :
   string ->
   D_loop.DStd.Expr.term ->
-  Dolmen.Std.Loc.loc ->
+  Loc.t ->
   decl_kind:Expr.decl_kind ->
   Expr.t
 

--- a/src/lib/reasoners/fun_sat.mli
+++ b/src/lib/reasoners/fun_sat.mli
@@ -51,7 +51,7 @@ module Make (_ : Theory.S) : sig
   val assume_th_elt : t -> Expr.th_elt -> Explanation.t -> t
 
   val pred_def :
-    t -> Expr.t -> string -> Explanation.t -> Dolmen.Std.Loc.loc -> t
+    t -> Expr.t -> string -> Explanation.t -> Loc.t -> t
 
   val unsat : t -> Expr.gformula -> Explanation.t
 

--- a/src/lib/reasoners/sat_solver_sig.ml
+++ b/src/lib/reasoners/sat_solver_sig.ml
@@ -114,7 +114,7 @@ module type S = sig
     Expr.t ->
     string ->
     Explanation.t ->
-    Dolmen.Std.Loc.loc ->
+    Loc.t ->
     unit
   (** [pred_def env f] assumes a new predicate definition [f] in [env]. *)
 

--- a/src/lib/reasoners/sat_solver_sig.mli
+++ b/src/lib/reasoners/sat_solver_sig.mli
@@ -94,7 +94,7 @@ module type S = sig
     Expr.t ->
     string ->
     Explanation.t ->
-    Dolmen.Std.Loc.loc ->
+    Loc.t ->
     unit
   (** [pred_def env f] assumes a new predicate definition [f] in [env]. *)
 

--- a/src/lib/structures/commands.ml
+++ b/src/lib/structures/commands.ml
@@ -41,7 +41,7 @@ type sat_decl_aux =
   | Pop of int
 
 type sat_tdecl = {
-  st_loc : Dolmen.Std.Loc.loc;
+  st_loc : Loc.t;
   st_decl : sat_decl_aux
 }
 
@@ -68,4 +68,3 @@ let print_aux fmt = function
     Format.fprintf fmt "%s %a" s Expr.print e
 
 let print fmt decl = print_aux fmt decl.st_decl
-

--- a/src/lib/structures/errors.ml
+++ b/src/lib/structures/errors.ml
@@ -50,7 +50,7 @@ type model_error =
   | Subst_not_model_term of Expr.t
 
 type error =
-  | Typing_error of Dolmen.Std.Loc.loc * typing_error
+  | Typing_error of Loc.t * typing_error
   | Run_error of run_error
   | Warning_as_error
   | Dolmen_error of (int * string)
@@ -117,7 +117,7 @@ let report_model_error ppf = function
 
 let report fmt = function
   | Typing_error (l,e) ->
-    DStd.Loc.fmt fmt l;
+    Loc.report fmt l;
     Format.fprintf fmt "Typing Error: ";
     report_typing_error fmt e
   | Run_error e ->

--- a/src/lib/structures/errors.mli
+++ b/src/lib/structures/errors.mli
@@ -58,7 +58,7 @@ type model_error =
 
 (** All types of error that can be raised *)
 type error =
-  | Typing_error of Dolmen.Std.Loc.loc * typing_error
+  | Typing_error of Loc.t * typing_error
   (** Error used at typing *)
   | Run_error of run_error (** Error used during solving *)
   | Warning_as_error
@@ -81,7 +81,7 @@ exception Error of error
 val error : error -> 'a
 
 (** Raise the input {!typing_error} as {!Typing_error} *)
-val typing_error : typing_error -> Dolmen.Std.Loc.loc -> 'a
+val typing_error : typing_error -> Loc.t -> 'a
 
 (** Raise the input {!run_error} as {!Run_error} *)
 val run_error : run_error -> 'a

--- a/src/lib/structures/explanation.ml
+++ b/src/lib/structures/explanation.ml
@@ -27,7 +27,7 @@
 
 module E = Expr
 
-type rootdep = { name : string; f : Expr.t; loc : Dolmen.Std.Loc.loc}
+type rootdep = { name : string; f : Expr.t; loc : Loc.t}
 
 type exp =
   | Literal of Satml_types.Atom.atom

--- a/src/lib/structures/explanation.mli
+++ b/src/lib/structures/explanation.mli
@@ -27,7 +27,7 @@
 
 type t
 
-type rootdep = { name : string; f : Expr.t; loc : Dolmen.Std.Loc.loc}
+type rootdep = { name : string; f : Expr.t; loc : Loc.t }
 
 type exp =
   | Literal of Satml_types.Atom.atom

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -71,7 +71,7 @@ and quantified = {
   binders : binders;
   sko_v : t list; (* This list has to be ordered for the skolemization. *)
   sko_vty : Ty.t list; (* This list has to be ordered for the skolemization. *)
-  loc : DStd.Loc.loc;
+  loc : Loc.t;
   kind : decl_kind;
 }
 

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -120,7 +120,7 @@ and quantified = private {
   (** The set of free type variables. In particular this set is always
       empty if we are the top level. *)
 
-  loc : Dolmen.Std.Loc.loc;
+  loc : Loc.t;
   (** Location of the "GLOBAL" axiom containing this quantified formula. It
       forms with name a unique identifier. *)
 
@@ -373,7 +373,7 @@ val resolution_triggers: is_back:bool -> quantified -> trigger list
 
 val mk_forall :
   string -> (* name *)
-  Dolmen.Std.Loc.loc -> (* location in the original file *)
+  Loc.t -> (* location in the original file *)
   binders -> (* quantified variables *)
   trigger list -> (* triggers *)
   t -> (* quantified formula *)
@@ -383,7 +383,7 @@ val mk_forall :
 
 val mk_exists :
   string -> (* name *)
-  Dolmen.Std.Loc.loc -> (* location in the original file *)
+  Loc.t -> (* location in the original file *)
   binders -> (* quantified variables *)
   trigger list -> (* triggers *)
   t -> (* quantified formula *)

--- a/src/lib/structures/profiling.ml
+++ b/src/lib/structures/profiling.ml
@@ -30,7 +30,7 @@ module MS = Map.Make(String)
 module DStd = Dolmen.Std
 
 type inst_info = {
-  loc : DStd.Loc.loc;
+  loc : Loc.t;
   kept : int;
   ignored : int;
   all_insts : SE.t;

--- a/src/lib/structures/profiling.mli
+++ b/src/lib/structures/profiling.mli
@@ -47,11 +47,11 @@ val reset_ilevel : int -> unit
 (* record when the axioms are instantiated. Bool tells whether the
    instance is kept or removed by the selector function. The formula
    is the instance that has been generated *)
-val new_instance_of : string -> Expr.t -> Dolmen.Std.Loc.loc -> bool -> unit
-val conflicting_instance : string -> Dolmen.Std.Loc.loc -> unit
+val new_instance_of : string -> Expr.t -> Loc.t -> bool -> unit
+val conflicting_instance : string -> Loc.t -> unit
 val register_produced_terms :
   string ->
-  Dolmen.Std.Loc.loc ->
+  Loc.t ->
   Expr.Set.t -> (* consumed *)
   Expr.Set.t -> (* all terms of the instance *)
   Expr.Set.t -> (* produced *)

--- a/src/lib/util/loc.ml
+++ b/src/lib/util/loc.ml
@@ -25,23 +25,12 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Sat entry *)
+type t = Dolmen.Std.Loc.loc
 
-type sat_decl_aux =
-  | Decl of Id.typed
-  | Assume of string * Expr.t * bool
-  | PredDef of Expr.t * string (*name of the predicate*)
-  | Optimize of Objective.Function.t
-  | Query of string *  Expr.t * Ty.goal_sort
-  | ThAssume of Expr.th_elt
-  | Push of int
-  | Pop of int
+let from_dolmen_loc l = l
 
-type sat_tdecl = {
-  st_loc : Loc.t;
-  st_decl : sat_decl_aux
-}
+let lexing_positions = Dolmen.Std.Loc.lexing_positions
 
-val src : Logs.src
+let dummy = Dolmen.Std.Loc.dummy
 
-val print : Format.formatter -> sat_tdecl -> unit
+let report = Dolmen.Std.Loc.fmt

--- a/src/lib/util/loc.mli
+++ b/src/lib/util/loc.mli
@@ -25,23 +25,24 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(* Sat entry *)
+(** Position in input files
 
-type sat_decl_aux =
-  | Decl of Id.typed
-  | Assume of string * Expr.t * bool
-  | PredDef of Expr.t * string (*name of the predicate*)
-  | Optimize of Objective.Function.t
-  | Query of string *  Expr.t * Ty.goal_sort
-  | ThAssume of Expr.th_elt
-  | Push of int
-  | Pop of int
+    This module defines a notion of location in files.
+    Note: this only specifies a position in an arbitrary file,
+          it does not contain information about the file itself.
+*)
 
-type sat_tdecl = {
-  st_loc : Loc.t;
-  st_decl : sat_decl_aux
-}
+type t
+(** The type of locations, a location is made up of two position in the file,
+    respectively corresponding to the beginning and end of the location. *)
 
-val src : Logs.src
+val from_dolmen_loc : Dolmen.Std.Loc.loc -> t
 
-val print : Format.formatter -> sat_tdecl -> unit
+val lexing_positions : t -> Lexing.position * Lexing.position
+
+val dummy : t
+(** A dummy location. *)
+
+val report : Format.formatter -> t -> unit
+(** Report a location on the given formatter, using standard
+    human-redable location reporting. *)

--- a/src/lib/util/printer.ml
+++ b/src/lib/util/printer.ml
@@ -313,7 +313,7 @@ let print_status_loc fmt loc =
   | None -> ()
   | Some loc ->
     if Options.get_answers_with_locs () then
-      Format.fprintf fmt "%a " DStd.Loc.fmt loc
+      Format.fprintf fmt "%a " Loc.report loc
 
 let print_status_value fmt (v,color) =
   if Options.get_output_with_colors () then

--- a/src/lib/util/printer.mli
+++ b/src/lib/util/printer.mli
@@ -104,7 +104,7 @@ val pp_list_space :
     the status. *)
 val print_status_unsat :
   ?validity_mode:bool ->
-  Dolmen.Std.Loc.loc option ->
+  Loc.t option ->
   float option ->
   int option ->
   string option -> unit
@@ -117,7 +117,7 @@ val print_status_unsat :
     the status. *)
 val print_status_sat :
   ?validity_mode:bool ->
-  Dolmen.Std.Loc.loc option ->
+  Loc.t option ->
   float option ->
   int option ->
   string option -> unit
@@ -130,7 +130,7 @@ val print_status_sat :
     the status. *)
 val print_status_unknown :
   ?validity_mode:bool ->
-  Dolmen.Std.Loc.loc option ->
+  Loc.t option ->
   float option ->
   int option ->
   string option -> unit
@@ -143,7 +143,7 @@ val print_status_unknown :
     the status. *)
 val print_status_timeout :
   ?validity_mode:bool ->
-  Dolmen.Std.Loc.loc option ->
+  Loc.t option ->
   float option ->
   int option ->
   string option -> unit
@@ -156,7 +156,7 @@ val print_status_timeout :
     the status. *)
 val print_status_inconsistent :
   ?validity_mode:bool ->
-  Dolmen.Std.Loc.loc option ->
+  Loc.t option ->
   float option ->
   int option ->
   string option -> unit


### PR DESCRIPTION
In #1284 we replaced custom locations with Dolmen locations explicitly, which breaks API users such as Owi. This patch makes the `Loc.t` type abstract and provides a conversion function from Dolmen locations instead.