### PR TITLE
matching: Separate trigger inference from actual matching

### DIFF
--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -400,16 +400,16 @@ module Make (Th : Theory.S) = struct
       | E.Let _ | E.Iff _ | E.Xor _ -> true
     end
 
-  let inst_predicates mconf env inst tbox selector ilvl =
-    try Inst.m_predicates mconf inst tbox selector ilvl
+  let inst_predicates mconf tconf env inst tbox selector ilvl =
+    try Inst.m_predicates mconf tconf inst tbox selector ilvl
     with Ex.Inconsistent (expl, classes) ->
       Debug.inconsistent expl env;
       Options.tool_req 2 "TR-Sat-Conflict-2";
       env.heuristics := Heuristics.bump_activity !(env.heuristics) expl;
       raise (IUnsat (expl, classes))
 
-  let inst_lemmas mconf env inst tbox selector ilvl =
-    try Inst.m_lemmas mconf inst tbox selector ilvl
+  let inst_lemmas mconf tconf env inst tbox selector ilvl =
+    try Inst.m_lemmas mconf tconf inst tbox selector ilvl
     with Ex.Inconsistent (expl, classes) ->
       Debug.inconsistent expl env;
       Options.tool_req 2 "TR-Sat-Conflict-2";
@@ -880,9 +880,9 @@ module Make (Th : Theory.S) = struct
     update_instances_cache, clear_instances_cache
 
   (* returns the (new) env and true if some new instances are made *)
-  let inst_and_assume mconf env inst_function inst_env =
+  let inst_and_assume mconf tconf env inst_function inst_env =
     let gd, ngd =
-      inst_function mconf env inst_env env.tbox (selector env) env.ilevel
+      inst_function mconf tconf env inst_env env.tbox (selector env) env.ilevel
     in
     let l = List.rev_append (List.rev gd) ngd in
 
@@ -1052,6 +1052,46 @@ module Make (Th : Theory.S) = struct
       let nb_ok = ref 0 in
       aux_rec ~rm_clauses env inst loop nb_ok, !nb_ok > 0
 
+  let greedy_mconf () =
+    {Util.no_ematching = false;
+     use_cs = true;
+     backward = Util.Normal;
+    }
+
+  let normal_mconf () =
+    let open Options in
+    {Util.no_ematching = get_no_ematching();
+     use_cs = false;
+     backward = Util.Normal;
+    }
+
+  let backward_mconf ()  =
+    let open Options in
+    {Util.no_ematching = get_no_ematching();
+     use_cs = false;
+     backward = Util.Backward;
+    }
+
+  let greedy_tconf () =
+    {Util.nb_triggers = max 10 (Options.get_nb_triggers () * 10);
+     triggers_var = true;
+     greedy = true;
+    }
+
+  let normal_tconf () =
+    let open Options in
+    {Util.nb_triggers = get_nb_triggers ();
+     triggers_var = get_triggers_var ();
+     greedy = get_greedy ();
+    }
+
+  let backward_tconf ()  =
+    let open Options in
+    {Util.nb_triggers = get_nb_triggers ();
+     triggers_var = get_triggers_var ();
+     greedy = get_greedy ();
+    }
+
   let greedy_instantiation env =
     match Options.get_instantiation_heuristic () with
     | INormal ->
@@ -1066,17 +1106,10 @@ module Make (Th : Theory.S) = struct
           env.gamma env.inst
       in
       let env = new_inst_level env in
-      let mconf =
-        {Util.nb_triggers = max 10 (Options.get_nb_triggers () * 10);
-         no_ematching = false;
-         triggers_var = true;
-         use_cs = true;
-         backward = Util.Normal;
-         greedy = true;
-        }
-      in
-      let env, ok1 = inst_and_assume mconf env inst_predicates gre_inst in
-      let env, ok2 = inst_and_assume mconf env inst_lemmas gre_inst in
+      let mconf = greedy_mconf () in
+      let tconf = greedy_tconf () in
+      let env, ok1 = inst_and_assume mconf tconf env inst_predicates gre_inst in
+      let env, ok2 = inst_and_assume mconf tconf env inst_lemmas gre_inst in
       let env, ok3 = syntactic_th_inst env gre_inst ~rm_clauses:false in
       let env, ok4 =
         semantic_th_inst  env gre_inst ~rm_clauses:false ~loop:4 in
@@ -1090,17 +1123,10 @@ module Make (Th : Theory.S) = struct
     Debug.print_nb_related env;
     let env = do_case_split env Util.BeforeMatching in
     let env = new_inst_level env in
-    let mconf =
-      {Util.nb_triggers = Options.get_nb_triggers ();
-       no_ematching = Options.get_no_ematching();
-       triggers_var = Options.get_triggers_var ();
-       use_cs = false;
-       backward = Util.Normal;
-       greedy = Options.get_greedy ();
-      }
-    in
-    let env, ok1 = inst_and_assume mconf env inst_predicates env.inst in
-    let env, ok2 = inst_and_assume mconf env inst_lemmas env.inst in
+    let mconf = normal_mconf () in
+    let tconf = normal_tconf () in
+    let env, ok1 = inst_and_assume mconf tconf env inst_predicates env.inst in
+    let env, ok2 = inst_and_assume mconf tconf env inst_lemmas env.inst in
     let env, ok3 = syntactic_th_inst env env.inst ~rm_clauses:false in
     let env, ok4 = semantic_th_inst  env env.inst ~rm_clauses:false ~loop:4 in
     let env = do_case_split env Util.AfterMatching in
@@ -1255,18 +1281,12 @@ module Make (Th : Theory.S) = struct
           ~module_name:"Fun_sat"
           ~function_name:"backward_instantiation_rec"
           "round %d / %d@ " rnd max_rnd;
-      let mconf =
-        let open Options in
-        {Util.nb_triggers = get_nb_triggers ();
-         no_ematching = get_no_ematching();
-         triggers_var = get_triggers_var ();
-         use_cs = false;
-         greedy = get_greedy ();
-         backward = Util.Backward;
-        }
+      let mconf = backward_mconf () in
+      let tconf = backward_tconf () in
+      let env, new_i1 =
+        inst_and_assume mconf tconf env inst_predicates env.inst
       in
-      let env, new_i1 = inst_and_assume mconf env inst_predicates env.inst in
-      let env, new_i2 = inst_and_assume mconf env inst_lemmas env.inst in
+      let env, new_i2 = inst_and_assume mconf tconf env inst_lemmas env.inst in
       let nb2 = env.nb_related_to_goal in
       let nc2 = env.nb_related_to_hypo in
       if Options.(get_verbose () || get_debug_sat ()) then
@@ -1433,24 +1453,16 @@ module Make (Th : Theory.S) = struct
       let env, _ = syntactic_th_inst env env.inst ~rm_clauses:true in
       let env, _ = semantic_th_inst  env env.inst ~rm_clauses:true ~loop:4 in
 
-      let mconf =
-        let open Options in
-        {Util.nb_triggers = get_nb_triggers ();
-         no_ematching = get_no_ematching();
-         triggers_var = get_triggers_var ();
-         use_cs = false;
-         backward = Util.Normal;
-         greedy = get_greedy ();
-        }
-      in
-      let env, _ = inst_and_assume mconf env inst_predicates env.inst in
+      let mconf = normal_mconf () in
+      let tconf = normal_tconf () in
+      let env, _ = inst_and_assume mconf tconf env inst_predicates env.inst in
 
       let env, _ = syntactic_th_inst env env.inst ~rm_clauses:true in
       let env, _ = semantic_th_inst  env env.inst ~rm_clauses:true ~loop:4 in
 
       (* goal directed for lemmas *)
       let gd, _ =
-        inst_lemmas mconf  env env.inst env.tbox (selector env) env.ilevel
+        inst_lemmas mconf tconf env env.inst env.tbox (selector env) env.ilevel
       in
       if Options.get_profiling() then Profiling.instances gd;
       let env = assume env gd in

--- a/src/lib/reasoners/fun_sat.ml
+++ b/src/lib/reasoners/fun_sat.ml
@@ -1594,6 +1594,7 @@ module Make (Th : Theory.S) = struct
     Ty.reinit_decls ();
     IntervalCalculus.reinit_cache ();
     Inst.reinit_em_cache ();
+    Matching.Triggers.reinit_caches ();
     Expr.reinit_cache ();
     Hstring.reinit_cache ();
     Shostak.Combine.reinit_cache ();

--- a/src/lib/reasoners/instances.ml
+++ b/src/lib/reasoners/instances.ml
@@ -55,6 +55,7 @@ module type S = sig
 
   val m_lemmas :
     Util.matching_env ->
+    Util.triggers_env ->
     t ->
     tbox ->
     (E.t -> E.t -> bool) ->
@@ -63,6 +64,7 @@ module type S = sig
 
   val m_predicates :
     Util.matching_env ->
+    Util.triggers_env ->
     t ->
     tbox ->
     (E.t -> E.t -> bool) ->
@@ -363,15 +365,15 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     Timers.with_timer Timers.M_Match Timers.F_new_facts @@ fun () ->
     new_facts env tbox selector substs
 
-  let mround env axs tbox selector ilvl kind mconf =
+  let mround env axs tbox selector ilvl kind mconf tconf =
     Debug.new_mround ilvl kind;
     Options.tool_req 2 "TR-Sat-Mround";
     let triggers =
       Matching.Triggers.add_triggers_of_formulas
-        mconf Matching.Triggers.empty axs
+        mconf tconf Matching.Triggers.empty axs
     in
     let ccx_tbox =
-      if mconf.Util.use_cs || mconf.Util.greedy then X.get_case_split_env tbox
+      if mconf.Util.use_cs || tconf.Util.greedy then X.get_case_split_env tbox
       else X.get_real_env tbox
     in
     let substs = EM.query mconf env.matching triggers ccx_tbox in
@@ -379,11 +381,11 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     let gd, ngd = split_and_filter_insts env insts in
     sort_facts gd, sort_facts ngd
 
-  let m_lemmas env tbox selector ilvl mconf =
-    mround env env.lemmas tbox selector ilvl "axioms" mconf
+  let m_lemmas env tbox selector ilvl mconf tconf =
+    mround env env.lemmas tbox selector ilvl "axioms" mconf tconf
 
-  let m_predicates env tbox selector ilvl mconf =
-    mround env env.predicates tbox selector ilvl "predicates" mconf
+  let m_predicates env tbox selector ilvl mconf tconf =
+    mround env env.predicates tbox selector ilvl "predicates" mconf tconf
 
   let add_lemma env gf dep =
     let guard = E.vrai in
@@ -415,12 +417,12 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     Timers.with_timer Timers.M_Match Timers.F_add_predicate @@ fun () ->
     add_predicate env ~guard ~name gf
 
-  let m_lemmas mconf env tbox selector ilvl =
+  let m_lemmas mconf tconf env tbox selector ilvl =
     Timers.with_timer Timers.M_Match Timers.F_m_lemmas @@ fun () ->
-    m_lemmas env tbox selector ilvl mconf
+    m_lemmas env tbox selector ilvl mconf tconf
 
-  let m_predicates mconf env tbox selector ilvl =
+  let m_predicates mconf tconf env tbox selector ilvl =
     Timers.with_timer Timers.M_Match Timers.F_m_predicates @@ fun () ->
-    m_predicates env tbox selector ilvl mconf
+    m_predicates env tbox selector ilvl mconf tconf
 
 end

--- a/src/lib/reasoners/instances.ml
+++ b/src/lib/reasoners/instances.ml
@@ -366,13 +366,15 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
   let mround env axs tbox selector ilvl kind mconf =
     Debug.new_mround ilvl kind;
     Options.tool_req 2 "TR-Sat-Mround";
-    let env =
-      {env with matching = EM.add_triggers mconf env.matching axs} in
+    let triggers =
+      Matching.Triggers.add_triggers_of_formulas
+        mconf Matching.Triggers.empty axs
+    in
     let ccx_tbox =
       if mconf.Util.use_cs || mconf.Util.greedy then X.get_case_split_env tbox
       else X.get_real_env tbox
     in
-    let substs = EM.query mconf env.matching ccx_tbox in
+    let substs = EM.query mconf env.matching triggers ccx_tbox in
     let insts = new_facts env tbox selector substs in
     let gd, ngd = split_and_filter_insts env insts in
     sort_facts gd, sort_facts ngd

--- a/src/lib/reasoners/instances.ml
+++ b/src/lib/reasoners/instances.ml
@@ -369,14 +369,23 @@ module Make(X : Theory.S) : S with type tbox = X.t = struct
     Debug.new_mround ilvl kind;
     Options.tool_req 2 "TR-Sat-Mround";
     let triggers =
-      Matching.Triggers.add_triggers_of_formulas
-        mconf tconf Matching.Triggers.empty axs
+      match mconf.Util.backward with
+      | Util.Normal ->
+        Matching.Triggers.add_triggers_of_formulas tconf
+          Matching.Triggers.empty axs
+      | Util.Backward ->
+        Matching.Triggers.add_backward_triggers_of_formulas
+          Matching.Triggers.empty axs
+      | Util.Forward ->
+        Matching.Triggers.add_forward_triggers_of_formulas
+          Matching.Triggers.empty axs
     in
     let ccx_tbox =
       if mconf.Util.use_cs || tconf.Util.greedy then X.get_case_split_env tbox
       else X.get_real_env tbox
     in
-    let substs = EM.query mconf env.matching triggers ccx_tbox in
+    let use_ematching = not mconf.Util.no_ematching in
+    let substs = EM.query ~use_ematching env.matching triggers ccx_tbox in
     let insts = new_facts env tbox selector substs in
     let gd, ngd = split_and_filter_insts env insts in
     sort_facts gd, sort_facts ngd

--- a/src/lib/reasoners/instances.mli
+++ b/src/lib/reasoners/instances.mli
@@ -50,6 +50,7 @@ module type S = sig
 
   val m_lemmas :
     Util.matching_env ->
+    Util.triggers_env ->
     t ->
     tbox ->
     (Expr.t -> Expr.t -> bool) ->
@@ -58,6 +59,7 @@ module type S = sig
 
   val m_predicates :
     Util.matching_env ->
+    Util.triggers_env ->
     t ->
     tbox ->
     (Expr.t -> Expr.t -> bool) ->

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2451,12 +2451,7 @@ let new_facts_for_axiom
 
 
 let syntactic_matching menv env uf _selector =
-  let mconf =
-    {Util.no_ematching = get_no_ematching();
-     use_cs = false;
-     backward = Util.Normal;
-    }
-  in
+  let use_ematching = not (get_no_ematching ()) in
   let tconf =
     {Util.nb_triggers = get_nb_triggers ();
      triggers_var = get_triggers_var ();
@@ -2470,9 +2465,9 @@ let syntactic_matching menv env uf _selector =
          let forms = ME.singleton f (E.vrai, 0 (*0 = age *), dep) in
          let triggers =
            Matching.Triggers.add_triggers_of_formulas
-             mconf tconf Matching.Triggers.empty forms
+             tconf Matching.Triggers.empty forms
          in
-         let res = EM.query mconf menv triggers uf in
+         let res = EM.query ~use_ematching menv triggers uf in
          if get_debug_fpa () >= 2 then begin
            let cpt = ref 0 in
            List.iter (fun (_, l) -> List.iter (fun _ -> incr cpt) l) res;

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2452,11 +2452,14 @@ let new_facts_for_axiom
 
 let syntactic_matching menv env uf _selector =
   let mconf =
-    {Util.nb_triggers = get_nb_triggers ();
-     no_ematching = get_no_ematching();
-     triggers_var = get_triggers_var ();
+    {Util.no_ematching = get_no_ematching();
      use_cs = false;
      backward = Util.Normal;
+    }
+  in
+  let tconf =
+    {Util.nb_triggers = get_nb_triggers ();
+     triggers_var = get_triggers_var ();
      greedy = get_greedy ();
     }
   in
@@ -2467,7 +2470,7 @@ let syntactic_matching menv env uf _selector =
          let forms = ME.singleton f (E.vrai, 0 (*0 = age *), dep) in
          let triggers =
            Matching.Triggers.add_triggers_of_formulas
-             mconf Matching.Triggers.empty forms
+             mconf tconf Matching.Triggers.empty forms
          in
          let res = EM.query mconf menv triggers uf in
          if get_debug_fpa () >= 2 then begin

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -2465,8 +2465,11 @@ let syntactic_matching menv env uf _selector =
       (fun f (_th_ax, dep) accu ->
          (* currently, No diff between propagators and case-split axs *)
          let forms = ME.singleton f (E.vrai, 0 (*0 = age *), dep) in
-         let menv = EM.add_triggers mconf menv forms in
-         let res = EM.query mconf menv uf in
+         let triggers =
+           Matching.Triggers.add_triggers_of_formulas
+             mconf Matching.Triggers.empty forms
+         in
+         let res = EM.query mconf menv triggers uf in
          if get_debug_fpa () >= 2 then begin
            let cpt = ref 0 in
            List.iter (fun (_, l) -> List.iter (fun _ -> incr cpt) l) res;
@@ -2488,7 +2491,7 @@ let instantiate ~do_syntactic_matching match_terms env uf selector =
       "entering IC.instantiate";
   let optimized = ref (SP.empty) in
   let t_infos, t_subterms = match_terms in
-  let menv = EM.make ~max_t_depth:100 t_infos t_subterms [] in
+  let menv = EM.make ~max_t_depth:100 t_infos t_subterms in
   let env =
     if not do_syntactic_matching then env
     else syntactic_matching menv env uf selector

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -36,7 +36,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module HEI = Hashtbl.Make (
   struct
     open Util
-    type t = E.t * Util.matching_env
+    type t = E.t * Util.triggers_env
     let hash (e, mc) =
       abs @@
       E.hash e *
@@ -117,14 +117,14 @@ module Triggers = struct
     in
     forward_triggers, clear_forward_triggers_trs_tbl
 
-  let add_triggers_of_formulas mconf env formulas =
+  let add_triggers_of_formulas mconf tconf env formulas =
     ME.fold
       (fun lem (guard, age, dep) env ->
          match E.form_view lem with
          | E.Lemma ({ E.main = f; name; _ } as q) ->
            let tgs, kind =
              match mconf.Util.backward with
-             | Util.Normal   -> triggers_of q mconf, "Normal"
+             | Util.Normal   -> triggers_of q tconf, "Normal"
              | Util.Backward -> backward_triggers q, "Backward"
              | Util.Forward  -> forward_triggers q, "Forward"
            in

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -117,17 +117,12 @@ module Triggers = struct
     in
     forward_triggers, clear_forward_triggers_trs_tbl
 
-  let add_triggers_of_formulas mconf tconf env formulas =
+  let add_triggers_of_formulas0 env formulas compute_triggers kind =
     ME.fold
       (fun lem (guard, age, dep) env ->
          match E.form_view lem with
          | E.Lemma ({ E.main = f; name; _ } as q) ->
-           let tgs, kind =
-             match mconf.Util.backward with
-             | Util.Normal   -> triggers_of q tconf, "Normal"
-             | Util.Backward -> backward_triggers q, "Backward"
-             | Util.Forward  -> forward_triggers q, "Forward"
-           in
+           let tgs = compute_triggers q in
            if Options.get_debug_triggers () then
              Printer.print_dbg
                ~module_name:"Matching" ~function_name:"add_triggers"
@@ -151,6 +146,15 @@ module Triggers = struct
          | E.Let _ | E.Iff _ | E.Xor _ -> assert false
       ) formulas env
 
+  let add_triggers_of_formulas tconf env formulas =
+    add_triggers_of_formulas0
+      env formulas (fun q -> triggers_of q tconf) "Normal"
+
+  let add_backward_triggers_of_formulas env formulas =
+    add_triggers_of_formulas0 env formulas backward_triggers "Backward"
+
+  let add_forward_triggers_of_formulas env formulas =
+    add_triggers_of_formulas0 env formulas forward_triggers "Forward"
 
   let reinit_caches () =
     clear_triggers_of_trs_tbl ();
@@ -175,7 +179,7 @@ module type S = sig
   val max_term_depth : t -> int -> t
   val terms_info : t -> Matching_types.info ME.t * E.t list ME.t Symbols.Map.t
   val query :
-    Util.matching_env -> t -> Triggers.t -> theory ->
+    use_ematching:bool -> t -> Triggers.t -> theory ->
     (Matching_types.trigger_info * Matching_types.gsubst list) list
 
   val reinit_caches : unit -> unit
@@ -454,8 +458,8 @@ module Make (X : Arg) : S with type theory = X.t = struct
            | Util.Cmp n -> n
     end)
 
-  let filter_classes mconf cl tbox =
-    if mconf.Util.no_ematching then cl
+  let filter_classes ~use_ematching cl tbox =
+    if not use_ematching then cl
     else
       let mtl =
         List.fold_left
@@ -491,7 +495,7 @@ module Make (X : Arg) : S with type theory = X.t = struct
         else if E.is_ground p1 then [minus_of_plus t p1 ty] else []
       | _ -> []
 
-  let rec match_term mconf env tbox
+  let rec match_term ~use_ematching env tbox
       ({ sty = s_ty; gen = g; goal = b; _ } as sg : Matching_types.gsubst)
       pat t =
     Options.exec_thread_yield ();
@@ -527,7 +531,7 @@ module Make (X : Arg) : S with type theory = X.t = struct
         if ignore_match then
           [gsb]
         else
-          let cl = if mconf.Util.no_ematching then E.Set.singleton t
+          let cl = if not use_ematching then E.Set.singleton t
             else X.class_of tbox t
           in
           Debug.match_class_of t cl;
@@ -539,33 +543,33 @@ module Make (X : Arg) : S with type theory = X.t = struct
                  else l
               ) cl []
           in
-          let cl = filter_classes mconf cl tbox in
+          let cl = filter_classes ~use_ematching cl tbox in
           let cl =
             if cl != [] then cl
             else linear_arithmetic_matching f_pat pats ty_pat t
           in
           List.fold_left
             (fun acc xs ->
-               try (match_list mconf env tbox gsb pats xs) -@ acc
+               try (match_list ~use_ematching env tbox gsb pats xs) -@ acc
                with Echec -> acc
             ) [] cl
       with Ty.TypeClash _ -> raise Echec
 
-  and match_list mconf env tbox sg pats xs =
+  and match_list ~use_ematching env tbox sg pats xs =
     Debug.match_list sg pats xs;
     try
       List.fold_left2
         (fun sb_l pat arg ->
            List.fold_left
              (fun acc sg ->
-                let aux = match_term mconf env tbox sg pat arg in
+                let aux = match_term ~use_ematching env tbox sg pat arg in
                 (*match aux with [] -> raise Echec | _  -> BUG !! *)
                 List.rev_append aux acc
              ) [] sb_l
         ) [sg] pats xs
     with Invalid_argument _ -> raise Echec
 
-  let match_one_pat mconf env tbox pat0 lsbt_acc sg =
+  let match_one_pat ~use_ematching env tbox pat0 lsbt_acc sg =
     Steps.incr (Steps.Matching);
     Debug.match_one_pat sg pat0;
     let pat = E.apply_subst (sg.sbs, sg.sty) pat0 in
@@ -588,18 +592,18 @@ module Make (X : Arg) : S with type theory = X.t = struct
                 sty = s_ty; gen = gen; goal = but;
                 s_term_orig = t::sg.s_term_orig }
             in
-            let aux = match_list mconf env tbox sg pats xs in
+            let aux = match_list ~use_ematching env tbox sg pats xs in
             List.rev_append aux lsbt
           with Echec | Ty.TypeClash _ -> lsbt
       in
       try ME.fold f_aux (Symbols.Map.find f env.fils) lsbt_acc
       with Not_found -> lsbt_acc
 
-  let match_pats_modulo mconf env tbox lsubsts pat =
+  let match_pats_modulo ~use_ematching env tbox lsubsts pat =
     Debug.match_pats_modulo pat lsubsts;
-    List.fold_left (match_one_pat mconf env tbox pat) [] lsubsts
+    List.fold_left (match_one_pat ~use_ematching env tbox pat) [] lsubsts
 
-  let matching mconf env tbox pat_info =
+  let matching ~use_ematching env tbox pat_info =
     let open Matching_types in
     let pats = pat_info.trigger in
     let pats_list = pats.E.content in
@@ -620,7 +624,9 @@ module Make (X : Arg) : S with type theory = X.t = struct
       | []  -> pat_info, []
       | [_] ->
         let res =
-          List.fold_left (match_pats_modulo mconf env tbox) [egs] pats_list in
+          List.fold_left
+            (match_pats_modulo ~use_ematching env tbox) [egs] pats_list
+        in
         Debug.candidate_substitutions pat_info res;
         pat_info, res
       | _ ->
@@ -629,12 +635,15 @@ module Make (X : Arg) : S with type theory = X.t = struct
           List.iter
             (fun pat ->
                cpt := !cpt *
-                      List.length (match_pats_modulo mconf env tbox [egs] pat);
+                      List.length
+                        (match_pats_modulo ~use_ematching env tbox [egs] pat);
                (* TODO: put an adaptive limit *)
                if !cpt = 0 || !cpt > 10_000 then raise Exit
             ) (List.rev pats_list);
           let res =
-            List.fold_left (match_pats_modulo mconf env tbox) [egs] pats_list
+            List.fold_left
+              (match_pats_modulo ~use_ematching env tbox)
+              [egs] pats_list
           in
           Debug.candidate_substitutions pat_info res;
           pat_info, res
@@ -650,11 +659,11 @@ module Make (X : Arg) : S with type theory = X.t = struct
     cache_are_equal_light := MT2.empty;
     cache_are_equal_full  := MT2.empty
 
-  let query mconf env triggers tbox =
+  let query ~use_ematching env triggers tbox =
     reset_cache_refs ();
     try
       let res =
-        List.rev_map (matching mconf env tbox) triggers.Triggers.pats
+        List.rev_map (matching ~use_ematching env tbox) triggers.Triggers.pats
       in
       reset_cache_refs ();
       res
@@ -662,9 +671,9 @@ module Make (X : Arg) : S with type theory = X.t = struct
       reset_cache_refs ();
       raise e
 
-  let query env tbox =
+  let query ~use_ematching env triggers tbox =
     Timers.with_timer Timers.M_Match Timers.F_query @@ fun () ->
-    query env tbox
+    query ~use_ematching env triggers tbox
 
   let max_term_depth env mx = {env with max_t_depth = max env.max_t_depth mx}
 

--- a/src/lib/reasoners/matching.ml
+++ b/src/lib/reasoners/matching.ml
@@ -33,6 +33,132 @@ module SubstE = Var.Map
 let src = Logs.Src.create ~doc:"Matching" __MODULE__
 module Log = (val Logs.src_log src : Logs.LOG)
 
+module HEI = Hashtbl.Make (
+  struct
+    open Util
+    type t = E.t * Util.matching_env
+    let hash (e, mc) =
+      abs @@
+      E.hash e *
+      (mc.nb_triggers +
+       (if mc.triggers_var then 10 else -10) +
+       (if mc.greedy then 50 else - 50)
+      )
+
+    let equal (e1, mc1) (e2, mc2) =
+      E.equal e1 e2 &&
+      mc1.nb_triggers == mc2.nb_triggers &&
+      mc1.triggers_var == mc2.triggers_var &&
+      mc1.greedy == mc2.greedy
+
+  end)
+
+module HE = Hashtbl.Make (E)
+
+module Triggers = struct
+  type t =
+    { pats : Matching_types.trigger_info list }
+  [@@unboxed]
+
+  let empty =
+    { pats = [] }
+
+  let add p triggers =
+    { pats = p :: triggers.pats }
+
+  let triggers_of, clear_triggers_of_trs_tbl =
+    let trs_tbl = HEI.create 101 in
+    let triggers_of q mconf =
+      match q.E.user_trs with
+      | _::_ as l -> l
+      | [] ->
+        try HEI.find trs_tbl (q.E.main, mconf)
+        with Not_found ->
+          let trs =
+            E.make_triggers q.E.main q.E.binders q.E.kind mconf
+          in
+          HEI.add trs_tbl (q.E.main, mconf) trs;
+          trs
+    in
+    let clear_triggers_of_trs_tbl () =
+      HEI.clear trs_tbl
+    in
+    triggers_of, clear_triggers_of_trs_tbl
+
+  let backward_triggers, clear_backward_triggers_trs_tbl =
+    let trs_tbl = HE.create 101 in
+    let backward_triggers q =
+      try HE.find trs_tbl q.E.main
+      with Not_found ->
+        let trs =
+          E.resolution_triggers ~is_back:true q
+        in
+        HE.add trs_tbl q.E.main trs;
+        trs
+    in
+    let clear_backward_triggers_trs_tbl () =
+      HE.clear trs_tbl
+    in
+    backward_triggers, clear_backward_triggers_trs_tbl
+
+  let forward_triggers, clear_forward_triggers_trs_tbl =
+    let trs_tbl = HE.create 101 in
+    let forward_triggers q =
+      try HE.find trs_tbl q.E.main
+      with Not_found ->
+        let trs =
+          E.resolution_triggers ~is_back:false q
+        in
+        HE.add trs_tbl q.E.main trs;
+        trs
+    in
+    let clear_forward_triggers_trs_tbl () =
+      HE.clear trs_tbl
+    in
+    forward_triggers, clear_forward_triggers_trs_tbl
+
+  let add_triggers_of_formulas mconf env formulas =
+    ME.fold
+      (fun lem (guard, age, dep) env ->
+         match E.form_view lem with
+         | E.Lemma ({ E.main = f; name; _ } as q) ->
+           let tgs, kind =
+             match mconf.Util.backward with
+             | Util.Normal   -> triggers_of q mconf, "Normal"
+             | Util.Backward -> backward_triggers q, "Backward"
+             | Util.Forward  -> forward_triggers q, "Forward"
+           in
+           if Options.get_debug_triggers () then
+             Printer.print_dbg
+               ~module_name:"Matching" ~function_name:"add_triggers"
+               "@[<v 2>%s triggers of %s are:@ %a@]"
+               kind name E.print_triggers tgs;
+           List.fold_left
+             (fun triggers tr ->
+                let info =
+                  Matching_types.{ trigger = tr;
+                                   trigger_age = age ;
+                                   trigger_orig = lem ;
+                                   trigger_formula = f ;
+                                   trigger_dep = dep;
+                                   trigger_increm_guard = guard
+                                 }
+                in
+                add info triggers
+             ) env tgs
+
+         | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
+         | E.Let _ | E.Iff _ | E.Xor _ -> assert false
+      ) formulas env
+
+
+  let reinit_caches () =
+    clear_triggers_of_trs_tbl ();
+    clear_backward_triggers_trs_tbl ();
+    clear_forward_triggers_trs_tbl ()
+end
+
+
 module type S = sig
   type t
   type theory
@@ -43,16 +169,13 @@ module type S = sig
     max_t_depth:int ->
     Matching_types.info ME.t ->
     E.t list ME.t Symbols.Map.t ->
-    Matching_types.trigger_info list ->
     t
 
   val add_term : Matching_types.term_info -> E.t -> t -> t
   val max_term_depth : t -> int -> t
-  val add_triggers :
-    Util.matching_env -> t -> (Expr.t * int * Explanation.t) ME.t -> t
   val terms_info : t -> Matching_types.info ME.t * E.t list ME.t Symbols.Map.t
   val query :
-    Util.matching_env -> t -> theory ->
+    Util.matching_env -> t -> Triggers.t -> theory ->
     (Matching_types.trigger_info * Matching_types.gsubst list) list
 
   val reinit_caches : unit -> unit
@@ -74,7 +197,6 @@ module Make (X : Arg) : S with type theory = X.t = struct
     fils : E.t list ME.t Symbols.Map.t ;
     info : Matching_types.info ME.t ;
     max_t_depth : int;
-    pats : Matching_types.trigger_info list
   }
 
   exception Echec
@@ -82,11 +204,11 @@ module Make (X : Arg) : S with type theory = X.t = struct
   let empty = {
     fils = Symbols.Map.empty ;
     info = ME.empty ;
-    pats = [ ];
     max_t_depth = 0;
   }
 
-  let make ~max_t_depth info fils pats = { fils; info; pats; max_t_depth }
+  let make ~max_t_depth info fils =
+    { fils; info; max_t_depth }
 
   let age_limite = Options.get_age_bound
   (* l'age limite des termes, au dela ils ne sont pas consideres par le
@@ -228,8 +350,6 @@ module Make (X : Arg) : S with type theory = X.t = struct
         List.fold_left add_rec env xs
     in
     if info.term_age > age_limite () then env else add_rec env t
-
-  let add_trigger p env = { env with pats = p :: env.pats }
 
   let all_terms
       f ty env tbox
@@ -530,10 +650,12 @@ module Make (X : Arg) : S with type theory = X.t = struct
     cache_are_equal_light := MT2.empty;
     cache_are_equal_full  := MT2.empty
 
-  let query mconf env tbox =
+  let query mconf env triggers tbox =
     reset_cache_refs ();
     try
-      let res = List.rev_map (matching mconf env tbox) env.pats in
+      let res =
+        List.rev_map (matching mconf env tbox) triggers.Triggers.pats
+      in
       reset_cache_refs ();
       res
     with e ->
@@ -576,119 +698,9 @@ module Make (X : Arg) : S with type theory = X.t = struct
       )[] triggers |> List.rev
   *)
 
-  module HEI = Hashtbl.Make (
-    struct
-      open Util
-      type t = E.t * Util.matching_env
-      let hash (e, mc) =
-        abs @@
-        E.hash e *
-        (mc.nb_triggers +
-         (if mc.triggers_var then 10 else -10) +
-         (if mc.greedy then 50 else - 50)
-        )
-
-      let equal (e1, mc1) (e2, mc2) =
-        E.equal e1 e2 &&
-        mc1.nb_triggers == mc2.nb_triggers &&
-        mc1.triggers_var == mc2.triggers_var &&
-        mc1.greedy == mc2.greedy
-
-    end)
-
-  module HE = Hashtbl.Make (E)
-
-  let triggers_of, clear_triggers_of_trs_tbl =
-    let trs_tbl = HEI.create 101 in
-    let triggers_of q mconf =
-      match q.E.user_trs with
-      | _::_ as l -> l
-      | [] ->
-        try HEI.find trs_tbl (q.E.main, mconf)
-        with Not_found ->
-          let trs =
-            E.make_triggers q.E.main q.E.binders q.E.kind mconf
-          in
-          HEI.add trs_tbl (q.E.main, mconf) trs;
-          trs
-    in
-    let clear_triggers_of_trs_tbl () =
-      HEI.clear trs_tbl
-    in
-    triggers_of, clear_triggers_of_trs_tbl
-
-  let backward_triggers, clear_backward_triggers_trs_tbl =
-    let trs_tbl = HE.create 101 in
-    let backward_triggers q =
-      try HE.find trs_tbl q.E.main
-      with Not_found ->
-        let trs =
-          E.resolution_triggers ~is_back:true q
-        in
-        HE.add trs_tbl q.E.main trs;
-        trs
-    in
-    let clear_backward_triggers_trs_tbl () =
-      HE.clear trs_tbl
-    in
-    backward_triggers, clear_backward_triggers_trs_tbl
-
-  let forward_triggers, clear_forward_triggers_trs_tbl =
-    let trs_tbl = HE.create 101 in
-    let forward_triggers q =
-      try HE.find trs_tbl q.E.main
-      with Not_found ->
-        let trs =
-          E.resolution_triggers ~is_back:false q
-        in
-        HE.add trs_tbl q.E.main trs;
-        trs
-    in
-    let clear_forward_triggers_trs_tbl () =
-      HE.clear trs_tbl
-    in
-    forward_triggers, clear_forward_triggers_trs_tbl
-
-  let add_triggers mconf env formulas =
-    ME.fold
-      (fun lem (guard, age, dep) env ->
-         match E.form_view lem with
-         | E.Lemma ({ E.main = f; name; _ } as q) ->
-           let tgs, kind =
-             match mconf.Util.backward with
-             | Util.Normal   -> triggers_of q mconf, "Normal"
-             | Util.Backward -> backward_triggers q, "Backward"
-             | Util.Forward  -> forward_triggers q, "Forward"
-           in
-           if Options.get_debug_triggers () then
-             Printer.print_dbg
-               ~module_name:"Matching" ~function_name:"add_triggers"
-               "@[<v 2>%s triggers of %s are:@ %a@]"
-               kind name E.print_triggers tgs;
-           List.fold_left
-             (fun env tr ->
-                let info =
-                  Matching_types.{ trigger = tr;
-                                   trigger_age = age ;
-                                   trigger_orig = lem ;
-                                   trigger_formula = f ;
-                                   trigger_dep = dep;
-                                   trigger_increm_guard = guard
-                                 }
-                in
-                add_trigger info env
-             ) env tgs
-
-         | E.Unit _ | E.Clause _ | E.Literal _ | E.Skolem _
-         | E.Let _ | E.Iff _ | E.Xor _ -> assert false
-      ) formulas env
-
   let terms_info env = env.info, env.fils
 
   let reinit_caches () =
-    clear_triggers_of_trs_tbl ();
-    clear_backward_triggers_trs_tbl ();
-    clear_forward_triggers_trs_tbl ();
     reset_cache_refs ()
 
 end

--- a/src/lib/reasoners/matching.mli
+++ b/src/lib/reasoners/matching.mli
@@ -27,6 +27,18 @@
 
 val src : Logs.src
 
+module Triggers : sig
+  type t
+
+  val empty : t
+
+  val add_triggers_of_formulas :
+    Util.matching_env -> t -> (Expr.t * int * Explanation.t) Expr.Map.t -> t
+
+  val reinit_caches : unit -> unit
+  (** Empties the e-matching caches *)
+end
+
 module type S = sig
   type t
   type theory
@@ -38,16 +50,17 @@ module type S = sig
     max_t_depth:int ->
     Matching_types.info Expr.Map.t ->
     Expr.t list Expr.Map.t Symbols.Map.t ->
-    Matching_types.trigger_info list ->
     t
 
   val add_term : term_info -> Expr.t -> t -> t
   val max_term_depth : t -> int -> t
-  val add_triggers :
-    Util.matching_env -> t -> (Expr.t * int * Explanation.t) Expr.Map.t -> t
   val terms_info : t -> info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t
   val query :
-    Util.matching_env -> t -> theory -> (trigger_info * gsubst list) list
+    Util.matching_env ->
+    t ->
+    Triggers.t ->
+    theory ->
+    (trigger_info * gsubst list) list
 
   val reinit_caches : unit -> unit
   (** Empties the e-matching caches *)

--- a/src/lib/reasoners/matching.mli
+++ b/src/lib/reasoners/matching.mli
@@ -33,7 +33,11 @@ module Triggers : sig
   val empty : t
 
   val add_triggers_of_formulas :
-    Util.matching_env -> t -> (Expr.t * int * Explanation.t) Expr.Map.t -> t
+    Util.matching_env ->
+    Util.triggers_env ->
+    t ->
+    (Expr.t * int * Explanation.t) Expr.Map.t ->
+    t
 
   val reinit_caches : unit -> unit
   (** Empties the e-matching caches *)

--- a/src/lib/reasoners/matching.mli
+++ b/src/lib/reasoners/matching.mli
@@ -33,11 +33,13 @@ module Triggers : sig
   val empty : t
 
   val add_triggers_of_formulas :
-    Util.matching_env ->
-    Util.triggers_env ->
-    t ->
-    (Expr.t * int * Explanation.t) Expr.Map.t ->
-    t
+    Util.triggers_env -> t -> (Expr.t * int * Explanation.t) Expr.Map.t -> t
+
+  val add_backward_triggers_of_formulas :
+    t -> (Expr.t * int * Explanation.t) Expr.Map.t -> t
+
+  val add_forward_triggers_of_formulas :
+    t -> (Expr.t * int * Explanation.t) Expr.Map.t -> t
 
   val reinit_caches : unit -> unit
   (** Empties the e-matching caches *)
@@ -60,7 +62,7 @@ module type S = sig
   val max_term_depth : t -> int -> t
   val terms_info : t -> info Expr.Map.t * Expr.t list Expr.Map.t Symbols.Map.t
   val query :
-    Util.matching_env ->
+    use_ematching:bool ->
     t ->
     Triggers.t ->
     theory ->

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -1392,6 +1392,7 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     Ty.reinit_decls ();
     IntervalCalculus.reinit_cache ();
     Inst.reinit_em_cache ();
+    Matching.Triggers.reinit_caches ();
     Expr.reinit_cache ();
     Hstring.reinit_cache ();
     Shostak.Combine.reinit_cache ();

--- a/src/lib/reasoners/satml_frontend.ml
+++ b/src/lib/reasoners/satml_frontend.ml
@@ -420,15 +420,15 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
          | Ex.Bj _ | Ex.Fresh _ -> assert false
       ) ex []
 
-  let mround menv env acc =
+  let mround menv tenv env acc =
     let tbox = SAT.current_tbox env.satml in
     let gd2, ngd2 =
-      Inst.m_predicates menv env.inst tbox (selector env) env.nb_mrounds
+      Inst.m_predicates menv tenv env.inst tbox (selector env) env.nb_mrounds
     in
     let l2 = List.rev_append (List.rev gd2) ngd2 in
     if Options.get_profiling() then Profiling.instances l2;
     let gd1, ngd1 =
-      Inst.m_lemmas menv env.inst tbox (selector env) env.nb_mrounds
+      Inst.m_lemmas menv tenv env.inst tbox (selector env) env.nb_mrounds
     in
     let l1 = List.rev_append (List.rev gd1) ngd1 in
     if Options.get_profiling() then Profiling.instances l1;
@@ -734,10 +734,10 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
                        that are facts with TRUE by mk_lit (and simplify)"]
 
 
-  let new_instances use_cs env sa inst_quantif acc =
+  let new_instances use_cs tenv env sa inst_quantif acc =
     let inst, acc = inst_env_from_atoms env acc sa inst_quantif in
     let inst = terms_from_dec_proc {env with inst=inst} in
-    mround use_cs {env with inst = inst} acc
+    mround use_cs tenv {env with inst = inst} acc
 
 
   type pending = {
@@ -903,49 +903,63 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
 
   let frugal_mconf () =
     let open Options in
-    {Util.nb_triggers = get_nb_triggers ();
-     no_ematching = get_no_ematching();
-     triggers_var = get_triggers_var ();
+    {Util.no_ematching = get_no_ematching();
      use_cs = false;
      backward = Util.Normal;
-     greedy = false;
     }
 
   let normal_mconf () =
     let open Options in
-    {Util.nb_triggers = Stdlib.max 2 (get_nb_triggers () * 2);
-     no_ematching = get_no_ematching();
-     triggers_var = get_triggers_var ();
+    {Util.no_ematching = get_no_ematching();
      use_cs = false;
      backward = Util.Normal;
-     greedy = false;
     }
 
   let greedy_mconf () =
-    let open Options in
-    {Util.nb_triggers = Stdlib.max 10 (get_nb_triggers () * 10);
-     no_ematching = false;
-     triggers_var = get_triggers_var ();
+    {Util.no_ematching = false;
      use_cs = true;
      backward = Util.Normal;
-     greedy = true;
     }
 
   let greedier_mconf () =
-    let open Options in
-    {Util.nb_triggers = Stdlib.max 10 (get_nb_triggers () * 10);
-     no_ematching = false;
-     triggers_var = true;
+    {Util.no_ematching = false;
      use_cs = true;
      backward = Util.Normal;
+    }
+
+  let frugal_tconf () =
+    let open Options in
+    {Util.nb_triggers = get_nb_triggers ();
+     triggers_var = get_triggers_var ();
+     greedy = false;
+    }
+
+  let normal_tconf () =
+    let open Options in
+    {Util.nb_triggers = Stdlib.max 2 (get_nb_triggers () * 2);
+     triggers_var = get_triggers_var ();
+     greedy = false;
+    }
+
+  let greedy_tconf () =
+    let open Options in
+    {Util.nb_triggers = Stdlib.max 10 (get_nb_triggers () * 10);
+     triggers_var = get_triggers_var ();
      greedy = true;
     }
 
-  let do_instantiation env sa inst_quantif mconf msg ~dec_lvl =
+  let greedier_tconf () =
+    let open Options in
+    {Util.nb_triggers = Stdlib.max 10 (get_nb_triggers () * 10);
+     triggers_var = true;
+     greedy = true;
+    }
+
+  let do_instantiation env sa inst_quantif mconf tconf msg ~dec_lvl =
     Debug.new_instances msg env;
     let l = instantiate_ground_preds env [] sa in
     let l = expand_skolems env l sa inst_quantif in
-    let l = new_instances mconf env sa inst_quantif l in
+    let l = new_instances mconf tconf env sa inst_quantif l in
     assume_aux ~dec_lvl env l
 
   type instantiation_strat =
@@ -959,40 +973,45 @@ module Make (Th : Theory.S) : Sat_solver_sig.S = struct
     match inst_strat with
     | Force_normal ->
       let mconf = frugal_mconf () in (* take frugal_mconf if normal is forced *)
+      let tconf = frugal_tconf () in (* take frugal_tconf if normal is forced *)
       env.last_forced_normal <- nb_mrounds;
       let sa, inst_quantif =
         instantiation_context env ~greedy_round:false ~frugal:false in
-      do_instantiation env sa inst_quantif mconf "normal-inst (forced)" ~dec_lvl
+      do_instantiation
+        env sa inst_quantif mconf tconf "normal-inst (forced)" ~dec_lvl
 
     | Force_greedy ->
-      let mconf = normal_mconf () in (*take normal_mconf if greedy is forced*)
+      let mconf = normal_mconf () in
+      let tconf = normal_tconf () in (* take normal_tconf if greedy is forced *)
       env.last_forced_greedy <- nb_mrounds;
       let sa, inst_quantif =
         instantiation_context env ~greedy_round:true ~frugal:true in
-      do_instantiation env sa inst_quantif mconf "greedy-inst (forced)" ~dec_lvl
+      do_instantiation
+        env sa inst_quantif mconf tconf "greedy-inst (forced)" ~dec_lvl
 
     | Auto ->
       List.fold_left
-        (fun updated (mconf, debug, greedy_round, frugal) ->
+        (fun updated (mconf, tconf, debug, greedy_round, frugal) ->
            if updated then updated
            (* TODO: stop here with an exception *)
            else
              let sa, inst_quantif =
                instantiation_context env ~greedy_round ~frugal in
-             do_instantiation env sa inst_quantif mconf debug ~dec_lvl
+             do_instantiation env sa inst_quantif mconf tconf debug ~dec_lvl
         )
         false
         (match Options.get_instantiation_heuristic () with
          | INormal ->
-           [ frugal_mconf (), "frugal-inst", false, true ;
-             normal_mconf (), "normal-inst", false, false ]
+           [ frugal_mconf (), frugal_tconf (), "frugal-inst", false, true ;
+             normal_mconf (), normal_tconf (), "normal-inst", false, false ]
          | IAuto ->
-           [ frugal_mconf (), "frugal-inst", false, true ;
-             normal_mconf (), "normal-inst", false, false;
-             greedier_mconf (), "greedier-inst", true, false]
+           [ frugal_mconf (), frugal_tconf (), "frugal-inst", false, true ;
+             normal_mconf (), normal_tconf (), "normal-inst", false, false;
+             greedier_mconf (), greedier_tconf (), "greedier-inst", true, false]
          | IGreedy ->
-           [ greedy_mconf (), "greedy-inst", true , false;
-             greedier_mconf (), "greedier-inst", true, false])
+           [ greedy_mconf (), greedy_tconf (), "greedy-inst", true , false;
+             greedier_mconf (), greedier_tconf (), "greedier-inst", true, false
+           ])
 
   let do_case_split env policy =
     match SAT.do_case_split env.satml policy with

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -334,7 +334,7 @@ val max_ground_terms_rec_of_form : t -> Set.t
 (** skolemization and other smart constructors for formulas **)
 
 val make_triggers:
-  t -> binders -> decl_kind -> Util.matching_env -> trigger list
+  t -> binders -> decl_kind -> Util.triggers_env -> trigger list
 (** [make_triggers f binders decl menv] generate multi-triggers for the
     formula [f] and binders [binders].
 

--- a/src/lib/util/util.ml
+++ b/src/lib/util/util.ml
@@ -160,12 +160,16 @@ let [@inline always] cmp_lists l1 l2 cmp_elts =
 
 type matching_env =
   {
-    nb_triggers : int;
-    triggers_var : bool;
     no_ematching: bool;
-    greedy : bool;
     use_cs : bool;
     backward : inst_kind
+  }
+
+type triggers_env =
+  {
+    nb_triggers : int;
+    triggers_var : bool;
+    greedy : bool;
   }
 
 let loop

--- a/src/lib/util/util.mli
+++ b/src/lib/util/util.mli
@@ -98,16 +98,20 @@ val cmp_lists: 'a list -> 'a list -> ('a -> 'a -> int) -> int
 
 type matching_env =
   {
+    no_ematching: bool;
+    use_cs : bool;
+    backward : inst_kind
+  }
+
+type triggers_env =
+  {
     nb_triggers : int;
     (** Limit the number of trigger generated per axiom. *)
 
     triggers_var : bool;
     (** If [true], we allow trigger variables during the trigger generation. *)
 
-    no_ematching: bool;
     greedy : bool;
-    use_cs : bool;
-    backward : inst_kind
   }
 
 (** Loops from 0 to [max] and returns


### PR DESCRIPTION
Currently, the matching environment (from the `Matching` module) is used to hold both the current triggers and the terms to match on. This separates the triggers part from the terms part for improved clarity and a better separation of concerns — it is also one step towards incremental e-matching, which requires keeping triggers (but not the terms to match against!) across instantiation rounds.

Review commit by commit.