### PR TITLE
Use local exception to early exit few functions

### DIFF
--- a/src/bin/common/solving_loop.ml
+++ b/src/bin/common/solving_loop.ml
@@ -158,6 +158,13 @@ type solve_res =
 
 exception StopProcessDecl
 
+let parse_solver_name s =
+  match s with
+  | "tableaux" -> Some Util.Tableaux
+  | "cdcl" | "satml" -> Some Util.CDCL
+  | "cdcl_tableaux" | "satml_tableaux" | "default" -> Some Util.CDCL_Tableaux
+  | _ -> None
+
 let interactive_prompt st =
   match D_loop.State.get D_loop.State.logic_file st with
   | { source = `Stdin; mode = (None | Some `Incremental); _ }
@@ -296,7 +303,6 @@ let process_source ?selector_inst ~print_status src =
     | Errors.Error e ->
       recoverable_error "%a" Errors.report e;
       st
-    | Exit -> raise (Exit_with_code 0)
     | _ as exn -> Printexc.raise_with_backtrace exn bt
   in
   let finally ~handle_exn st e =
@@ -492,26 +498,19 @@ let process_source ?selector_inst ~print_status src =
              after initialization";
           st
         ) else
-          try
-            let sat_solver =
-              match solver with
-              | "tableaux" -> Util.Tableaux
-              | "cdcl" | "satml" -> Util.CDCL
-              | "cdcl_tableaux" | "satml_tableaux" | "default" ->
-                Util.CDCL_Tableaux
-              | _ -> raise Exit
-            in
-            let is_cdcl_tableaux =
-              match sat_solver with CDCL_Tableaux -> true | _ -> false
-            in
-            Options.set_cdcl_tableaux_inst is_cdcl_tableaux;
-            Options.set_cdcl_tableaux_th is_cdcl_tableaux;
-            set_sat_solver sat_solver st
-          with Exit ->
-            recoverable_error ~loc
-              "error setting ':sat-solver', invalid option value '%s'"
-              solver;
-            st
+          (match parse_solver_name solver with
+           | Some sat_solver ->
+             let is_cdcl_tableaux =
+               match sat_solver with CDCL_Tableaux -> true | _ -> false
+             in
+             Options.set_cdcl_tableaux_inst is_cdcl_tableaux;
+             Options.set_cdcl_tableaux_th is_cdcl_tableaux;
+             set_sat_solver sat_solver st
+           | None ->
+             recoverable_error ~loc
+               "error setting ':sat-solver', invalid option value '%s'"
+               solver;
+             st)
       )
     | ":produce-assignments",  Symbol { name = Simple b; _ } ->
       begin
@@ -845,7 +844,7 @@ let process_source ?selector_inst ~print_status src =
         |> DO.init
         |> State.set named_terms Util.MS.empty
 
-      | {contents = `Exit; _} -> raise Exit
+      | {contents = `Exit; _} -> raise (Exit_with_code 0)
 
       | {contents = `Echo str; _} ->
         Fmt.pf

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -720,7 +720,10 @@ module Flat_Formula : FLAT_FORMULA = struct
                    not (Options.get_disable_flat_formulas_simplification ()) &&
                    a.Atom.var.Atom.level = 0 ->
                  begin
-                   if a.Atom.neg.Atom.is_true then (aaz a; raise Contradiction); (* XXX*)
+                   if a.Atom.neg.Atom.is_true then (
+                     aaz a;
+                     raise Contradiction
+                   ); (* XXX*)
                    if a.Atom.is_true then (aaz a; acc)
                    else so, e::nso
                  end

--- a/src/lib/structures/satml_types.ml
+++ b/src/lib/structures/satml_types.ml
@@ -707,43 +707,45 @@ module Flat_Formula : FLAT_FORMULA = struct
       then merge_rec l1 l2 h1
       else merge_rec l1 l2 h2
 
-  let mk_and hcons l =
-    try
-      let so, nso =
-        List.fold_left
-          (fun ((so,nso) as acc) e ->
-             match e.view with
-             | AND l -> merge_and_check so l, nso
-             | UNIT a when
-                 not (Options.get_disable_flat_formulas_simplification ()) &&
-                 a.Atom.var.Atom.level = 0 ->
-               begin
-                 if a.Atom.neg.Atom.is_true then (aaz a; raise Exit); (* XXX*)
-                 if a.Atom.is_true then (aaz a; acc)
-                 else so, e::nso
-               end
-             | _     -> so, e::nso
-          )([],[]) l
-      in
-      let delta_inv = List.fast_sort (fun a b -> compare b a) nso in
-      let delta_u = match delta_inv with
-        | [] -> delta_inv
-        | e::l ->
-          let _, delta_u =
-            List.fold_left
-              (fun ((c,l) as acc) e ->
-                 if complements c e then raise Exit;
-                 if equal c e then acc
-                 else (e, e::l)
-              )(e,[e]) l
-          in
-          delta_u
-      in
-      match merge_and_check so delta_u with
-      | [] -> vrai
-      | [e]-> e
-      | l -> make hcons (AND l) (OR (List.rev (List.rev_map mk_not l)))
-    with Exit -> faux
+  let mk_and =
+    let exception Contradiction in
+    fun hcons l ->
+      try
+        let so, nso =
+          List.fold_left
+            (fun ((so,nso) as acc) e ->
+               match e.view with
+               | AND l -> merge_and_check so l, nso
+               | UNIT a when
+                   not (Options.get_disable_flat_formulas_simplification ()) &&
+                   a.Atom.var.Atom.level = 0 ->
+                 begin
+                   if a.Atom.neg.Atom.is_true then (aaz a; raise Contradiction); (* XXX*)
+                   if a.Atom.is_true then (aaz a; acc)
+                   else so, e::nso
+                 end
+               | _     -> so, e::nso
+            )([],[]) l
+        in
+        let delta_inv = List.fast_sort (fun a b -> compare b a) nso in
+        let delta_u = match delta_inv with
+          | [] -> delta_inv
+          | e::l ->
+            let _, delta_u =
+              List.fold_left
+                (fun ((c,l) as acc) e ->
+                   if complements c e then raise Contradiction;
+                   if equal c e then acc
+                   else (e, e::l)
+                )(e,[e]) l
+            in
+            delta_u
+        in
+        match merge_and_check so delta_u with
+        | [] -> vrai
+        | [e]-> e
+        | l -> make hcons (AND l) (OR (List.rev (List.rev_map mk_not l)))
+      with Contradiction -> faux
 
   (* res = l1 inter l2 *)
   let intersect_list l1 l2 =
@@ -830,60 +832,62 @@ module Flat_Formula : FLAT_FORMULA = struct
         try Some (common, List.rev_map (diff_list common) ands)
         with Not_included -> assert false
 
-  let rec mk_or hcons l =
-    try
-      let so, nso =
-        List.fold_left
-          (fun ((so,nso) as acc) e ->
-             match e.view with
-             | OR l  -> merge_and_check so l, nso
-             | UNIT a  when
-                 not (Options.get_disable_flat_formulas_simplification ()) &&
-                 a.Atom.var.Atom.level = 0 ->
-               begin
-                 if a.Atom.is_true then (aaz a; raise Exit); (* XXX *)
-                 if a.Atom.neg.Atom.is_true then (aaz a; acc)
-                 else so, e::nso
-               end
-             | _     -> so, e::nso
-          )([],[]) l
-      in
-      let delta_inv = List.fast_sort (fun a b -> compare b a) nso in
-      let delta_u = match delta_inv with
-        | [] -> delta_inv
-        | e::l ->
-          let _, delta_u =
-            List.fold_left
-              (fun ((c,l) as acc) e ->
-                 if complements c e then raise Exit;
-                 if equal c e then acc
-                 else (e, e::l)
-              )(e,[e]) l
-          in
-          delta_u
-      in
-      match merge_and_check so delta_u with
-      | [] -> faux
-      | [e]-> e
-      | l  ->
-        match extract_common l with
-        | None ->
-          begin match l with
-            | [{ view = UNIT _; _ } as fa; { view = AND ands; _ }] ->
-              begin
-                try
-                  mk_or hcons
-                    [fa ; (mk_and hcons (remove_elt (mk_not fa) ands))]
-                with Not_included ->
-                  make hcons (OR l) (AND (List.rev (List.rev_map mk_not l)))
-              end
-            | _ ->
-              make hcons (OR l) (AND (List.rev (List.rev_map mk_not l)))
-          end
-        | Some (com,ands) ->
-          let ands = List.rev_map (mk_and hcons) ands in
-          mk_and hcons ((mk_or hcons ands) :: com)
-    with Exit -> vrai
+  let rec mk_or =
+    let exception Tautology in
+    fun hcons l ->
+      try
+        let so, nso =
+          List.fold_left
+            (fun ((so,nso) as acc) e ->
+               match e.view with
+               | OR l  -> merge_and_check so l, nso
+               | UNIT a  when
+                   not (Options.get_disable_flat_formulas_simplification ()) &&
+                   a.Atom.var.Atom.level = 0 ->
+                 begin
+                   if a.Atom.is_true then (aaz a; raise Tautology); (* XXX *)
+                   if a.Atom.neg.Atom.is_true then (aaz a; acc)
+                   else so, e::nso
+                 end
+               | _     -> so, e::nso
+            )([],[]) l
+        in
+        let delta_inv = List.fast_sort (fun a b -> compare b a) nso in
+        let delta_u = match delta_inv with
+          | [] -> delta_inv
+          | e::l ->
+            let _, delta_u =
+              List.fold_left
+                (fun ((c,l) as acc) e ->
+                   if complements c e then raise Tautology;
+                   if equal c e then acc
+                   else (e, e::l)
+                )(e,[e]) l
+            in
+            delta_u
+        in
+        match merge_and_check so delta_u with
+        | [] -> faux
+        | [e]-> e
+        | l  ->
+          match extract_common l with
+          | None ->
+            begin match l with
+              | [{ view = UNIT _; _ } as fa; { view = AND ands; _ }] ->
+                begin
+                  try
+                    mk_or hcons
+                      [fa ; (mk_and hcons (remove_elt (mk_not fa) ands))]
+                  with Not_included ->
+                    make hcons (OR l) (AND (List.rev (List.rev_map mk_not l)))
+                end
+              | _ ->
+                make hcons (OR l) (AND (List.rev (List.rev_map mk_not l)))
+            end
+          | Some (com,ands) ->
+            let ands = List.rev_map (mk_and hcons) ands in
+            mk_and hcons ((mk_or hcons ands) :: com)
+      with Tautology -> vrai
 
   (* translation from E.t *)
 


### PR DESCRIPTION
Using `Stdlib.Exit` to early exit loops is acceptable if we have backtraces. Unfortunately, backtraces are not recorded without instrumentating code for jsoo. Debugging #1348 was a nightmare because of this. 

I believe that we should use local exceptions in this case:
```ocaml
let foo = 
  let exception Early_exit in 
  fun ... -> ...
```

As a bonus, this allows us to use more descriptive names for our exceptions.