### PR TITLE
Register exn printer for Errors.Error _

### DIFF
--- a/src/lib/structures/errors.ml
+++ b/src/lib/structures/errors.ml
@@ -134,3 +134,11 @@ let report fmt = function
       report_mode_error merr;
   | Model_error err ->
     Fmt.pf fmt "Model Error: %a" report_model_error err
+
+let () =
+  Printexc.register_printer (
+    function
+    | Error e ->
+      Some (Fmt.str "%a" report e)
+    | _ -> None
+  )


### PR DESCRIPTION
Prints more detailed (but sometimes bulky) error messages than `AltErgoLib.Errors.Error(_)`
(noticed while reproducing https://github.com/OCamlPro/owi/issues/638)