### PR TITLE
fix: Use the actual location for lemmas

### DIFF
--- a/src/lib/frontend/translate.ml
+++ b/src/lib/frontend/translate.ml
@@ -1843,7 +1843,7 @@ let make file acc stmt =
                 in
                 let qb = E.mk_eq ~iff:true defn ff in
                 let ff =
-                  E.mk_forall name_base Loc.dummy binders [] qb
+                  E.mk_forall name_base st_loc binders [] qb
                     ~toplevel:true ~decl_kind
                 in
                 assert (Var.Map.is_empty (E.free_vars ff Var.Map.empty));
@@ -1864,7 +1864,7 @@ let make file acc stmt =
                 let iff = Ty.equal (Expr.type_info defn) (Ty.Tbool) in
                 let qb = E.mk_eq ~iff defn ff in
                 let ff =
-                  E.mk_forall name_base Loc.dummy binders [] qb
+                  E.mk_forall name_base st_loc binders [] qb
                     ~toplevel:true ~decl_kind
                 in
                 assert (Var.Map.is_empty (E.free_vars ff Var.Map.empty));

--- a/src/lib/structures/errors.ml
+++ b/src/lib/structures/errors.ml
@@ -77,6 +77,17 @@ let invalid_set_option mode opt_key =
 let forbidden_command mode cmd_name =
   error (Mode_error (mode, Forbidden_command cmd_name))
 
+exception Internal_error
+
+let internal_error fmt =
+  let ppf = Options.Output.get_fmt_diagnostic () in
+  Fmt.pf ppf "@[<v>Internal error:@ @[";
+  Fmt.kpf
+    (fun ppf ->
+       Fmt.pf ppf "@]@]@.";
+       raise Internal_error)
+    ppf fmt
+
 let report_typing_error fmt = function
   | NonPositiveBitvType(n) ->
     fprintf fmt "non positive bitvector size (%d)" n

--- a/src/lib/structures/errors.mli
+++ b/src/lib/structures/errors.mli
@@ -103,3 +103,9 @@ val forbidden_command : Util.mode -> string -> 'a
 
 (** Print a message on the formatter corresponding to the error *)
 val report : Format.formatter -> error -> unit
+
+(** {2 Internal error } *)
+
+exception Internal_error
+
+val internal_error : ('a, Format.formatter, unit, 'b) format4 -> 'a

--- a/src/lib/structures/profiling.ml
+++ b/src/lib/structures/profiling.ml
@@ -202,14 +202,24 @@ let empty_inst_info loc =
     _new  = SE.empty;
   }
 
+let find_inst_info ~loc axiom instances_map =
+  match MS.find axiom instances_map with
+  | exception Not_found -> empty_inst_info loc
+  | ii ->
+    if ii.loc != loc
+    then
+      Errors.internal_error
+        "Instances for axiom '%s' have incompatible locations.@ @ \
+         @[<v 2>Previous location was:@ %a@]@ \
+         @[<v 2>Now registering at location:@ %a@]\
+        "
+        axiom Loc.report ii.loc Loc.report loc;
+    ii
+
 let new_instance_of axiom inst loc kept =
   if_profiling @@ fun state ->
   let () = state.instances_map_printed <- false in
-  let ii =
-    try MS.find axiom state.instances_map
-    with Not_found -> empty_inst_info loc
-  in
-  assert (ii.loc == loc);
+  let ii = find_inst_info ~loc axiom state.instances_map in
   let ii =
     if kept then
       {ii with kept = ii.kept + 1; all_insts = SE.add inst ii.all_insts}
@@ -256,11 +266,7 @@ let decision d origin =
 
 let register_produced_terms axiom loc consumed all produced _new =
   if_profiling @@ fun state ->
-  let ii =
-    try MS.find axiom state.instances_map
-    with Not_found -> empty_inst_info loc
-  in
-  assert (ii.loc == loc);
+  let ii = find_inst_info ~loc axiom state.instances_map in
   let ii =
     {ii with
      consumed = SE.union ii.consumed consumed;


### PR DESCRIPTION
Using a dummy location breaks assertions in the profiling module.