### PR TITLE
Add an upper bound for Dolmen

### DIFF
--- a/alt-ergo-lib.opam
+++ b/alt-ergo-lib.opam
@@ -17,9 +17,9 @@ depends: [
   "ocaml" {>= "4.08.1"}
   "dune" {>= "3.14"}
   "dune-build-info"
-  "dolmen" {>= "0.10"}
-  "dolmen_type" {>= "0.10"}
-  "dolmen_loop" {>= "0.10"}
+  "dolmen" {>= "0.10" & < "0.11"}
+  "dolmen_type" {>= "0.10" & < "0.11"}
+  "dolmen_loop" {>= "0.10" & < "0.11"}
   "ocplib-simplex" {>= "0.5.1"}
   "zarith" {>= "1.11"}
   "seq"

--- a/dune-project
+++ b/dune-project
@@ -77,9 +77,9 @@ See more details on http://alt-ergo.ocamlpro.com/"
   (ocaml (>= 4.08.1))
   dune
   dune-build-info
-  (dolmen (>= 0.10))
-  (dolmen_type (>= 0.10))
-  (dolmen_loop (>= 0.10))
+  (dolmen (and (>= 0.10) (< 0.11)))
+  (dolmen_type (and (>= 0.10) (< 0.11)))
+  (dolmen_loop (and (>= 0.10) (< 0.11)))
   (ocplib-simplex (>= 0.5.1))
   (zarith (>= 1.11))
   seq


### PR DESCRIPTION
Dolmen 0.11 introduces breaking API changes that are incompatible with Alt-Ergo v2.6.x.