### PR TITLE
Rely on Z.t and Q.t to build integer and rational literals when possible

### DIFF
--- a/src/lib/frontend/translate.ml
+++ b/src/lib/frontend/translate.ml
@@ -723,7 +723,9 @@ let destruct_app e =
 let mk_lt translate ty x y =
   if ty == `Int
   then
-    let e3 = E.mk_term (Sy.Op Sy.Minus) [translate y; E.int "1"] Ty.Tint in
+    let e3 =
+      E.mk_term (Sy.Op Sy.Minus) [translate y; E.Ints.of_Z Z.one] Ty.Tint
+    in
     let e1 = translate x in
     E.mk_builtin ~is_pos:true Sy.LE [e1; e3]
   else E.mk_builtin ~is_pos:true Sy.LT [translate x; translate y]
@@ -731,7 +733,9 @@ let mk_lt translate ty x y =
 let mk_gt translate ty x y =
   if ty == `Int
   then
-    let e3 = E.mk_term (Sy.Op Sy.Minus) [translate x; E.int "1"] Ty.Tint in
+    let e3 =
+      E.mk_term (Sy.Op Sy.Minus) [translate x; E.Ints.of_Z Z.one] Ty.Tint
+    in
     let e2 = translate y in
     E.mk_builtin ~is_pos:true Sy.LE [e2; e3]
   else E.mk_builtin ~is_pos:true Sy.LT [translate y; translate x]
@@ -910,7 +914,9 @@ let rec mk_expr ?(loc = Loc.dummy) ?(name_base = "") ?(toplevel = false)
           (* Unary builtins *)
           | Minus mty, [x] ->
             let e1, ty =
-              if mty == `Int then E.int "0", Ty.Tint else E.real "0", Ty.Treal
+              if mty == `Int
+              then E.Ints.of_Z Z.zero, Ty.Tint
+              else E.Reals.of_Q Q.zero, Ty.Treal
             in
             E.mk_term (Sy.Op Sy.Minus) [e1; aux_mk_expr x] ty
           | Minus _, _ -> invalid_app_term ()

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -700,18 +700,16 @@ struct
       else
         let term_of_cst, cpt =
           match X.type_info r with
-          | Ty.Tint -> E.int, cpt_int
-          | Ty.Treal -> E.real, cpt_real
+          | Ty.Tint -> E.Ints.of_Q, cpt_int
+          | Ty.Treal -> E.Reals.of_Q, cpt_real
           | _ -> assert false
         in
         cpt := Q.add Q.one (max_constant distincts !cpt);
-        Some (term_of_cst (Q.to_string !cpt), true)
+        Some (term_of_cst !cpt, true)
 
   let to_model_term r =
     match P.is_const (embed r), X.type_info r with
-    | Some i, Ty.Tint ->
-      assert (Z.equal (Q.den i) Z.one);
-      Some (Expr.Ints.of_Z (Q.num i))
-    | Some q, Ty.Treal -> Some (Expr.Reals.of_Q q)
+    | Some i, Ty.Tint -> Some (E.Ints.of_Q i)
+    | Some q, Ty.Treal -> Some (E.Reals.of_Q q)
     | _ -> None
 end

--- a/src/lib/reasoners/arith.ml
+++ b/src/lib/reasoners/arith.ml
@@ -700,7 +700,7 @@ struct
       else
         let term_of_cst, cpt =
           match X.type_info r with
-          | Ty.Tint -> E.Ints.of_Q, cpt_int
+          | Ty.Tint -> E.Ints.of_Q_exn, cpt_int
           | Ty.Treal -> E.Reals.of_Q, cpt_real
           | _ -> assert false
         in
@@ -709,7 +709,7 @@ struct
 
   let to_model_term r =
     match P.is_const (embed r), X.type_info r with
-    | Some i, Ty.Tint -> Some (E.Ints.of_Q i)
+    | Some i, Ty.Tint -> Some (E.Ints.of_Q_exn i)
     | Some q, Ty.Treal -> Some (E.Reals.of_Q q)
     | _ -> None
 end

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -1898,7 +1898,7 @@ let model_from_simplex sim is_int env uf =
       then main_vars, slake_vars
       else round_to_integers main_vars, round_to_integers slake_vars
     in
-    let fct = if is_int then E.int else E.real in
+    let fct = if is_int then E.Ints.of_Q else E.Reals.of_Q in
     List.fold_left
       (fun acc (v, q) ->
         assert ((not is_int) || Q.is_int q);
@@ -1907,7 +1907,7 @@ let model_from_simplex sim is_int env uf =
           (* may happen because of incremental simplex on rationals *)
           acc
         else
-          let t = fct (Q.to_string q) in
+          let t = fct q in
           let r, _ = X.make t in
           if get_debug_interpretation ()
           then
@@ -1939,7 +1939,7 @@ let model_from_infinite_domains =
 
 let mk_const_term c ty =
   match ty with
-  | Ty.Tint -> E.Ints.of_Z (Q.to_z c)
+  | Ty.Tint -> E.Ints.of_Q c
   | Ty.Treal -> E.Reals.of_Q c
   | _ -> assert false
 
@@ -2120,8 +2120,8 @@ let best_interval_of optimized env p =
 
 let mk_const_term ty s =
   match ty with
-  | Ty.Tint -> E.int (Q.to_string s)
-  | Ty.Treal -> E.real (Q.to_string s)
+  | Ty.Tint -> E.Ints.of_Q s
+  | Ty.Treal -> E.Reals.of_Q s
   | _ -> assert false
 
 let integrate_mapsTo_bindings sbs maps_to =

--- a/src/lib/reasoners/intervalCalculus.ml
+++ b/src/lib/reasoners/intervalCalculus.ml
@@ -1898,7 +1898,7 @@ let model_from_simplex sim is_int env uf =
       then main_vars, slake_vars
       else round_to_integers main_vars, round_to_integers slake_vars
     in
-    let fct = if is_int then E.Ints.of_Q else E.Reals.of_Q in
+    let fct = if is_int then E.Ints.of_Q_exn else E.Reals.of_Q in
     List.fold_left
       (fun acc (v, q) ->
         assert ((not is_int) || Q.is_int q);
@@ -1939,7 +1939,7 @@ let model_from_infinite_domains =
 
 let mk_const_term c ty =
   match ty with
-  | Ty.Tint -> E.Ints.of_Q c
+  | Ty.Tint -> E.Ints.of_Q_exn c
   | Ty.Treal -> E.Reals.of_Q c
   | _ -> assert false
 
@@ -2120,7 +2120,7 @@ let best_interval_of optimized env p =
 
 let mk_const_term ty s =
   match ty with
-  | Ty.Tint -> E.Ints.of_Q s
+  | Ty.Tint -> E.Ints.of_Q_exn s
   | Ty.Treal -> E.Reals.of_Q s
   | _ -> assert false
 

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -931,7 +931,8 @@ let bitv bt ty = mk_term (Sy.bitv bt) [] ty
 
 let float fp_val eb sb = mk_term (Sy.Float fp_val) [] (Ty.Tfloat (eb, sb))
 
-let pred t = mk_term (Sy.Op Sy.Minus) [t; int "1"] Ty.Tint
+let pred t =
+  mk_term (Sy.Op Sy.Minus) [t; mk_term (Sy.Int Z.one) [] Ty.Tint] Ty.Tint
 
 (** simple smart constructors for formulas *)
 
@@ -2845,13 +2846,15 @@ end
 (** Constructors from the smtlib theory of integers.
     https://smtlib.cs.uiowa.edu/theories-Ints.shtml *)
 module Ints = struct
-  let of_int n = int (string_of_int n)
-
-  let ( ~$ ) = of_int
-
-  let of_Z n = int (Z.to_string n)
+  let of_Z n = mk_term (Int n) [] Tint
 
   let ( ~$$ ) = of_Z
+
+  let of_Q q = of_Z (Numbers.Q.to_z q)
+
+  let of_int n = of_Z (Z.of_int n)
+
+  let ( ~$ ) = of_int
 
   let ( + ) x y = mk_term (Op Plus) [x; y] Tint
 
@@ -2881,15 +2884,15 @@ end
 (** Constructors from the smtlib theory of real numbers.
     https://smtlib.cs.uiowa.edu/theories-Reals.shtml *)
 module Reals = struct
-  let of_int n = real (string_of_int n)
+  let of_Q q = mk_term (Real q) [] Treal
+
+  let of_Z n = of_Q (Q.of_bigint n)
+
+  let of_int n = of_Z (Z.of_int n)
 
   let ( ~$ ) = of_int
 
-  let of_Z n = real (Z.to_string n)
-
   let ( ~$$ ) = of_Z
-
-  let of_Q q = real (Q.to_string q)
 
   let ( ~$$$ ) = of_Q
 

--- a/src/lib/structures/expr.ml
+++ b/src/lib/structures/expr.ml
@@ -2850,7 +2850,7 @@ module Ints = struct
 
   let ( ~$$ ) = of_Z
 
-  let of_Q q = of_Z (Numbers.Q.to_z q)
+  let of_Q_exn q = of_Z (Numbers.Q.to_z q)
 
   let of_int n = of_Z (Z.of_int n)
 

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -514,6 +514,11 @@ module Ints : sig
 
   val ( ~$$ ) : Z.t -> t
 
+  val of_Q : Q.t -> t
+  (** [of_Q q] Conversion from a rational [q] known to be an integer
+
+      @raise Assert_failure if [q] is not an integer *)
+
   (* Arithmetic operations *)
   val ( + ) : t -> t -> t
 

--- a/src/lib/structures/expr.mli
+++ b/src/lib/structures/expr.mli
@@ -514,8 +514,8 @@ module Ints : sig
 
   val ( ~$$ ) : Z.t -> t
 
-  val of_Q : Q.t -> t
-  (** [of_Q q] Conversion from a rational [q] known to be an integer
+  val of_Q_exn : Q.t -> t
+  (** [of_Q_exn q] Conversion from a rational [q] known to be an integer
 
       @raise Assert_failure if [q] is not an integer *)
 


### PR DESCRIPTION
Since we now rely on Dolmen as a front-end we should not need to manually parse integer and real literals, notably because Dolmen uses the `Minus` unary operator to represent negative integer/real literals, so AFAIK we only need to parse positive integer/real literals.
And since we use `Z.t` and `Q.t` to represent integer/real literals, we can have negative literals directly instead of rewriting things as `0 - x`. We can also build literals using `Z.t` and `Q.t` directly instead of using strings.