### PR TITLE
The `Firebug` module of `js_of_ocaml` is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           dune-cache: true
 
       - name: Install dependencies
-        run: opam exec -- make deps js-deps
+        run: opam exec -- make test-deps js-deps
 
       - name: Build the project
         run: opam exec -- dune build --profile ci @check

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -98,7 +98,7 @@ jobs:
         run: git fetch --tags --force
 
       - name: Install static dependencies
-        run: sudo apk add zlib-static
+        run: sudo apk add zlib-static gmp-static
 
       - run: opam switch create . ocaml-system --locked --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -98,7 +98,10 @@ jobs:
         run: git fetch --tags --force
 
       - name: Install static dependencies
-        run: sudo apk add zlib-static gmp-static
+        run: sudo apk add zlib-static
+
+      - name: Update opam repository
+        run: opam update
 
       - run: opam switch create . ocaml-system --locked --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 

--- a/Makefile
+++ b/Makefile
@@ -228,11 +228,12 @@ dev-switch:
 js-deps:
 	opam install \
 		'js_of_ocaml>=6.0.0' \
+		'js_of_ocaml<6.1.0' \
 		js_of_ocaml-lwt \
 		js_of_ocaml-ppx \
 		data-encoding \
 		'zarith_stubs_js>=v0.16.1' \
-		lwt_ppx -y
+		lwt_ppx
 
 deps:
 	opam install . --deps-only

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ dev-switch:
 
 js-deps:
 	opam install \
-		'js_of_ocaml>=5.4.0' \
+		'js_of_ocaml>=6.0.0' \
 		js_of_ocaml-lwt \
 		js_of_ocaml-ppx \
 		data-encoding \

--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -29,7 +29,7 @@ depends: [
   "ppx_deriving"
   "odoc" {with-doc}
   "ppx_deriving"
-  "qcheck" {with-test & = "0.22"}
+  "qcheck" {with-test & = "0.25"}
 ]
 conflicts: [
   "ppxlib" {< "0.30.0"}

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -17,27 +17,21 @@ doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
   "base-bigarray" {= "base"}
-  "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "cmdliner" {= "1.3.0"}
   "conf-gmp" {= "5"}
   "conf-pkg-config" {= "4"}
   "cppo" {= "1.8.0"}
-  "csexp" {= "1.5.2"}
   "dolmen" {= "0.10"}
   "dolmen_loop" {= "0.10"}
   "dolmen_type" {= "0.10"}
-  "dune" {= "3.19.0"}
-  "dune-build-info" {= "3.19.0"}
-  "dune-configurator" {= "3.19.0"}
+  "dune" {= "3.19.1"}
+  "dune-build-info" {= "3.19.1"}
   "fmt" {= "0.10.0"}
   "gen" {= "1.1"}
   "hmap" {= "0.8.1"}
-  "js_of_ocaml" {= "6.0.1"}
-  "js_of_ocaml-compiler" {= "6.0.1"}
-  "logs" {= "0.6.3"}
-  "lwt" {= "5.9.1"}
+  "logs" {= "0.8.0"}
   "menhir" {= "20240715"}
   "menhirCST" {= "20240715"}
   "menhirLib" {= "20240715"}
@@ -45,21 +39,22 @@ depends: [
   "ocaml-options-vanilla" {= "1"}
   "ocamlbuild" {= "0.16.1"}
   "ocamlfind" {= "1.9.8"}
-  "ocplib-endian" {= "1.2"}
   "ocplib-simplex" {= "0.5.1"}
+  "ounit2" {= "2.2.7" & with-test}
   "pp_loc" {= "2.1.0"}
   "ppx_blob" {= "0.9.0"}
   "ppx_derivers" {= "1.2.1"}
-  "ppx_deriving" {= "6.0.3"}
-  "ppxlib" {= "0.35.0"}
-  "sedlex" {= "3.4"}
+  "ppx_deriving" {= "6.1.0"}
+  "ppxlib" {= "0.36.0"}
+  "qcheck" {= "0.25" & with-test}
+  "qcheck-core" {= "0.25" & with-test}
+  "qcheck-ounit" {= "0.25" & with-test}
   "seq" {= "base"}
   "sexplib0" {= "v0.17.0"}
   "spelll" {= "0.4"}
   "stdlib-shims" {= "0.3.0"}
   "topkg" {= "1.0.8"}
   "uutf" {= "1.0.4"}
-  "yojson" {= "2.2.2"}
   "zarith" {= "1.14"}
 ]
 build: [

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -36,6 +36,7 @@ depends: [
   "menhirCST" {= "20240715"}
   "menhirLib" {= "20240715"}
   "menhirSdk" {= "20240715"}
+  "ocaml-compiler-libs" {= "v0.12.4"}
   "ocaml-options-vanilla" {= "1"}
   "ocamlbuild" {= "0.16.1"}
   "ocamlfind" {= "1.9.8"}

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -20,47 +20,47 @@ depends: [
   "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "camlzip" {= "1.11"}
-  "cmdliner" {= "1.2.0"}
-  "conf-gmp" {= "4"}
-  "conf-pkg-config" {= "3"}
-  "conf-zlib" {= "1"}
-  "cppo" {= "1.6.9"}
+  "cmdliner" {= "1.3.0"}
+  "conf-gmp" {= "5"}
+  "conf-pkg-config" {= "4"}
+  "cppo" {= "1.8.0"}
   "csexp" {= "1.5.2"}
   "dolmen" {= "0.10"}
   "dolmen_loop" {= "0.10"}
   "dolmen_type" {= "0.10"}
-  "dune" {= "3.16.0"}
-  "dune-build-info" {= "3.16.0"}
-  "dune-configurator" {= "3.16.0"}
-  "fmt" {= "0.9.0"}
+  "dune" {= "3.19.0"}
+  "dune-build-info" {= "3.19.0"}
+  "dune-configurator" {= "3.19.0"}
+  "fmt" {= "0.10.0"}
   "gen" {= "1.1"}
-  "js_of_ocaml" {= "5.4.0"}
-  "js_of_ocaml-compiler" {= "5.4.0"}
-  "logs" {= "0.7.0"}
-  "lwt" {= "5.7.0"}
-  "menhir" {= "20230608"}
-  "menhirLib" {= "20230608"}
-  "menhirSdk" {= "20230608"}
-  "ocaml-compiler-libs" {= "v0.12.4"}
-  "ocamlbuild" {= "0.14.2"}
-  "ocamlfind" {= "1.9.6"}
+  "hmap" {= "0.8.1"}
+  "js_of_ocaml" {= "6.0.1"}
+  "js_of_ocaml-compiler" {= "6.0.1"}
+  "logs" {= "0.6.3"}
+  "lwt" {= "5.9.1"}
+  "menhir" {= "20240715"}
+  "menhirCST" {= "20240715"}
+  "menhirLib" {= "20240715"}
+  "menhirSdk" {= "20240715"}
+  "ocaml-options-vanilla" {= "1"}
+  "ocamlbuild" {= "0.16.1"}
+  "ocamlfind" {= "1.9.8"}
   "ocplib-endian" {= "1.2"}
   "ocplib-simplex" {= "0.5.1"}
   "pp_loc" {= "2.1.0"}
-  "ppx_blob" {= "0.7.2"}
+  "ppx_blob" {= "0.9.0"}
   "ppx_derivers" {= "1.2.1"}
-  "ppx_deriving" {= "5.2.1"}
-  "ppxlib" {= "0.31.0"}
-  "qcheck" {= "0.21.3"}
-  "result" {= "1.5"}
+  "ppx_deriving" {= "6.0.3"}
+  "ppxlib" {= "0.35.0"}
+  "sedlex" {= "3.4"}
   "seq" {= "base"}
-  "sexplib0" {= "v0.16.0"}
+  "sexplib0" {= "v0.17.0"}
   "spelll" {= "0.4"}
-  "topkg" {= "1.0.7"}
-  "uutf" {= "1.0.3"}
-  "yojson" {= "2.1.1"}
-  "zarith" {= "1.13"}
+  "stdlib-shims" {= "0.3.0"}
+  "topkg" {= "1.0.8"}
+  "uutf" {= "1.0.4"}
+  "yojson" {= "2.2.2"}
+  "zarith" {= "1.14"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -82,10 +82,4 @@ dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"
 conflicts: [
   "ppxlib" {< "0.30.0"}
   "result" {< "1.5"}
-]
-pin-depends: [
-  [
-    "js_of_ocaml.5.4.0"
-    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.4.0/js_of_ocaml-5.4.0.tbz"
-  ]
 ]

--- a/dune-project
+++ b/dune-project
@@ -65,7 +65,7 @@ See more details on http://alt-ergo.ocamlpro.com/"
   ppx_deriving
   (odoc :with-doc)
   ppx_deriving
-  (qcheck (and :with-test (= 0.22)))
+  (qcheck (and :with-test (= 0.25)))
  )
  (conflicts
   (ppxlib (< 0.30.0))

--- a/src/bin/js/dune
+++ b/src/bin/js/dune
@@ -7,7 +7,7 @@
  )
  (modules main_text_js)
  (modes byte js)
- (js_of_ocaml (flags --no-source-map +toplevel.js +dynlink.js))
+ (js_of_ocaml (flags +toplevel.js +dynlink.js))
 )
 
 (library
@@ -31,7 +31,7 @@
  )
  (modules worker_js options_interface)
  (modes byte js)
- (js_of_ocaml (flags --no-source-map +toplevel.js +dynlink.js))
+ (js_of_ocaml (flags +toplevel.js +dynlink.js))
 )
 
 ; Rule to build a small js example running the Alt-Ergo web worker

--- a/src/bin/js/worker_example.ml
+++ b/src/bin/js/worker_example.ml
@@ -84,11 +84,11 @@ let solve () =
           Worker_interface.file_to_json
             (Some ("dummy" ^ !extension)) (Some 42) file
         in
-        Firebug.console##log json_file;
+        Console.console##log json_file;
         let json_options = Worker_interface.options_to_json options in
-        Firebug.console##log json_options;
+        Console.console##log json_options;
         let%lwt results = exec worker json_file json_options in
-        Firebug.console##log results;
+        Console.console##log results;
         let res = Worker_interface.results_from_json results in
         Lwt.return res
       )


### PR DESCRIPTION
After bumping the version of nixpkgs, I got warnings about `Firebug`. This PR fixes them. 