### PR TITLE
Bump minimal version of cmdliner to 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.2
+  OCAML_DEFAULT_VERSION: 4.14.3
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -28,8 +28,8 @@ jobs:
           - windows-latest
         ocaml-compiler:
           - 4.08.1
-          - 4.14.2
-          - 5.0.0
+          - 4.14.3
+          - 5.4.0
         exclude:
           # No longer seems to be available
           - os: macos-latest
@@ -80,7 +80,7 @@ jobs:
           dune-cache: true
 
       - name: Install dependencies
-        run: opam exec -- make deps js-deps
+        run: opam exec -- make test-deps js-deps
 
       - name: Build the project
         run: opam exec -- dune build --profile ci @check

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -5,7 +5,7 @@ name: Build Javascript
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.2
+  OCAML_DEFAULT_VERSION: 4.14.3
   # Add OPAMYES=true to the environment, this is usefull to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -39,8 +39,11 @@ jobs:
 
       - uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.14.1
+          ocaml-compiler: 4.14.3
           dune-cache: true
+
+      - name: Update opam repository
+        run: opam update
 
       - run: opam install . --locked --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 
@@ -99,6 +102,9 @@ jobs:
 
       - name: Install static dependencies
         run: sudo apk add zlib-static
+
+      - name: Update opam repository
+        run: opam update
 
       - run: opam switch create . ocaml-system --locked --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.2
+  OCAML_DEFAULT_VERSION: 4.14.3
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,7 @@ name: Linter
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.2
+  OCAML_DEFAULT_VERSION: 4.14.3
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -18,7 +18,7 @@ jobs:
         ocp-indent-version:
           # Fixed ocp-indent version. A PR with updated indented code is needed
           # if this version is changed
-          - 1.8.1
+          - 1.9.0
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.2
+  OCAML_DEFAULT_VERSION: 4.14.3
   OPAMYES: true
   OPAMLOCKED: locked
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## v2.6.3
+
+ - Bump minimal cmdliner version to 2.0 (#1340)
+
 ## v2.6.2
 
  - Expose some internal APIs for Owi (#1259)

--- a/Makefile
+++ b/Makefile
@@ -243,9 +243,11 @@ lock:
 dev-switch:
 	opam switch create . --deps-only --ignore-constraints-on alt-ergo-lib,alt-ergo-parsers
 
+# FIXME: the version 6.3.0 of js_of_ocaml contains a bug, see
+# https://github.com/ocsigen/js_of_ocaml/issues/2209
 js-deps:
 	opam install \
-		'js_of_ocaml>=5.4.0' \
+		'js_of_ocaml<=6.2.0' \
 		js_of_ocaml-lwt \
 		js_of_ocaml-ppx \
 		data-encoding \

--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -26,11 +26,10 @@ depends: [
   "fmt" {>= "0.9.0"}
   "stdlib-shims"
   "ppx_blob" {>= "0.7.2"}
-  "ppx_deriving"
   "camlzip" {>= "1.07"}
   "odoc" {with-doc}
   "ppx_deriving"
-  "qcheck" {with-test & = "0.22"}
+  "qcheck" {with-test & = "0.25"}
 ]
 conflicts: [
   "ppxlib" {< "0.30.0"}

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -17,50 +17,44 @@ doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
   "base-bigarray" {= "base"}
-  "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
-  "camlzip" {= "1.11"}
-  "cmdliner" {= "1.2.0"}
-  "conf-gmp" {= "4"}
-  "conf-pkg-config" {= "3"}
+  "camlzip" {= "1.14"}
+  "cmdliner" {= "2.1.0"}
+  "conf-gmp" {= "5"}
+  "conf-pkg-config" {= "4"}
   "conf-zlib" {= "1"}
-  "cppo" {= "1.6.9"}
-  "csexp" {= "1.5.2"}
+  "cppo" {= "1.8.0"}
   "dolmen" {= "0.10"}
   "dolmen_loop" {= "0.10"}
   "dolmen_type" {= "0.10"}
-  "dune" {= "3.16.0"}
-  "dune-build-info" {= "3.16.0"}
-  "dune-configurator" {= "3.16.0"}
-  "fmt" {= "0.9.0"}
+  "dune" {= "3.22.0"}
+  "dune-build-info" {= "3.22.0"}
+  "fmt" {= "0.11.0"}
   "gen" {= "1.1"}
-  "js_of_ocaml" {= "5.4.0"}
-  "js_of_ocaml-compiler" {= "5.4.0"}
-  "logs" {= "0.7.0"}
-  "lwt" {= "5.7.0"}
-  "menhir" {= "20230608"}
-  "menhirLib" {= "20230608"}
-  "menhirSdk" {= "20230608"}
-  "ocaml-compiler-libs" {= "v0.12.4"}
-  "ocamlbuild" {= "0.14.2"}
-  "ocamlfind" {= "1.9.6"}
-  "ocplib-endian" {= "1.2"}
+  "hmap" {= "0.8.1"}
+  "logs" {= "0.10.0"}
+  "menhir" {= "20250912"}
+  "menhirCST" {= "20250912"}
+  "menhirLib" {= "20250912"}
+  "menhirSdk" {= "20250912"}
+  "ocaml-options-vanilla" {= "1"}
+  "ocamlbuild" {= "0.16.1"}
+  "ocamlfind" {= "1.9.8"}
   "ocplib-simplex" {= "0.5.1"}
   "pp_loc" {= "2.1.0"}
-  "ppx_blob" {= "0.7.2"}
+  "ppx_blob" {= "0.9.0"}
   "ppx_derivers" {= "1.2.1"}
-  "ppx_deriving" {= "5.2.1"}
-  "ppxlib" {= "0.31.0"}
-  "qcheck" {= "0.21.3"}
-  "result" {= "1.5"}
+  "ppx_deriving" {= "6.1.1"}
+  "ppxlib" {= "0.37.0"}
+  "qcheck" {= "0.25"}
   "seq" {= "base"}
-  "sexplib0" {= "v0.16.0"}
+  "sexplib0" {= "v0.17.0"}
   "spelll" {= "0.4"}
-  "topkg" {= "1.0.7"}
-  "uutf" {= "1.0.3"}
-  "yojson" {= "2.1.1"}
-  "zarith" {= "1.13"}
+  "stdlib-shims" {= "0.3.0"}
+  "topkg" {= "1.1.1"}
+  "uutf" {= "1.0.4"}
+  "zarith" {= "1.14"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -82,10 +76,4 @@ dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"
 conflicts: [
   "ppxlib" {< "0.30.0"}
   "result" {< "1.5"}
-]
-pin-depends: [
-  [
-    "js_of_ocaml.5.4.0"
-    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.4.0/js_of_ocaml-5.4.0.tbz"
-  ]
 ]

--- a/alt-ergo.opam
+++ b/alt-ergo.opam
@@ -18,7 +18,7 @@ depends: [
   "alt-ergo-parsers" {= version}
   "menhir"
   "dune-site"
-  "cmdliner" {>= "1.1.0" & < "2.0"}
+  "cmdliner" {>= "2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@ See more details on https://alt-ergo.ocamlpro.com/")
   (alt-ergo-parsers (= :version))
   menhir
   dune-site
-  (cmdliner (and (>= 1.1.0) (< 2.0)))
+  (cmdliner (>= 2.0))
   (odoc :with-doc)
  )
 
@@ -86,11 +86,10 @@ See more details on http://alt-ergo.ocamlpro.com/"
   (fmt (>= 0.9.0))
   stdlib-shims
   (ppx_blob (>= 0.7.2))
-  ppx_deriving
   (camlzip (>= 1.07))
   (odoc :with-doc)
   ppx_deriving
-  (qcheck (and :with-test (= 0.22)))
+  (qcheck (and :with-test (= 0.25)))
  )
  (conflicts
   (ppxlib (< 0.30.0))

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -12,6 +12,13 @@ import sources.nixpkgs {
         dolmen_loop = pkgs.callPackage ./dolmen_loop.nix { };
         landmarks = pkgs.callPackage ./landmarks.nix { };
         landmarks-ppx = pkgs.callPackage ./landmarks-ppx.nix { };
+        cmdliner_2 = super.cmdliner.overrideAttrs (_: rec {
+          version = "2.1.0";
+          src = pkgs.fetchurl {
+            url = "https://erratique.ch/software/cmdliner/releases/cmdliner-${version}.tbz";
+            hash = "sha256-iBTGFM1D1S/R68ivWjHZElwhTEmPpgVmDk7Rlf+ENOk=";
+          };
+        });
       });
     })
   ];

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -26,15 +26,15 @@
         "version": "dev"
     },
     "nixpkgs": {
-        "branch": "release-24.05",
+        "branch": "release-25.11",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b260a95463a8f5f9094527c05329d79527e5a4aa",
-        "sha256": "0qlnwrha950kflbnfsl39mrdkkll3663bssjlxrrm7w1qnbbbp1n",
+        "rev": "e4f687fc1caadcb540453a2ce7ea9c9f2763434d",
+        "sha256": "089xw68v2sk4i3pra095qaqqs31j5b482j4bl7lw9qwrl9bni91n",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/b260a95463a8f5f9094527c05329d79527e5a4aa.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e4f687fc1caadcb540453a2ce7ea9c9f2763434d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ocplib-simplex": {

--- a/shell.nix
+++ b/shell.nix
@@ -35,7 +35,7 @@ pkgs.mkShell {
     lwt_ppx
     data-encoding
     zarith_stubs_js
-    cmdliner
+    cmdliner_2
     ppx_blob
     odoc
     ppx_deriving

--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -737,7 +737,7 @@ let main () =
   let handle_get_info (st : State.t) (name: string) =
     let print_std =
       fun (type a) (pp :a Fmt.t) (a : a) ->
-        Printer.print_std "(%s %a)" name pp a
+      Printer.print_std "(%s %a)" name pp a
     in
     let pp_reason_unknown st =
       let err () =

--- a/src/bin/js/dune
+++ b/src/bin/js/dune
@@ -7,7 +7,7 @@
  )
  (modules main_text_js)
  (modes byte js)
- (js_of_ocaml (flags --no-source-map +toplevel.js +dynlink.js))
+ (js_of_ocaml (flags +toplevel.js +dynlink.js))
 )
 
 (library
@@ -31,7 +31,7 @@
  )
  (modules worker_js options_interface)
  (modes byte js)
- (js_of_ocaml (flags --no-source-map +toplevel.js +dynlink.js))
+ (js_of_ocaml (flags +toplevel.js +dynlink.js))
 )
 
 ; Rule to build a small js example running the Alt-Ergo web worker

--- a/src/bin/js/worker_example.ml
+++ b/src/bin/js/worker_example.ml
@@ -27,6 +27,7 @@
 
 open Js_of_ocaml
 open Js_of_ocaml_lwt
+module Console = Js_of_ocaml.Console
 
 module Html = Dom_html
 
@@ -83,11 +84,11 @@ let solve () =
       (
         let file = String.split_on_char '\n' !file in
         let json_file = Worker_interface.file_to_json None (Some 42) file in
-        Firebug.console##log json_file;
+        Console.console##log json_file;
         let json_options = Worker_interface.options_to_json options in
-        Firebug.console##log json_options;
+        Console.console##log json_options;
         let%lwt results = exec worker json_file json_options in
-        Firebug.console##log results;
+        Console.console##log results;
         let res = Worker_interface.results_from_json results in
         Lwt.return res
       )

--- a/tests/cram.t/run.t
+++ b/tests/cram.t/run.t
@@ -1,4 +1,4 @@
-  $ echo '(check-sat)' | alt-ergo --inequalities-plugin does-not-exist -i smtlib2 -o smtlib2 2>&1 >/dev/null | sed -e '/^[[:space:]]*>>/d'
+  $ echo '(check-sat)' | alt-ergo --inequalities-plugin does-not-exist -i smtlib2 -o smtlib2 2>&1 >/dev/null | tr -d '\n' | sed -e 's/[[:space:]]*>>.*//g'
   alt-ergo: Fatal Error: [Dynlink] Loading the plugin "does-not-exist" failed!
 
 Now we will have some tests for the models. Note that it is okay if the format


### PR DESCRIPTION
Changes:
- Bump the minimal version of `cmdliner` to 2.0.
- Bump the minimal version of `js_of_ocaml` to 6.2.0. This version is
  compatible both with cmdliner < 2.0 and cmdliner 2. The latest release
  of js_of_ocaml contains a bug
  (see https://github.com/ocsigen/js_of_ocaml/issues/2209). 
  We must use js_of_ocaml 6.2.0 until the next release of the compiler.
  Unfortunately, they dropped support for OCaml compiler < 4.13, which means we cannot compile our JavaScript artifact  for the old versions of the compiler.
- Bump `ocp-indent` to 1.9.0 as 1.8.1 depends on `cmdliner` < 2.0.
- Update OCaml versions in the CI (4.14.1 -> 4.14.3 and 5.0 -> 5.4.0).
- Bump the nixpkgs version to 25.11. The release `24.05` didn't contain this patch https://github.com/NixOS/nixpkgs/commit/69ca7055ae35b751e62099e51200fcb280b8f448.