### PR TITLE
Bump minimal version to 4.11.2 in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,16 +27,16 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - 4.08.1
+          - 4.11.2
           - 4.14.3
           - 5.4.0
         exclude:
-          # No longer seems to be available
+          # OCaml 4.11.2 is not available on macOS + arm
           - os: macos-latest
-            ocaml-compiler: 4.08.1
+            ocaml-compiler: 4.11.2
           # Opam 2.2 requires at least OCaml 4.13
           - os: windows-latest
-            ocaml-compiler: 4.08.1
+            ocaml-compiler: 4.11.2
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
OCaml < 4.11 is archived on opam repository.
Notice that OCaml 4.11 is not available on macOS + arm.