### PR TITLE
Attach time spent before starting a timer to the correct module

### DIFF
--- a/src/lib/util/timers.ml
+++ b/src/lib/util/timers.ml
@@ -262,7 +262,7 @@ let start env m f =
   begin
     match env.cur_t with
     | (M_None, _, _) -> ()
-    | kd ->
+    | (m, f, _) as kd ->
       accumulate env cur m f;
       env.stack <- kd :: env.stack
   end;


### PR DESCRIPTION
If we start a profiling timer in module [m1] then, after some time [dt], another timer in module [m2], the elapsed time [dt] should be counted as time passed in module [m1]. Unfortunately we currently count it in module [m2], which is plain wrong.

This patch makes it so that we now properly account the elapsed time as time spent in module [m1], i.e. the current module *before* starting the new timer.