### PR TITLE
Bump the OCaml compiler versions in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,16 +27,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - "4.11.2"
+          - "4.13.1"
           - "4.14"
           - "5.5"
-        exclude:
-          # OCaml 4.11.2 is not available on macOS + arm
-          - os: macos-latest
-            ocaml-compiler: "4.11.2"
-          # Opam 2.2 requires at least OCaml 4.13
-          - os: windows-latest
-            ocaml-compiler: "4.11.2"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.3
+  OCAML_DEFAULT_VERSION: "4.14"
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true
@@ -27,16 +27,16 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - 4.11.2
-          - 4.14.3
-          - 5.4.0
+          - "4.11.2"
+          - "4.14"
+          - 5
         exclude:
           # OCaml 4.11.2 is not available on macOS + arm
           - os: macos-latest
-            ocaml-compiler: 4.11.2
+            ocaml-compiler: "4.11.2"
           # Opam 2.2 requires at least OCaml 4.13
           - os: windows-latest
-            ocaml-compiler: 4.11.2
+            ocaml-compiler: "4.11.2"
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         ocaml-compiler:
           - "4.11.2"
           - "4.14"
-          - 5
+          - "5.5"
         exclude:
           # OCaml 4.11.2 is not available on macOS + arm
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
           - "4.13.1"
           - "4.14"
           - "5.5"
+        exclude:
+          - ocaml-compiler: "4.13.1"
+            os: windows-latest
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -60,7 +60,7 @@ jobs:
       # Use Node Js actions
       - uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '16.9.0'
 
       # Run simple test with node
       # TODO: use gentest to run more tests there.

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -5,7 +5,7 @@ name: Build Javascript
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.3
+  OCAML_DEFAULT_VERSION: "4.14"
   # Add OPAMYES=true to the environment, this is usefull to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/build_js.yml
+++ b/.github/workflows/build_js.yml
@@ -60,7 +60,7 @@ jobs:
       # Use Node Js actions
       - uses: actions/setup-node@v4
         with:
-          node-version: '16.9.0'
+          node-version: '22.0.0'
 
       # Run simple test with node
       # TODO: use gentest to run more tests there.

--- a/.github/workflows/build_static.yml
+++ b/.github/workflows/build_static.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 4.14.3
+          ocaml-compiler: "4.14"
           dune-cache: true
 
       - name: Update opam repository

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.3
+  OCAML_DEFAULT_VERSION: "4.14"
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,7 @@ name: Linter
 on: [push,pull_request]
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.3
+  OCAML_DEFAULT_VERSION: "4.14"
   # Add OPAMYES=true to the environment, this is usefill to replace `-y` option
   # in any opam call
   OPAMYES: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch
 
 env:
-  OCAML_DEFAULT_VERSION: 4.14.3
+  OCAML_DEFAULT_VERSION: "4.14"
   OPAMYES: true
   OPAMLOCKED: locked
 

--- a/alt-ergo-js.opam
+++ b/alt-ergo-js.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "3.14"}
   "alt-ergo" {= version}
   "alt-ergo-lib" {= version}
-  "js_of_ocaml" {>= "6.0.0" & <= "6.2.0"}
+  "js_of_ocaml" {>= "6.4.0"}
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
   "data-encoding"

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -1,3 +1,4 @@
+
 opam-version: "2.0"
 name: "alt-ergo-lib"
 version: "dev"
@@ -17,45 +18,36 @@ doc: "https://ocamlpro.github.io/alt-ergo"
 bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
 depends: [
   "base-bigarray" {= "base"}
-  "base-bytes" {= "base"}
   "base-threads" {= "base"}
   "base-unix" {= "base"}
   "camlzip" {= "1.14"}
-  "cmdliner" {= "2.1.0"}
+  "cmdliner" {= "2.1.1"}
   "conf-gmp" {= "5"}
-  "conf-pkg-config" {= "4"}
+  "conf-pkg-config" {= "5"}
   "conf-zlib" {= "1"}
-  "cppo" {= "1.8.0"}
-  "crunch" {= "4.0.0"}
+  "crunch" {= "4.1.0"}
   "csexp" {= "1.5.2"}
   "dolmen" {= "dev"}
   "dolmen_loop" {= "dev"}
   "dolmen_type" {= "dev"}
-  "dune" {= "3.22.0"}
-  "dune-build-info" {= "3.22.0"}
-  "dune-configurator" {= "3.22.0"}
-  "dune-private-libs" {= "3.22.0"}
-  "dune-site" {= "3.22.0"}
-  "dyn" {= "3.22.0"}
+  "dune" {= "3.24.2"}
+  "dune-build-info" {= "3.24.2"}
+  "dune-private-libs" {= "3.24.2"}
+  "dune-site" {= "3.24.2"}
+  "dyn" {= "3.24.2"}
   "fmt" {= "0.11.0"}
-  "fs-io" {= "3.22.0"}
+  "fs-io" {= "3.24.2"}
   "gen" {= "1.1"}
   "hmap" {= "0.8.1"}
-  "js_of_ocaml-compiler" {= "6.4.0"}
   "logs" {= "0.10.0"}
-  "lwt" {= "5.9.2"}
   "menhir" {= "20260209"}
   "menhirCST" {= "20260209"}
   "menhirGLR" {= "20260209"}
   "menhirLib" {= "20260209"}
   "menhirSdk" {= "20260209"}
-  "ocaml-compiler-libs" {= "v0.12.4"}
-  "ocaml-options-vanilla" {= "1"}
   "ocamlbuild" {= "0.16.1"}
-  "ocamlfind" {= "1.9.8"}
-  "ocplib-endian" {= "1.2"}
   "ocplib-simplex" {= "0.5.1"}
-  "ordering" {= "3.22.0"}
+  "ordering" {= "3.24.2"}
   "ounit2" {= "2.2.7" & with-test}
   "pp" {= "2.0.0"}
   "pp_loc" {= "2.1.0"}
@@ -63,17 +55,17 @@ depends: [
   "qcheck" {= "0.25" & with-test}
   "qcheck-core" {= "0.25" & with-test}
   "qcheck-ounit" {= "0.25" & with-test}
-  "sedlex" {= "3.7"}
   "seq" {= "base"}
-  "sexplib0" {= "v0.16.0"}
   "spelll" {= "0.4"}
   "stdlib-shims" {= "0.3.0"}
-  "stdune" {= "3.22.0"}
-  "top-closure" {= "3.22.0"}
+  "stdune" {= "3.24.2"}
+  "top-closure" {= "3.24.2"}
   "topkg" {= "1.1.1"}
   "uutf" {= "1.0.4"}
-  "yojson" {= "2.2.2"}
   "zarith" {= "1.14"}
+]
+conflicts: [
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -92,9 +84,6 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"
-conflicts: [
-  "result" {< "1.5"}
-]
 pin-depends: [
   [
     "dolmen.dev"

--- a/alt-ergo-lib.opam.locked
+++ b/alt-ergo-lib.opam.locked
@@ -41,7 +41,7 @@ depends: [
   "fs-io" {= "3.22.0"}
   "gen" {= "1.1"}
   "hmap" {= "0.8.1"}
-  "js_of_ocaml-compiler" {= "6.2.0"}
+  "js_of_ocaml-compiler" {= "6.4.0"}
   "logs" {= "0.10.0"}
   "lwt" {= "5.9.2"}
   "menhir" {= "20260209"}

--- a/docs/sphinx_docs/Javascript/index.md
+++ b/docs/sphinx_docs/Javascript/index.md
@@ -66,8 +66,8 @@ To install the `Alt-Ergo` JavaScript artifacts, simply install the `alt-ergo-js`
 opam package. The artifacts will be available in `SHARE/alt-ergo-js`, where
 `SHARE` refers to the share directory of your current opam switch.
 
-The JavaScript artifacts require at least NodeJS 16.9.0.
-To execute Alt-Ergo JavaScript, use the following command:
+We recommend at least NodeJS 22 for the JavaScript artifact. To run it, use
+the following command:
 ```console
 node SHARE/alt-ergo-js/alt-ergo.js <options> <input_files>
 ```

--- a/docs/sphinx_docs/Javascript/index.md
+++ b/docs/sphinx_docs/Javascript/index.md
@@ -66,6 +66,7 @@ To install the `Alt-Ergo` JavaScript artifacts, simply install the `alt-ergo-js`
 opam package. The artifacts will be available in `SHARE/alt-ergo-js`, where
 `SHARE` refers to the share directory of your current opam switch.
 
+The JavaScript artifacts require at least NodeJS 16.9.0.
 To execute Alt-Ergo JavaScript, use the following command:
 ```console
 node SHARE/alt-ergo-js/alt-ergo.js <options> <input_files>

--- a/dune-project
+++ b/dune-project
@@ -46,7 +46,7 @@ See more details on https://alt-ergo.ocamlpro.com/")
  (depends
   (alt-ergo (= :version))
   (alt-ergo-lib (= :version))
-  (js_of_ocaml (and (>= 6.0.0) (<= 6.2.0)))
+  (js_of_ocaml (>= 6.4.0))
   js_of_ocaml-lwt
   js_of_ocaml-ppx
   data-encoding


### PR DESCRIPTION
This commit introduces three changes:
- Bump 4.14.3 to 4.14.4 and 5.4.0 to 5.5.0,
- Use major version for the upper bound and minor version for the 4.14,
- Quote compiler versions as recommended by the documentation of setup-ocaml.