### PR TITLE
Upgrade dolmen version

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -60,3 +60,18 @@ license: [
   "LicenseRef-OCamlpro-Non-Commercial"
   "Apache-2.0"
 ]
+
+pin-depends: [
+  [
+    "dolmen.0.11"
+    "git+https://github.com/Gbury/dolmen.git#a0f1bc66e7256fff1068ac0df525a2d23c1f3ea7"
+  ]
+  [
+    "dolmen_loop.0.11"
+    "git+https://github.com/Gbury/dolmen.git#a0f1bc66e7256fff1068ac0df525a2d23c1f3ea7"
+  ]
+  [
+    "dolmen_type.0.11"
+    "git+https://github.com/Gbury/dolmen.git#a0f1bc66e7256fff1068ac0df525a2d23c1f3ea7"
+  ]
+]

--- a/alt-ergo-lib.opam.template
+++ b/alt-ergo-lib.opam.template
@@ -6,3 +6,18 @@ license: [
   "LicenseRef-OCamlpro-Non-Commercial"
   "Apache-2.0"
 ]
+
+pin-depends: [
+  [
+    "dolmen.0.11"
+    "git+https://github.com/Gbury/dolmen.git#a0f1bc66e7256fff1068ac0df525a2d23c1f3ea7"
+  ]
+  [
+    "dolmen_loop.0.11"
+    "git+https://github.com/Gbury/dolmen.git#a0f1bc66e7256fff1068ac0df525a2d23c1f3ea7"
+  ]
+  [
+    "dolmen_type.0.11"
+    "git+https://github.com/Gbury/dolmen.git#a0f1bc66e7256fff1068ac0df525a2d23c1f3ea7"
+  ]
+]

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,14 +5,14 @@ import sources.nixpkgs {
     (_: pkgs: { inherit sources; })
     (_: pkgs: {
       ocamlPackages = pkgs.ocaml-ng.ocamlPackages_4_14.overrideScope (self: super: {
-        pp_loc = pkgs.callPackage ./pp_loc.nix { };
-        ocplib-simplex = pkgs.callPackage ./ocplib-simplex.nix { };
-        dolmen = pkgs.callPackage ./dolmen.nix { };
-        dolmen_type = pkgs.callPackage ./dolmen_type.nix { };
-        dolmen_loop = pkgs.callPackage ./dolmen_loop.nix { };
-        landmarks = pkgs.callPackage ./landmarks.nix { };
-        landmarks-ppx = pkgs.callPackage ./landmarks-ppx.nix { };
-        zarith_stubs_js = pkgs.callPackage ./zarith_stubs_js.nix { };
+        pp_loc = self.callPackage ./pp_loc.nix { };
+        ocplib-simplex = self.callPackage ./ocplib-simplex.nix { };
+        dolmen = self.callPackage ./dolmen.nix { };
+        dolmen_type = self.callPackage ./dolmen_type.nix { };
+        dolmen_loop = self.callPackage ./dolmen_loop.nix { };
+        landmarks = self.callPackage ./landmarks.nix { };
+        landmarks-ppx = self.callPackage ./landmarks-ppx.nix { };
+        zarith_stubs_js = self.callPackage ./zarith_stubs_js.nix { };
       });
     })
   ];

--- a/nix/dolmen.nix
+++ b/nix/dolmen.nix
@@ -1,23 +1,20 @@
-{ sources, lib, ocamlPackages }:
+{ sources, lib, buildDunePackage
+, menhir, hmap, menhirLib, fmt, uutf, dune-site }:
 
-let
-  dolmen = sources.dolmen;
-in
-
-ocamlPackages.buildDunePackage {
+buildDunePackage {
   strictDeps = true;
   pname = "dolmen";
-  inherit (dolmen) version;
+  inherit (sources.dolmen) version;
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
-  src = dolmen;
+  src = sources.dolmen;
 
-  nativeBuildInputs = [ ocamlPackages.menhir ];
-  propagatedBuildInputs = with ocamlPackages; [ hmap menhirLib fmt ];
+  nativeBuildInputs = [ menhir ];
+  propagatedBuildInputs = [ hmap menhirLib fmt uutf dune-site ];
 
   meta = with lib; {
-    inherit (dolmen) homepage description;
+    inherit (sources.dolmen) homepage description;
   };
 }

--- a/nix/dolmen_loop.nix
+++ b/nix/dolmen_loop.nix
@@ -1,13 +1,14 @@
-{ sources, lib, ocamlPackages }:
+{ sources, lib, buildDunePackage
+, gen, zarith, dolmen, dolmen_type }:
 
-ocamlPackages.buildDunePackage {
+buildDunePackage {
   pname = "dolmen_loop";
-  inherit (ocamlPackages.dolmen) version src strictDeps;
+  inherit (dolmen) version src strictDeps;
 
   minimalOCamlVersion = "4.08";
   duneVersion = "3";
 
-  propagatedBuildInputs = [ ocamlPackages.gen ocamlPackages.dolmen_type ];
+  propagatedBuildInputs = [ gen dolmen_type zarith ];
 
-  meta = ocamlPackages.dolmen.meta;
+  meta = dolmen.meta;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "dolmen": {
-        "branch": "v0.10",
+        "branch": "master",
         "description": "Dolmen provides a library and a binary to parse, typecheck, and evaluate languages used in automated deduction",
         "homepage": "",
         "owner": "Gbury",
         "repo": "dolmen",
-        "rev": "c33632daab31fb3bb719031169baa6c984bb860f",
-        "sha256": "1vvlg72sbwmpnh0kvwkbvnxxgwrdqcy5adqp26n3hpq3mix4sp7d",
+        "rev": "3c77a22b2aac2eb85aca76f198797d40ca3ec4a3",
+        "sha256": "0qsl5f0mh4azmqvq99l24cna8brvw00x9703wyd98gm0pbmsc3pm",
         "type": "tarball",
-        "url": "https://github.com/Gbury/dolmen/archive/c33632daab31fb3bb719031169baa6c984bb860f.tar.gz",
+        "url": "https://github.com/Gbury/dolmen/archive/3c77a22b2aac2eb85aca76f198797d40ca3ec4a3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "0.10"
     },

--- a/src/bin/common/parse_command.ml
+++ b/src/bin/common/parse_command.ml
@@ -78,6 +78,7 @@ let format_parser s =
 let format_to_string = function
   | Native -> "native"
   | Smtlib2 `V2_6 -> "smtlib2-v2.6"
+  | Smtlib2 `V2_7 -> "smtlib2-v2.7"
   | Smtlib2 `Poly -> "psmt2"
   | Smtlib2 `Latest -> "smtlib2"
   | Why3 -> "why3"

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -138,7 +138,7 @@ let add_if_named
     ~(acc : DStd.Expr.term Util.MS.t)
     (stmt : Typer_Pipe.typechecked D_loop.Typer_Pipe.stmt) =
   match stmt.contents with
-  | `Defs [`Term_def ({name = Simple n; _}, id, _, _, t)] ->
+  | `Defs (_recursive, [`Term_def ({name = Simple n; _}, id, _, _, t)]) ->
     begin
       match DStd.Expr.Id.get_tag id DStd.Expr.Tags.named with
       | None -> acc
@@ -404,7 +404,7 @@ let process_source ?selector_inst ~print_status src =
       ~interactive_prompt
     |> Typer.init
       ~additional_builtins:Translate.builtins
-      ~extension_builtins:[Typer.Ext.bv2nat]
+      ~extension_builtins:[Dolmen_loop.Typer.Ext.bvconv]
     |> Typer_Pipe.init ~type_check
   in
 
@@ -608,7 +608,9 @@ let process_source ?selector_inst ~print_status src =
      issue in Dolmen, we can replace the [loc] argument by the [st_loc]
      value built in [handle_stmt]. *)
   let handle_custom_statement ~loc id args st =
-    let args = List.map Dolmen_type.Core.Smtlib2.sexpr_as_term args in
+    let args =
+      List.map (Dolmen_type.Core.Smtlib2.sexpr_as_term (`Script `Poly)) args
+    in
     let logic_file = State.get State.logic_file st in
     let st, terms = Typer.terms st ~input:(`Logic logic_file) ~loc args in
     match id, terms.ret with
@@ -638,46 +640,53 @@ let process_source ?selector_inst ~print_status src =
       st
   in
 
-  let handle_get_info ~loc (st : State.t) (name: string) =
-    let print_std =
-      fun (type a) (pp :a Fmt.t) (a : a) ->
-        Printer.print_std "(%s %a)" name pp a
-    in
-    let pp_reason_unknown st =
-      let err () =
-        recoverable_error ~loc "Invalid (get-info :reason-unknown)"
+  let handle_get_info ~loc (st : State.t) (info : DStd.Term.t) =
+    match info with
+    | { term = Builtin _ | App _ | Binder _ | Match _ | Colon _; _ }
+    | { term = Symbol { ns = (Var | Sort | Term | Decl | Track | Value _); _ }
+      ; _ }
+    | { term = Symbol { name = Indexed _ | Qualified _; ns = Attr }; _ } ->
+      unsupported_opt "get-info"
+    | { term = Symbol { name = Simple name; ns = Attr }; _ } ->
+      let print_std =
+        fun (type a) (pp :a Fmt.t) (a : a) ->
+          Printer.print_std "(%s %a)" name pp a
       in
-      match State.get partial_model_key st with
-      | None -> err ()
-      | Some Model ((module SAT), sat) ->
-        match SAT.get_unknown_reason sat with
+      let pp_reason_unknown st =
+        let err () =
+          recoverable_error ~loc "Invalid (get-info :reason-unknown)"
+        in
+        match State.get partial_model_key st with
         | None -> err ()
-        | Some ur ->
-          print_std Sat_solver_sig.pp_smt_unknown_reason ur
-    in
-    match name with
-    | ":authors" ->
-      print_std (fun fmt -> Fmt.pf fmt "%S") "Alt-Ergo developers"
-    | ":error-behavior" ->
-      let behavior =
-        if Options.get_exit_on_error () then
-          "immediate-exit"
-        else
-          "continued-execution"
+        | Some Model ((module SAT), sat) ->
+          match SAT.get_unknown_reason sat with
+          | None -> err ()
+          | Some ur ->
+            print_std Sat_solver_sig.pp_smt_unknown_reason ur
       in
-      print_std Fmt.string behavior
-    | ":name" ->
-      print_std (fun fmt -> Fmt.pf fmt "%S") "Alt-Ergo"
-    | ":reason-unknown" ->
-      pp_reason_unknown st
-    | ":version" ->
-      print_std Fmt.string Version._version
-    | ":all-statistics" ->
-      Printer.print_std "%t" Profiling.print_statistics
-    | ":assertion-stack-levels" ->
-      unsupported_opt name
-    | _ ->
-      unsupported_opt name
+      match name with
+      | ":authors" ->
+        print_std (fun fmt -> Fmt.pf fmt "%S") "Alt-Ergo developers"
+      | ":error-behavior" ->
+        let behavior =
+          if Options.get_exit_on_error () then
+            "immediate-exit"
+          else
+            "continued-execution"
+        in
+        print_std Fmt.string behavior
+      | ":name" ->
+        print_std (fun fmt -> Fmt.pf fmt "%S") "Alt-Ergo"
+      | ":reason-unknown" ->
+        pp_reason_unknown st
+      | ":version" ->
+        print_std Fmt.string Version._version
+      | ":all-statistics" ->
+        Printer.print_std "%t" Profiling.print_statistics
+      | ":assertion-stack-levels" ->
+        unsupported_opt name
+      | _ ->
+        unsupported_opt name
   in
 
   (* Fetches the term value in the current model. *)
@@ -921,7 +930,18 @@ let process_source ?selector_inst ~print_status src =
       let preludes =
         theory_preludes @
         List.map (fun path ->
-            let dir, source = State.split_input (`File path) in
+            (* Using [`File] sources with preludes is currently broken,
+               see https://github.com/Gbury/dolmen/issues/248
+               and https://github.com/OCamlPro/alt-ergo/issues/1330 *)
+            let dir, source =
+              let content =
+                let ch = open_in_bin path in
+                let s = really_input_string ch (in_channel_length ch) in
+                close_in ch;
+                s
+              in
+              Filename.dirname path, (`Raw (Filename.basename path, content))
+            in
             State.mk_file dir source) (Options.get_preludes ())
       in
       let g =

--- a/src/lib/frontend/translate.ml
+++ b/src/lib/frontend/translate.ml
@@ -460,7 +460,7 @@ let smt_tag_builtins =
     | _ -> `Not_found
 
 let builtins =
-  fun _st (lang : Typer.lang) ->
+  fun _st (lang : Dolmen_loop.Typer_intf.lang) ->
   match lang with
   | `Logic Alt_ergo -> ae_fpa_builtins
   | `Logic (Smtlib2 _) ->
@@ -487,9 +487,9 @@ let clear_cache () = Cache.clear ()
 let rec dty_to_ty ?(update = false) ?(is_var = false) dty =
   let aux = dty_to_ty ~update ~is_var in
   match DT.view dty with
-  | `Prop | `App (`Builtin B.Prop, []) -> Ty.Tbool
-  | `Int  | `App (`Builtin B.Int, []) -> Ty.Tint
-  | `Real | `App (`Builtin B.Real, []) -> Ty.Treal
+  | `Prop | `App (`Builtin (B.Prop T), []) -> Ty.Tbool
+  | `Int  | `App (`Builtin (B.Arith Int), []) -> Ty.Tint
+  | `Real | `App (`Builtin (B.Arith Real), []) -> Ty.Treal
   | `Array (ity, vty) ->
     let ity = aux ity in
     let vty = aux vty in
@@ -665,7 +665,7 @@ end = struct
     match term_descr with
     | App (
         { term_descr =
-            Cst ({ builtin = B.Constructor { adt; case; }; _ } as cst); _
+            Cst ({ builtin = B.Adt Constructor { adt; case; }; _ } as cst); _
         }, _, pargs
       ) ->
       let vnames =
@@ -694,7 +694,7 @@ end = struct
       in
       Constr (cst, List.rev rev_args)
 
-    | Cst ({ builtin = B.Constructor _; _ } as cst) ->
+    | Cst ({ builtin = B.Adt Constructor _; _ } as cst) ->
       Constr (cst, [])
 
     | Var ({ builtin = B.Base; path; _ } as t_v) ->
@@ -772,10 +772,10 @@ let parse_semantic_bound ?(loc = Loc.dummy) ~var b x y =
   assert (is_main_var x || is_main_var y);
   let op, t =
     match b with
-    | B.Lt t -> `Lt, t
-    | B.Leq t -> `Le, t
-    | B.Gt t -> `Gt, t
-    | B.Geq t -> `Ge, t
+    | B.Arith Lt t -> `Lt, t
+    | B.Arith Leq t -> `Le, t
+    | B.Arith Gt t -> `Gt, t
+    | B.Arith Geq t -> `Ge, t
     | _ ->
       Fmt.failwith
         "%aInternal error: invalid semantic bound"
@@ -784,7 +784,7 @@ let parse_semantic_bound ?(loc = Loc.dummy) ~var b x y =
   let sort = arith_ty t in
   let parse_bound_kind { DE.term_descr; _ } =
     match term_descr with
-    | Cst { builtin = (B.Integer s | B.Rational s | B.Decimal s); _ } ->
+    | Cst { builtin = B.Arith (Integer s | Rational s | Decimal s); _ } ->
       Sy.ValBnd (Numbers.Q.from_string s)
     | Var v -> Sy.VarBnd (Cache.find_var v)
     | _ ->
@@ -879,11 +879,11 @@ let rec mk_expr
       match term_descr with
       | Cst ({ builtin; _ } as tcst) ->
         begin match builtin with
-          | B.True -> E.vrai
-          | B.False -> E.faux
-          | B.Integer s -> E.int s
-          | B.Decimal s -> E.real s
-          | B.Bitvec s ->
+          | B.Prop True -> E.vrai
+          | B.Prop False -> E.faux
+          | B.Arith Integer s -> E.int s
+          | B.Arith Decimal s -> E.real s
+          | B.Bitv Binary_lit s ->
             let ty = dty_to_ty term_ty in
             E.bitv s ty
 
@@ -892,7 +892,7 @@ let rec mk_expr
             let ty = dty_to_ty term_ty in
             E.mk_term sy [] ty
 
-          | B.Constructor _ ->
+          | B.Adt Constructor _ ->
             let ty = dty_to_ty term_ty in
             E.mk_constr tcst [] ty
 
@@ -917,16 +917,16 @@ let rec mk_expr
         begin match builtin, args with
           (* Unary applications *)
 
-          | B.Neg, [x] ->
+          | B.Prop Neg, [x] ->
             E.neg (aux_mk_expr x)
 
-          | B.Minus mty, [x] ->
+          | B.Arith Minus mty, [x] ->
             let e1, ty =
               if mty == `Int then E.int "0", Ty.Tint else E.real "0",Ty.Treal
             in
             E.mk_term (Sy.Op Sy.Minus) [e1; aux_mk_expr x] ty
 
-          | B.Destructor { case; field; adt; _ }, [x] ->
+          | B.Adt Destructor { case; field; adt; _ }, [x] ->
             begin match DT.definition adt with
               | Some (Adt { cases;  _ }) ->
                 begin match cases.(case).dstrs.(field) with
@@ -951,8 +951,8 @@ let rec mk_expr
                   DE.Ty.Const.print adt DE.Term.print app_term
             end
 
-          | B.Tester {
-              cstr = { builtin = B.Constructor { adt; _ }; _ } as cstr; _
+          | B.Adt Tester {
+              cstr = { builtin = B.Adt Constructor { adt; _ }; _ } as cstr; _
             }, [x] ->
             begin
               let ty_c =
@@ -989,64 +989,64 @@ let rec mk_expr
             semantic_trigger ~loc ?var trigger
 
           (* Unary functions from FixedSizeBitVectors theory *)
-          | B.Bitv_extract { i; j; _ }, [ x ] -> E.BV.extract i j (mk x)
-          | B.Bitv_not _, [ x ] -> E.BV.bvnot (mk x)
-          | B.Bitv_neg _, [ x ] -> E.BV.bvneg (mk x)
+          | B.Bitv Extract { i; j; _ }, [ x ] -> E.BV.extract i j (mk x)
+          | B.Bitv Not _, [ x ] -> E.BV.bvnot (mk x)
+          | B.Bitv Neg _, [ x ] -> E.BV.bvneg (mk x)
 
           (* Unary functions from QF_BV logic *)
-          | B.Bitv_repeat { k; _ }, [ x ] -> E.BV.repeat k (mk x)
-          | B.Bitv_zero_extend { k; _ }, [ x ] -> E.BV.zero_extend k (mk x)
-          | B.Bitv_sign_extend { k; _ }, [ x ] -> E.BV.sign_extend k (mk x)
-          | B.Bitv_rotate_left { i; _ }, [ x ] -> E.BV.rotate_left i (mk x)
-          | B.Bitv_rotate_right { i; _ }, [ x ] -> E.BV.rotate_right i (mk x)
+          | B.Bitv Repeat { k; _ }, [ x ] -> E.BV.repeat k (mk x)
+          | B.Bitv Zero_extend { k; _ }, [ x ] -> E.BV.zero_extend k (mk x)
+          | B.Bitv Sign_extend { k; _ }, [ x ] -> E.BV.sign_extend k (mk x)
+          | B.Bitv Rotate_left { i; _ }, [ x ] -> E.BV.rotate_left i (mk x)
+          | B.Bitv Rotate_right { i; _ }, [ x ] -> E.BV.rotate_right i (mk x)
 
           (* Binary applications *)
 
-          | B.Select, [ x; y ] ->
+          | B.Array Select, [ x; y ] ->
             let rty = dty_to_ty term_ty in
             E.mk_term (Sy.Op Sy.Get) [aux_mk_expr x; aux_mk_expr y] rty
 
           (* Binary functions from FixedSizeBitVectors theory *)
-          | B.Bitv_concat _, [ x; y ] -> E.BV.concat (mk x) (mk y)
-          | B.Bitv_and _, [ x; y ] -> E.BV.bvand (mk x) (mk y)
-          | B.Bitv_or _, [ x; y ] -> E.BV.bvor (mk x) (mk y)
-          | B.Bitv_add _, [ x; y ] -> E.BV.bvadd (mk x) (mk y)
-          | B.Bitv_mul _, [ x; y ] -> E.BV.bvmul (mk x) (mk y)
-          | B.Bitv_udiv _, [ x; y ] -> E.BV.bvudiv (mk x) (mk y)
-          | B.Bitv_urem _, [ x; y ] -> E.BV.bvurem (mk x) (mk y)
-          | B.Bitv_shl _, [ x; y ] -> E.BV.bvshl (mk x) (mk y)
-          | B.Bitv_lshr _, [ x; y ] -> E.BV.bvlshr (mk x) (mk y)
-          | B.Bitv_ult _, [ x; y ] -> E.BV.bvult (mk x) (mk y)
+          | B.Bitv Concat _, [ x; y ] -> E.BV.concat (mk x) (mk y)
+          | B.Bitv And _, [ x; y ] -> E.BV.bvand (mk x) (mk y)
+          | B.Bitv Or _, [ x; y ] -> E.BV.bvor (mk x) (mk y)
+          | B.Bitv Add _, [ x; y ] -> E.BV.bvadd (mk x) (mk y)
+          | B.Bitv Mul _, [ x; y ] -> E.BV.bvmul (mk x) (mk y)
+          | B.Bitv Udiv _, [ x; y ] -> E.BV.bvudiv (mk x) (mk y)
+          | B.Bitv Urem _, [ x; y ] -> E.BV.bvurem (mk x) (mk y)
+          | B.Bitv Shl _, [ x; y ] -> E.BV.bvshl (mk x) (mk y)
+          | B.Bitv Lshr _, [ x; y ] -> E.BV.bvlshr (mk x) (mk y)
+          | B.Bitv Ult _, [ x; y ] -> E.BV.bvult (mk x) (mk y)
 
           (* Binary functions from QF_BV logic *)
-          | B.Bitv_nand _, [ x; y ] -> E.BV.bvnand (mk x) (mk y)
-          | B.Bitv_nor _, [ x; y ] -> E.BV.bvnor (mk x) (mk y)
-          | B.Bitv_xor _, [ x; y ] -> E.BV.bvxor (mk x) (mk y)
-          | B.Bitv_xnor _, [ x; y ] -> E.BV.bvxnor (mk x) (mk y)
-          | B.Bitv_comp _, [ x; y ] -> E.BV.bvcomp (mk x) (mk y)
-          | B.Bitv_sub _, [ x; y ] -> E.BV.bvsub (mk x) (mk y)
-          | B.Bitv_sdiv _, [ x; y ] -> E.BV.bvsdiv (mk x) (mk y)
-          | B.Bitv_srem _, [ x; y ] -> E.BV.bvsrem (mk x) (mk y)
-          | B.Bitv_smod _, [ x; y ] -> E.BV.bvsmod (mk x) (mk y)
-          | B.Bitv_ashr _, [ x; y ] -> E.BV.bvashr (mk x) (mk y)
+          | B.Bitv Nand _, [ x; y ] -> E.BV.bvnand (mk x) (mk y)
+          | B.Bitv Nor _, [ x; y ] -> E.BV.bvnor (mk x) (mk y)
+          | B.Bitv Xor _, [ x; y ] -> E.BV.bvxor (mk x) (mk y)
+          | B.Bitv Xnor _, [ x; y ] -> E.BV.bvxnor (mk x) (mk y)
+          | B.Bitv Comp _, [ x; y ] -> E.BV.bvcomp (mk x) (mk y)
+          | B.Bitv Sub _, [ x; y ] -> E.BV.bvsub (mk x) (mk y)
+          | B.Bitv Sdiv _, [ x; y ] -> E.BV.bvsdiv (mk x) (mk y)
+          | B.Bitv Srem _, [ x; y ] -> E.BV.bvsrem (mk x) (mk y)
+          | B.Bitv Smod _, [ x; y ] -> E.BV.bvsmod (mk x) (mk y)
+          | B.Bitv Ashr _, [ x; y ] -> E.BV.bvashr (mk x) (mk y)
 
-          | B.Bitv_ule _, [ x; y ] -> E.BV.bvule (mk x) (mk y)
-          | B.Bitv_ugt _, [ x; y ] -> E.BV.bvugt (mk x) (mk y)
-          | B.Bitv_uge _, [ x; y ] -> E.BV.bvuge (mk x) (mk y)
-          | B.Bitv_slt _, [ x; y ] -> E.BV.bvslt (mk x) (mk y)
-          | B.Bitv_sle _, [ x; y ] -> E.BV.bvsle (mk x) (mk y)
-          | B.Bitv_sgt _, [ x; y ] -> E.BV.bvsgt (mk x) (mk y)
-          | B.Bitv_sge _, [ x; y ] -> E.BV.bvsge (mk x) (mk y)
+          | B.Bitv Ule _, [ x; y ] -> E.BV.bvule (mk x) (mk y)
+          | B.Bitv Ugt _, [ x; y ] -> E.BV.bvugt (mk x) (mk y)
+          | B.Bitv Uge _, [ x; y ] -> E.BV.bvuge (mk x) (mk y)
+          | B.Bitv Slt _, [ x; y ] -> E.BV.bvslt (mk x) (mk y)
+          | B.Bitv Sle _, [ x; y ] -> E.BV.bvsle (mk x) (mk y)
+          | B.Bitv Sgt _, [ x; y ] -> E.BV.bvsgt (mk x) (mk y)
+          | B.Bitv Sge _, [ x; y ] -> E.BV.bvsge (mk x) (mk y)
 
           (* Ternary applications *)
 
-          | B.Ite, [ x; y; z ] ->
+          | B.Prop Ite, [ x; y; z ] ->
             let e1 = aux_mk_expr x in
             let e2 = aux_mk_expr y in
             let e3 = aux_mk_expr z in
             E.mk_ite e1 e2 e3
 
-          | B.Store, [ x; y; z ] ->
+          | B.Array Store, [ x; y; z ] ->
             let ty = dty_to_ty term_ty in
             let e1 = aux_mk_expr x in
             let e2 = aux_mk_expr y in
@@ -1061,25 +1061,25 @@ let rec mk_expr
             let l = List.map (fun t -> aux_mk_expr t) args in
             E.mk_term sy l ty
 
-          | B.And, h :: (_ :: _ as t) ->
+          | B.Prop And, h :: (_ :: _ as t) ->
             List.fold_left (
               fun acc x ->
                 E.mk_and acc (aux_mk_expr x) false
             ) (aux_mk_expr h) t
 
-          | B.Or, h :: (_ :: _ as t) ->
+          | B.Prop Or, h :: (_ :: _ as t) ->
             List.fold_left (
               fun acc x ->
                 E.mk_or acc (aux_mk_expr x) false
             ) (aux_mk_expr h) t
 
-          | B.Xor, h :: (_ :: _ as t) ->
+          | B.Prop Xor, h :: (_ :: _ as t) ->
             List.fold_left (
               fun acc x ->
                 E.mk_xor acc (aux_mk_expr x)
             ) (aux_mk_expr h) t
 
-          | B.Imply, _ ->
+          | B.Prop Imply, _ ->
             begin match List.rev_map aux_mk_expr args with
               | h :: t ->
                 List.fold_left (
@@ -1089,13 +1089,13 @@ let rec mk_expr
               | _ -> assert false
             end
 
-          | B.Equiv, h :: (_ :: _ as t) ->
+          | B.Prop Equiv, h :: (_ :: _ as t) ->
             List.fold_left (
               fun acc x ->
                 E.mk_iff acc (aux_mk_expr x)
             ) (aux_mk_expr h) t
 
-          | B.Lt ty, h1 :: h2 :: t ->
+          | B.Arith Lt ty, h1 :: h2 :: t ->
             let (res, _) =
               List.fold_left (
                 fun (acc, curr) next ->
@@ -1105,7 +1105,7 @@ let rec mk_expr
               ) (mk_lt aux_mk_expr ty h1 h2, h2) t
             in res
 
-          | B.Gt ty, h1 :: h2 :: t ->
+          | B.Arith Gt ty, h1 :: h2 :: t ->
             let (res, _) =
               List.fold_left (
                 fun (acc, curr) next ->
@@ -1115,7 +1115,7 @@ let rec mk_expr
               ) (mk_gt aux_mk_expr ty h1 h2, h2) t
             in res
 
-          | B.Leq _, h1 :: h2 :: t ->
+          | B.Arith Leq _, h1 :: h2 :: t ->
             let (res, _) =
               List.fold_left (
                 fun (acc, curr) next ->
@@ -1131,7 +1131,7 @@ let rec mk_expr
               ) t
             in res
 
-          | B.Geq _, h1 :: h2 :: t ->
+          | B.Arith Geq _, h1 :: h2 :: t ->
             let (res, _) =
               List.fold_left (
                 fun (acc, curr) next ->
@@ -1147,45 +1147,45 @@ let rec mk_expr
               ) t
             in res
 
-          | B.Add ty, _ ->
+          | B.Arith Add ty, _ ->
             let rty = if ty == `Int then Ty.Tint else Treal in
             let sy = Sy.Op Sy.Plus in
             mk_add aux_mk_expr sy rty args
 
-          | B.Sub ty, h :: t ->
+          | B.Arith Sub ty, h :: t ->
             let rty = if ty == `Int then Ty.Tint else Treal in
             let sy = Sy.Op Sy.Minus in
             let args = List.rev_map aux_mk_expr (List.rev t) in
             List.fold_left
               (fun x y -> E.mk_term sy [x; y] rty) (aux_mk_expr h) args
 
-          | B.Mul ty, h :: t ->
+          | B.Arith Mul ty, h :: t ->
             let rty = if ty == `Int then Ty.Tint else Treal in
             let sy = Sy.Op Sy.Mult in
             let args = List.rev_map aux_mk_expr (List.rev t) in
             List.fold_left
               (fun x y -> E.mk_term sy [x; y] rty) (aux_mk_expr h) args
 
-          | (B.Div _ | B.Div_e (`Real | `Rat)), h :: t ->
+          | B.Arith (Div _ | Div_e (`Real | `Rat)), h :: t ->
             let sy = Sy.Op Sy.Div in
             let args = List.rev_map aux_mk_expr (List.rev t) in
             List.fold_left
               (fun x y -> E.mk_term sy [x; y] Ty.Treal) (aux_mk_expr h) args
 
-          | B.Div_e `Int, h :: t ->
+          | B.Arith Div_e `Int, h :: t ->
             let sy = Sy.Op Sy.Div in
             let args = List.rev_map aux_mk_expr (List.rev t) in
             List.fold_left
               (fun x y -> E.mk_term sy [x; y] Ty.Tint) (aux_mk_expr h) args
 
-          | B.Modulo_e ty, h :: t ->
+          | B.Arith Modulo_e ty, h :: t ->
             let rty = if ty == `Int then Ty.Tint else Treal in
             let sy = Sy.Op Sy.Modulo in
             let args = List.rev_map aux_mk_expr (List.rev t) in
             List.fold_left
               (fun x y -> E.mk_term sy [x; y] rty) (aux_mk_expr h) args
 
-          | B.Pow ty, h :: t ->
+          | B.Arith Pow ty, h :: t ->
             let rty = if ty == `Int then Ty.Tint else Treal in
             let sy = Sy.Op Sy.Pow in
             let args = List.rev_map aux_mk_expr (List.rev t) in
@@ -1194,7 +1194,7 @@ let rec mk_expr
 
           | B.Equal, h1 :: h2 :: t ->
             begin match h1.term_ty.ty_descr with
-              | TyApp ({builtin = B.Prop; _ }, _) ->
+              | TyApp ({builtin = B.Prop T; _ }, _) ->
                 let (res, _) =
                   List.fold_left (
                     fun (acc, curr) next ->
@@ -1230,7 +1230,7 @@ let rec mk_expr
           | B.Distinct, _ ->
             E.mk_distinct ~iff:true (List.map (fun t -> aux_mk_expr t) args)
 
-          | B.Constructor _, _ ->
+          | B.Adt Constructor _, _ ->
             let ty = dty_to_ty term_ty in
             let sy = Sy.constr tcst in
             let l = List.map (fun t -> aux_mk_expr t) args in
@@ -1254,13 +1254,13 @@ let rec mk_expr
           | Integer_round, _ -> op Integer_round
           | Abs_real, _ -> op Abs_real
           | Sqrt_real, _ -> op Sqrt_real
-          | B.Bitv_of_int { n }, _ -> op (Int2BV n)
-          | B.Bitv_to_nat { n = _ }, _ -> op BV2Nat
+          | B.Bitv Of_int { n }, _ -> op (Int2BV n)
+          | B.Bitv To_int { n = _ ; signed = false }, _ -> op BV2Nat
           | Sqrt_real_default, _ -> op Sqrt_real_default
           | Sqrt_real_excess, _ -> op Sqrt_real_excess
-          | B.Abs, _ -> op Abs_int
-          | B.Floor_to_int `Real, _ -> op Int_floor
-          | B.Is_int `Real, _ -> op Real_is_int
+          | B.Arith Abs, _ -> op Abs_int
+          | B.Arith Floor_to_int `Real, _ -> op Int_floor
+          | B.Arith Is_int `Real, _ -> op Real_is_int
           | Ceiling_to_int `Real, _ -> op Int_ceil
           | Max_real, _ -> op Max_real
           | Min_real, _ -> op Min_real
@@ -1270,11 +1270,11 @@ let rec mk_expr
           | Not_theory_constant, _ -> op Not_theory_constant
           | Is_theory_constant, _ -> op Is_theory_constant
           | Linear_dependency, _ -> op Linear_dependency
-          | B.RoundNearestTiesToEven, _ -> mk_rounding NearestTiesToEven
-          | B.RoundNearestTiesToAway, _ -> mk_rounding NearestTiesToAway
-          | B.RoundTowardPositive, _ -> mk_rounding Up
-          | B.RoundTowardNegative, _ -> mk_rounding Down
-          | B.RoundTowardZero, _ -> mk_rounding ToZero
+          | B.Float RoundNearestTiesToEven, _ -> mk_rounding NearestTiesToEven
+          | B.Float RoundNearestTiesToAway, _ -> mk_rounding NearestTiesToAway
+          | B.Float RoundTowardPositive, _ -> mk_rounding Up
+          | B.Float RoundTowardNegative, _ -> mk_rounding Down
+          | B.Float RoundTowardZero, _ -> mk_rounding ToZero
           | _, _ -> unsupported "Application Term %a" DE.Term.print term
         end
 
@@ -1428,7 +1428,7 @@ let rec mk_expr
       end
 
     (* open-ended in interval *)
-    | (B.Lt _ | B.Leq _ | B.Gt _ | B.Geq _) as b, [x; y] ->
+    | B.Arith (Lt _ | Leq _ | Gt _ | Geq _) as b, [x; y] ->
       let main_var, main_expr = Option.get var in
       let qm = Sy.Unbounded in
       let sort, lb, ub = parse_semantic_bound ~loc ~var:main_var b x y in
@@ -1444,7 +1444,7 @@ let rec mk_expr
       E.mk_term (Sy.mk_in lb ub) [aux_mk_expr main_expr] Ty.Tbool
 
     (* conjunction *)
-    | B.And, [x; y] ->
+    | B.Prop And, [x; y] ->
       let main_var, main_expr = Option.get var in
       begin match destruct_app x, destruct_app y with
         | Some (b, [l; r]), Some (b', [l'; r']) ->
@@ -1544,27 +1544,27 @@ let pp_query ?(hyps =[]) t =
       elim_toplevel_forall bnot body
 
     | App (
-        { term_descr = Cst { builtin = B.Neg; _ }; _ },
+        { term_descr = Cst { builtin = B.Prop Neg; _ }; _ },
         _tyl, [x]
       ) ->
       elim_toplevel_forall (not bnot) x
 
     | App (
-        { term_descr = Cst { builtin = B.And; _ }; _ },
+        { term_descr = Cst { builtin = B.Prop And; _ }; _ },
         tyl, es
       ) when not bnot ->
       let es = List.map (elim_toplevel_forall false) es in
       DE.Term.apply_cst DE.Term.Const.and_ tyl es
 
     | App (
-        { term_descr = Cst { builtin = B.Or;  _ }; _ },
+        { term_descr = Cst { builtin = B.Prop Or;  _ }; _ },
         tyl, es
       ) when bnot ->
       let es = List.map (elim_toplevel_forall true) es in
       DE.Term.apply_cst DE.Term.Const.and_ tyl es
 
     | App (
-        { term_descr = Cst { builtin = B.Imply; _ }; _ },
+        { term_descr = Cst { builtin = B.Prop Imply; _ }; _ },
         tyl, [x; y]
       ) when bnot ->
       let e1 = elim_toplevel_forall false x in
@@ -1579,7 +1579,7 @@ let pp_query ?(hyps =[]) t =
   let rec intro_hypothesis DE.({ term_descr; _ } as t) =
     match term_descr with
     | App (
-        { term_descr = Cst { builtin = B.Imply; _ }; _ }, _, [x; y]
+        { term_descr = Cst { builtin = B.Prop Imply; _ }; _ }, _, [x; y]
       ) ->
       let nx = elim_toplevel_forall false x in
       let axioms, goal = intro_hypothesis y in
@@ -1787,7 +1787,8 @@ let make file acc stmt =
       C.{ st_decl; st_loc } :: acc
 
     (* Function and predicate definitions *)
-    | { contents = `Defs defs; _ } ->
+    | { contents = `Defs (_recursive, defs); _ } ->
+      (* CR bclement: Do not assume that all definitions are recursive. *)
       (* For a mutually recursive definition, we have to add all the function
          names in a row. *)
       List.iter (fun (def : Typer_Pipe.def) ->
@@ -1882,8 +1883,12 @@ let make file acc stmt =
             assert false
         ) defs
 
-    | {contents = `Decls [td]; _ } ->
+    | {contents = `Decls (_recursive, [td]); _ } ->
       begin match td with
+        | `Implicit_type_var ->
+          (* CR bclement: Ask guillaume *)
+          acc
+
         | `Type_decl (td, _def) ->
           mk_ty_decl td;
           acc
@@ -1892,7 +1897,7 @@ let make file acc stmt =
           C.{ st_decl = Decl (mk_term_decl td); st_loc } :: acc
       end
 
-    | {contents = `Decls dcl; _ } ->
+    | {contents = `Decls (_recursive, dcl); _ } ->
       let rec aux ty_decls tdl acc =
         (* for now, when acc has more than one element it is assumed that the
            types are mutually recursive. Which is not necessarily the case.
@@ -1910,6 +1915,9 @@ let make file acc stmt =
         | `Type_decl (td, _def) :: tl ->
           aux (td :: ty_decls) tl acc
 
+        | `Implicit_type_var :: tl ->
+          aux ty_decls tl acc
+
         | [] ->
           begin
             let () =
@@ -1923,7 +1931,7 @@ let make file acc stmt =
       in
       aux [] dcl acc
 
-    | { contents = `Set_logic _ | `Set_info _ | `Get_info _ ; _ } -> acc
+    | { contents = `Set_logic _ | `Set_info _ | `Get_info _ | `End; _ } -> acc
 
     | { contents = #Typer_Pipe.typechecked; _ } as stmt ->
       (* TODO:

--- a/src/lib/frontend/translate.mli
+++ b/src/lib/frontend/translate.mli
@@ -54,5 +54,5 @@ val make :
 
 val builtins :
   Dolmen_loop.State.t ->
-  D_loop.Typer.lang ->
+  Dolmen_loop.Typer_intf.lang ->
   Dolmen_loop.Typer.T.builtin_symbols

--- a/src/lib/reasoners/adt_rel.ml
+++ b/src/lib/reasoners/adt_rel.ml
@@ -171,7 +171,7 @@ module Domains = struct
 
   let is_enum_constr DE.{ builtin; _ } =
     match builtin with
-    | B.Constructor { adt ; case } ->
+    | B.Adt (B.Adt.Constructor { adt ; case }) ->
       begin match DE.Ty.definition adt with
         | Some Adt { cases; _ } ->
           Array.length cases.(case).dstrs = 0

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -1279,7 +1279,7 @@ let has_attached_order id =
 
 let mk_constr c xs ty =
   match c.DE.builtin with
-  | DStd.Builtin.Constructor _ ->
+  | DStd.Builtin.Adt Constructor _ ->
     (* This assertion ensures that the API of the [Nest] module have been
        correctly used, that is [Nest.attach_orders] have been called on
        the nest of [id] if [id] is a constructor of ADT. *)
@@ -1291,7 +1291,7 @@ let mk_constr c xs ty =
 
 let mk_tester c t =
   match c.DE.builtin with
-  | DStd.Builtin.Constructor _ ->
+  | DStd.Builtin.Adt Constructor _ ->
     mk_builtin ~is_pos:true (Sy.IsConstr c) [t]
   | _ ->
     Fmt.invalid_arg "expected a constructor, got %a" DE.Id.print c

--- a/src/lib/structures/id.ml
+++ b/src/lib/structures/id.ml
@@ -23,7 +23,7 @@ type typed = t * Ty.t list * Ty.t [@@deriving ord]
 let equal = Hstring.equal
 
 let pp ppf id =
-  Dolmen.Smtlib2.Script.Poly.Print.id ppf
+  Dolmen.Smtlib2.Script.Poly.Print.symbol ppf
     (Dolmen.Std.Name.simple (Hstring.view id))
 
 let show id = Fmt.str "%a" pp id

--- a/src/lib/structures/symbols.ml
+++ b/src/lib/structures/symbols.ml
@@ -320,7 +320,7 @@ let print_bound fmt b = Format.fprintf fmt "%s" (string_of_bound b)
 
 let pp_name ppf (_ns, s) =
   (* Names are pre-mangled *)
-  Dolmen.Smtlib2.Script.Poly.Print.id ppf (Dolmen.Std.Name.simple s)
+  Dolmen.Smtlib2.Script.Poly.Print.symbol ppf (Dolmen.Std.Name.simple s)
 
 module AEPrinter = struct
   let pp_operator ppf op =
@@ -492,7 +492,7 @@ module SmtPrinter = struct
     | Float -> Fmt.pf ppf "ae.round"
 
     (* Not in the SMT-LIB standard *)
-    | Int2BV n -> Fmt.pf ppf "(_ int2bv %d)" n
+    | Int2BV n -> Fmt.pf ppf "(_ int_to_bv %d)" n
     | Not_theory_constant -> Fmt.pf ppf "ae.not_theory_constant"
     | Is_theory_constant -> Fmt.pf ppf "ae.is_theory_constant"
     | Linear_dependency -> Fmt.pf ppf "ae.linear_dependency"

--- a/src/lib/util/nest.ml
+++ b/src/lib/util/nest.ml
@@ -83,7 +83,7 @@ let (let*) = Option.bind
 let def_of_dstr dstr =
   let* ty_cst =
     match dstr with
-    | DE.{ builtin = B.Destructor _; id_ty; _ } ->
+    | DE.{ builtin = B.Adt (B.Adt.Destructor _); id_ty; _ } ->
       begin match DT.view id_ty with
         | `Arrow (_, ty) ->
           begin match DT.view ty with
@@ -150,7 +150,7 @@ end
 
 let ty_cst_of_constr DE.{ builtin; _ } =
   match builtin with
-  | B.Constructor { adt; _ } -> adt
+  | B.Adt (B.Adt.Constructor { adt; _ }) -> adt
   | _ -> Fmt.failwith "expect an ADT constructor"
 
 let order_tag : int DStd.Tag.t = DStd.Tag.create ()
@@ -178,7 +178,7 @@ let attach_orders defs =
 
 let perfect_hash id =
   match (id : DE.term_cst) with
-  | { builtin = B.Constructor _; _ } as id ->
+  | { builtin = B.Adt (B.Adt.Constructor _); _ } as id ->
     begin match DE.Term.Const.get_tag id order_tag with
       | Some h -> h
       | None ->

--- a/src/lib/util/options.ml
+++ b/src/lib/util/options.ml
@@ -111,7 +111,7 @@ end
 type instantiation_heuristic = INormal | IAuto | IGreedy
 
 (* As in Dolmen *)
-type smtlib2_version = [ `Latest | `V2_6 | `Poly ]
+type smtlib2_version = [ `Latest | `V2_6 | `V2_7 | `Poly ]
 
 type input_format =
   | Native

--- a/src/lib/util/options.mli
+++ b/src/lib/util/options.mli
@@ -50,6 +50,9 @@ type smtlib2_version =
   | `V2_6
   (** {{: https://smt-lib.org/papers/smt-lib-reference-v2.6-r2021-05-12.pdf }
       The SMT-LIB standard: Version 2.6} *)
+  | `V2_7
+  (** {{: https://smt-lib.org/papers/smt-lib-reference-v2.7-r2025-07-07.pdf }
+      The SMT-LIB standard: Version 2.7} *)
   | `Poly
     (** Polymorphic extension of the SMT-LIB standard.
 


### PR DESCRIPTION
Use the current development version of Dolmen, as preparation for its next release.

This patch does the minimal amount of work needed to make Alt-Ergo support this version of Dolmen ; in particular, it does not exploit Dolmen's new organization of builtins by theories or implement new operators from the SMT-LIB 2.7 standard (except for `ubv_to_int` and `int_to_bv`, which are now new names for `bv2nat` and `int2bv` respectively).